### PR TITLE
Changes copy src to public

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN yarn
 COPY .babelrc razzle.config.js postcss.config.js $APP_PATH/
 
 COPY src $APP_PATH/src
-COPY src $APP_PATH/public
+COPY public $APP_PATH/public
 
 # Build client code
 ENV NODE_ENV=production


### PR DESCRIPTION
Changes ```COPY src $APP_PATH/public``` to ```COPY public $APP_PATH/public``` in the dockerfile. The `public` folder is not included with the old version of the `Dockerfile`.