### PR TITLE
dont pass error object to next in forwardingRoute #1144

### DIFF
--- a/src/server/routes/forwardingRoute.js
+++ b/src/server/routes/forwardingRoute.js
@@ -34,6 +34,6 @@ export async function forwardingRoute(req, resp, next) {
     const newPath = await taxonomyLookup(requestUrl);
     resp.redirect(301, `${languagePrefix}/subjects${newPath.path}`);
   } catch (e) {
-    next(e);
+    next();
   }
 }


### PR DESCRIPTION
connected to NDLANO/Issues#1144

By sending the error object from `catch` to `next`, express handles the error as 404, and is not sending it forward to the next matching route