### PR TITLE
#934: Adds query parameter to download image source

### DIFF
--- a/src/components/license/ImageLicenseList.jsx
+++ b/src/components/license/ImageLicenseList.jsx
@@ -20,6 +20,7 @@ import {
 } from 'ndla-ui';
 import { injectT } from 'ndla-i18n';
 import { metaTypes, getGroupedContributorDescriptionList } from 'ndla-licenses';
+import queryString from 'query-string';
 import CopyTextButton from './CopyTextButton';
 import { CopyrightObjectShape } from '../../shapes';
 import { getCopyrightCopyString } from './getCopyrightCopyString';
@@ -30,6 +31,14 @@ const ImageShape = PropTypes.shape({
   altText: PropTypes.string.isRequired,
   copyright: CopyrightObjectShape.isRequired,
 });
+
+export const downloadUrl = imageSrc => {
+  const urlObject = queryString.parseUrl(imageSrc);
+  return `${urlObject.url}?${queryString.stringify({
+    ...urlObject.query,
+    download: true,
+  })}`;
+};
 
 const ImageLicenseInfo = ({ image, locale, t }) => {
   const items = getGroupedContributorDescriptionList(image.copyright, locale);
@@ -71,7 +80,7 @@ const ImageLicenseInfo = ({ image, locale, t }) => {
               hasCopiedTitle={t('hasCopiedTitle')}
             />
             <a
-              href={image.src}
+              href={downloadUrl(image.src)}
               className="c-button c-button--outline c-licenseToggle__button"
               download>
               {t('download')}

--- a/src/components/license/__tests__/ImageLicenseInfoDownloadUrl.js
+++ b/src/components/license/__tests__/ImageLicenseInfoDownloadUrl.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2018-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { downloadUrl } from '../ImageLicenseList';
+
+test('That downloadUrl adds download query param to image source', () => {
+  expect(
+    downloadUrl(
+      'http://api-gateway.ndla-local/image-api/raw/394537450.jpg?width=200',
+    ),
+  ).toBe(
+    'http://api-gateway.ndla-local/image-api/raw/394537450.jpg?width=200&download=true',
+  );
+
+  expect(
+    downloadUrl('http://api-gateway.ndla-local/image-api/raw/394537450.jpg'),
+  ).toBe(
+    'http://api-gateway.ndla-local/image-api/raw/394537450.jpg?download=true',
+  );
+
+  expect(
+    downloadUrl(
+      'http://api-gateway.ndla-local/image-api/raw/394537450.jpg?download=true',
+    ),
+  ).toBe(
+    'http://api-gateway.ndla-local/image-api/raw/394537450.jpg?download=true',
+  );
+});


### PR DESCRIPTION
connects to https://github.com/NDLANO/Issues/issues/934
Testing:
- Find article with image
- Attempt to download image from "Bruk innhold" and see that it downloads rather than opens in browser