### PR TITLE
Ndlano/issues#1161 handle nn nodes forwarding

### DIFF
--- a/src/server/routes/__tests__/forwardingRoute-test.js
+++ b/src/server/routes/__tests__/forwardingRoute-test.js
@@ -55,7 +55,7 @@ test('forwardingRoute redirect with 301 if mapping OK (nb)', async () => {
   expect(
     redirect.calledWith(
       301,
-      `/nb/subjects/subject:3/topic:1:55212/topic:1:175218/resource:1:72007`,
+      `/subjects/subject:3/topic:1:55212/topic:1:175218/resource:1:72007`,
     ),
   ).toBe(true);
   expect(next.notCalled).toBe(true);

--- a/src/server/routes/__tests__/forwardingRoute-test.js
+++ b/src/server/routes/__tests__/forwardingRoute-test.js
@@ -10,16 +10,16 @@ import nock from 'nock';
 import sinon from 'sinon';
 import { forwardingRoute } from '../forwardingRoute';
 
-function prepareNock(status) {
+function prepareNock(status, nodeId = '1337') {
   if (status === 200) {
     return nock('http://ndla-api')
-      .get('/taxonomy/v1/url/mapping?url=ndla.no/node/1337')
+      .get(`/taxonomy/v1/url/mapping?url=ndla.no/node/${nodeId}`)
       .reply(200, {
         path: '/subject:3/topic:1:55212/topic:1:175218/resource:1:72007',
       });
   }
   return nock('http://ndla-api')
-    .get('/taxonomy/v1/url/mapping?url=ndla.no/node/1337')
+    .get(`/taxonomy/v1/url/mapping?url=ndla.no/node/${nodeId}`)
     .reply(404);
 }
 
@@ -83,7 +83,13 @@ test('forwardingRoute redirect with 301 if mapping OK (en)', async () => {
 });
 
 test('forwardingRoute redirect with 301 if mapping OK (nn)', async () => {
-  prepareNock(200);
+  nock('http://ndla-api')
+    .get('/article-api/v2/articles/external_ids/1337')
+    .reply(200, {
+      articleId: 2602,
+      externalIds: ['1339', '1337'],
+    });
+  prepareNock(200, '1339');
 
   const next = sinon.spy();
   const redirect = sinon.spy();

--- a/src/server/routes/forwardingRoute.js
+++ b/src/server/routes/forwardingRoute.js
@@ -47,7 +47,7 @@ export async function forwardingRoute(req, res, next) {
     const lookupUrl = `ndla.no/node/${nodeId}`;
     const newPath = await taxonomyLookup(lookupUrl);
 
-    const languagePrefix = lang ? `/${lang}` : '';
+    const languagePrefix = lang && lang !== 'nb' ? `/${lang}` : ''; // send urls with nb to root/default lang
     res.redirect(301, `${languagePrefix}/subjects${newPath.path}`);
   } catch (e) {
     next();

--- a/src/server/routes/forwardingRoute.js
+++ b/src/server/routes/forwardingRoute.js
@@ -20,7 +20,7 @@ const taxonomyLookup = url => {
   return fetchWithAccessToken(k).then(resolveJsonOrRejectWithError);
 };
 
-export async function forwardingRoute(req, resp, next) {
+export async function forwardingRoute(req, res, next) {
   const token = await getToken();
   storeAccessToken(token.access_token);
 
@@ -32,7 +32,7 @@ export async function forwardingRoute(req, resp, next) {
 
   try {
     const newPath = await taxonomyLookup(requestUrl);
-    resp.redirect(301, `${languagePrefix}/subjects${newPath.path}`);
+    res.redirect(301, `${languagePrefix}/subjects${newPath.path}`);
   } catch (e) {
     next();
   }

--- a/src/server/routes/forwardingRoute.js
+++ b/src/server/routes/forwardingRoute.js
@@ -23,15 +23,13 @@ const taxonomyLookup = url => {
 export async function forwardingRoute(req, res, next) {
   const token = await getToken();
   storeAccessToken(token.access_token);
+  const { nodeId, lang } = req.params;
 
-  const pathParts = req.originalUrl.substring(1).split('/');
-  const languagePrefix =
-    pathParts.length > 0 && pathParts[0] !== 'node' ? `/${pathParts[0]}` : '';
-
-  const requestUrl = `ndla.no${req.originalUrl}`;
+  const lookupUrl = `ndla.no/node/${nodeId}`;
 
   try {
-    const newPath = await taxonomyLookup(requestUrl);
+    const newPath = await taxonomyLookup(lookupUrl);
+    const languagePrefix = lang ? `/${lang}` : '';
     res.redirect(301, `${languagePrefix}/subjects${newPath.path}`);
   } catch (e) {
     next();

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -167,7 +167,7 @@ app.get('/oembed', ndlaMiddleware, async (req, res) => {
 
 app.get('/:lang?/search/apachesolr_search(/*)?', proxy(config.oldNdlaProxyUrl));
 
-app.get('/:lang?/node/*', async (req, res, next) =>
+app.get('/:lang?/node/:nodeId', async (req, res, next) =>
   forwardingRoute(req, res, next),
 );
 

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -193,5 +193,6 @@ app.get(
 );
 
 app.get('/*', proxy(config.oldNdlaProxyUrl));
+app.post('/*', proxy(config.oldNdlaProxyUrl));
 
 export default app;

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -121,21 +121,17 @@ async function handleRequest(req, res, route, enableCache = false) {
     const token = await getToken();
     storeAccessToken(token.access_token);
     try {
-      let response;
-      let data;
-      let status;
-
       if (enableCache) {
-        ({ res: response, data, status } = await renderAndCache(
+        const { res: response, data, status } = await renderAndCache(
           req,
           res,
           route,
-        ));
+        );
+        sendResponse(response, data, status);
       } else {
-        ({ data, status } = await route(req));
+        const { data, status } = await route(req);
+        sendResponse(res, data, status);
       }
-
-      sendResponse(response, data, status);
     } catch (e) {
       handleError(e);
       sendInternalServerError(res);

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -165,19 +165,9 @@ app.get('/oembed', ndlaMiddleware, async (req, res) => {
   handleRequest(req, res, oembedArticleRoute);
 });
 
-app.get('/search/apachesolr_search(/*)?', proxy(config.oldNdlaProxyUrl));
-app.get('/nb/search/apachesolr_search(/*)?', proxy(config.oldNdlaProxyUrl));
-app.get('/nn/search/apachesolr_search(/*)?', proxy(config.oldNdlaProxyUrl));
-app.get('/en/search/apachesolr_search(/*)?', proxy(config.oldNdlaProxyUrl));
+app.get('/:lang?/search/apachesolr_search(/*)?', proxy(config.oldNdlaProxyUrl));
 
-app.get('/node/*', async (req, res, next) => forwardingRoute(req, res, next));
-app.get('/nb/node/*', async (req, res, next) =>
-  forwardingRoute(req, res, next),
-);
-app.get('/nn/node/*', async (req, res, next) =>
-  forwardingRoute(req, res, next),
-);
-app.get('/en/node/*', async (req, res, next) =>
+app.get('/:lang?/node/*', async (req, res, next) =>
   forwardingRoute(req, res, next),
 );
 


### PR DESCRIPTION
Redirect tests has to be done against staging:

- [ ] That article-iframe route works again
- [ ] `{baseURL}/nb/node/92713?fag=52291` redirects to a new url without /nb prefix
- [ ] `{baseURL}/nn/node/92713?fag=52291` redirects to the same article but with /nn prefix