### PR TITLE
#1096: Add issuu, livestream, tomknudsen.no and msdn domains to frameSrc

### DIFF
--- a/src/server/contentSecurityPolicy.js
+++ b/src/server/contentSecurityPolicy.js
@@ -134,6 +134,10 @@ export default {
       '*.vg.no/',
       '*.facebook.com',
       '*.twitter.com',
+      'e.issuu.com',
+      'new.livestream.com',
+      'livestream.com',
+      'channel9.msdn.com',
     ],
     styleSrc: [
       "'self'",

--- a/src/server/contentSecurityPolicy.js
+++ b/src/server/contentSecurityPolicy.js
@@ -138,6 +138,8 @@ export default {
       'new.livestream.com',
       'livestream.com',
       'channel9.msdn.com',
+      'tomknudsen.no',
+      'www.tomknudsen.no',
     ],
     styleSrc: [
       "'self'",


### PR DESCRIPTION
connects to https://github.com/NDLANO/Issues/issues/1096

https://test.api.ndla.no/article-api/v2/articles/6070 <- msdn
https://test.api.ndla.no/article-api/v2/articles/6297 <- issuu
https://test.api.ndla.no/article-api/v2/articles/6667 <- livestream
