### PR TITLE
Ndlano/issues#1240 learningpath forwarding

### DIFF
--- a/src/components/RedirectExternal.js
+++ b/src/components/RedirectExternal.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2018-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Redirect from 'react-router-dom/Redirect';
+
+/**
+ * The react-router Redirect component does'nt work with external
+ * urls client side. So we use this helper component to handle it
+ * for us.
+ */
+class RedirectExternal extends Component {
+  componentDidMount() {
+    window.location.replace(this.props.to);
+  }
+
+  render() {
+    // Redirect component works with external urls serverside
+    if (process.env.BUILD_TARGET === 'SERVER') {
+      return <Redirect to={this.props.to} />;
+    }
+    return null;
+  }
+}
+
+RedirectExternal.propTypes = {
+  to: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
+};
+
+export default RedirectExternal;

--- a/src/components/RedirectExternal.js
+++ b/src/components/RedirectExternal.js
@@ -6,31 +6,52 @@
  *
  */
 
-import React, { Component } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
-import Redirect from 'react-router-dom/Redirect';
 
 /**
  * The react-router Redirect component does'nt work with external
- * urls client side. So we use this helper component to handle it
- * for us.
+ * urls. So we use this helper component to handle it for us.
  */
 class RedirectExternal extends Component {
+  constructor(props, context) {
+    super(props, context);
+
+    const { staticContext } = this.context.router;
+
+    if (this.isStatic()) {
+      // Update static context serverside (see https://github.com/NDLANO/ndla-frontend/blob/master/src/server/helpers/render.js#L49)
+      staticContext.action = 'REPLACE';
+      staticContext.location = props.to;
+      staticContext.url = props.to;
+    }
+  }
+
   componentDidMount() {
-    window.location.replace(this.props.to);
+    // Probably clientside. Just use window.location.replace
+    if (!this.isStatic()) {
+      window.location.replace(this.props.to);
+    }
+  }
+
+  // Checks if we are using StaticRouter (i.e. serverside)
+  isStatic() {
+    return this.context.router && this.context.router.staticContext;
   }
 
   render() {
-    // Redirect component works with external urls serverside
-    if (process.env.BUILD_TARGET === 'SERVER') {
-      return <Redirect to={this.props.to} />;
-    }
     return null;
   }
 }
 
 RedirectExternal.propTypes = {
   to: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
+};
+
+RedirectExternal.contextTypes = {
+  router: PropTypes.shape({
+    staticContext: PropTypes.object,
+  }).isRequired,
 };
 
 export default RedirectExternal;

--- a/src/components/Status.jsx
+++ b/src/components/Status.jsx
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2016-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import Route from 'react-router-dom/Route';
+
+const Status = ({ code, children }) => (
+  <Route
+    render={({ staticContext }) => {
+      const context = staticContext;
+      if (staticContext) {
+        context.status = code;
+      }
+      return children;
+    }}
+  />
+);
+
+Status.propTypes = {
+  code: PropTypes.number.isRequired,
+};
+
+export default Status;

--- a/src/components/__tests__/RedirectExternal-test.js
+++ b/src/components/__tests__/RedirectExternal-test.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2017-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import React from 'react';
+import { StaticRouter, MemoryRouter } from 'react-router';
+import renderer from 'react-test-renderer';
+import sinon from 'sinon';
+import RedirectExternal from '../RedirectExternal';
+
+test('External redirect for static router', () => {
+  const context = {};
+  renderer.create(
+    <StaticRouter context={context}>
+      <RedirectExternal to="https://google.com/" />
+    </StaticRouter>,
+  );
+
+  expect(context).toEqual({
+    action: 'REPLACE',
+    location: 'https://google.com/',
+    url: 'https://google.com/',
+  });
+});
+
+test('External redirect for static router with basename', () => {
+  const context = {};
+  renderer.create(
+    <StaticRouter basename="/nb" context={context}>
+      <RedirectExternal to="https://google.com/" />
+    </StaticRouter>,
+  );
+
+  expect(context).toEqual({
+    action: 'REPLACE',
+    location: 'https://google.com/',
+    url: 'https://google.com/',
+  });
+});
+
+test('External redirect for (memory/dom) router', () => {
+  const context = {};
+  const replace = sinon.spy();
+  Object.defineProperty(window.location, 'replace', {
+    value: replace,
+  });
+
+  renderer.create(
+    <MemoryRouter basename="/nb" context={context}>
+      <RedirectExternal to="https://google.com/" />
+    </MemoryRouter>,
+  );
+
+  expect(context).toEqual({});
+  expect(replace.calledWith('https://google.com/')).toBe(true);
+});

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,11 +1,11 @@
 /**
- * Copyright (c) 2016-present, NDLA.
+ * Copyright (c) 2018-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.
  *
  */
 
-import SubjectLinkList from './SubjectLinkList';
-
-export { SubjectLinkList };
+export { default as SubjectLinkList } from './SubjectLinkList';
+export { default as Status } from './Status';
+export { default as RedirectExternal } from './RedirectExternal';

--- a/src/config.js
+++ b/src/config.js
@@ -54,6 +54,10 @@ const learningPathDomain = () => {
 };
 
 const gaTrackingId = () => {
+  if (process.env.NODE_ENV !== 'production') {
+    return '';
+  }
+
   switch (ndlaEnvironment) {
     case 'local':
       return '';

--- a/src/containers/ArticlePage/ArticlePage.jsx
+++ b/src/containers/ArticlePage/ArticlePage.jsx
@@ -38,10 +38,9 @@ import Resources from '../Resources/Resources';
 import { runQueries } from '../../util/runQueries';
 import { getFiltersFromUrl } from '../../util/filterHelper';
 import {
-  URN_LEARTNING_PATH,
-  getLearningPathIdFromResource,
+  isLearningPathResource,
+  getLearningPathUrlFromResource,
 } from '../Resources/resourceHelpers';
-import config from '../../config';
 import { RedirectExternal, Status } from '../../components';
 
 const transformData = data => {
@@ -143,17 +142,11 @@ class ArticlePage extends Component {
     const topicTitle =
       topicPath.length > 0 ? topicPath[topicPath.length - 1].name : '';
 
-    if (
-      resource !== null &&
-      resource.contentUri &&
-      resource.contentUri.startsWith(URN_LEARTNING_PATH)
-    ) {
-      const id = getLearningPathIdFromResource(resource);
+    if (isLearningPathResource(resource)) {
+      const url = getLearningPathUrlFromResource(resource);
       return (
         <Status code={307}>
-          <RedirectExternal
-            to={`${config.learningPathDomain}/learningpaths/${id}/first-step`}
-          />
+          <RedirectExternal to={url} />
         </Status>
       );
     }

--- a/src/containers/ArticlePage/ArticlePage.jsx
+++ b/src/containers/ArticlePage/ArticlePage.jsx
@@ -37,6 +37,12 @@ import {
 import Resources from '../Resources/Resources';
 import { runQueries } from '../../util/runQueries';
 import { getFiltersFromUrl } from '../../util/filterHelper';
+import {
+  URN_LEARTNING_PATH,
+  getLearningPathIdFromResource,
+} from '../Resources/resourceHelpers';
+import config from '../../config';
+import { RedirectExternal, Status } from '../../components';
 
 const transformData = data => {
   const { subject, topic } = data;
@@ -136,6 +142,21 @@ class ArticlePage extends Component {
     const { resource, topic, resourceTypes, subject, topicPath } = data;
     const topicTitle =
       topicPath.length > 0 ? topicPath[topicPath.length - 1].name : '';
+
+    if (
+      resource !== null &&
+      resource.contentUri &&
+      resource.contentUri.startsWith(URN_LEARTNING_PATH)
+    ) {
+      const id = getLearningPathIdFromResource(resource);
+      return (
+        <Status code={307}>
+          <RedirectExternal
+            to={`${config.learningPathDomain}/learningpaths/${id}/first-step`}
+          />
+        </Status>
+      );
+    }
 
     if (resource === null || resource.article === null) {
       const error = errors ? errors.find(e => e.path.includes('resource')) : {};

--- a/src/containers/NotFoundPage/NotFoundPage.jsx
+++ b/src/containers/NotFoundPage/NotFoundPage.jsx
@@ -7,27 +7,10 @@
  */
 
 import React from 'react';
-import PropTypes from 'prop-types';
 import { OneColumn, ErrorMessage } from 'ndla-ui';
 import { injectT } from 'ndla-i18n';
-import Route from 'react-router-dom/Route';
 import { HelmetWithTracker } from 'ndla-tracker';
-
-const Status = ({ code, children }) => (
-  <Route
-    render={({ staticContext }) => {
-      const context = staticContext;
-      if (staticContext) {
-        context.status = code;
-      }
-      return children;
-    }}
-  />
-);
-
-Status.propTypes = {
-  code: PropTypes.number.isRequired,
-};
+import { Status } from '../../components';
 
 const NotFound = ({ t }) => (
   <Status code={404}>

--- a/src/containers/Resources/__tests__/resourceHelpers-test.js
+++ b/src/containers/Resources/__tests__/resourceHelpers-test.js
@@ -28,6 +28,7 @@ test('resourceHelpers/isLearningPathResource ', () => {
   );
   testHelper(helper.isLearningPathResource, {}, false);
   testHelper(helper.isLearningPathResource, undefined, false);
+  testHelper(helper.isLearningPathResource, null, false);
 });
 
 test('resourceHelpers/isArticleResource ', () => {

--- a/src/containers/Resources/resourceHelpers.js
+++ b/src/containers/Resources/resourceHelpers.js
@@ -36,12 +36,18 @@ export const getLearningPathIdFromResource = resource => {
   return undefined;
 };
 
+export function getLearningPathUrlFromResource(resource, languagePrefix = '') {
+  return `${
+    config.learningPathDomain
+  }${languagePrefix}/learningpaths/${getLearningPathIdFromResource(
+    resource,
+  )}/first-step`;
+}
+
 export const resourceToLinkProps = (resource, subjectTopicPath, filters) => {
   if (isLearningPathResource(resource)) {
     return {
-      to: `${
-        config.learningPathDomain
-      }/learningpaths/${getLearningPathIdFromResource(resource)}/first-step`,
+      to: getLearningPathUrlFromResource(resource),
       target: '_blank',
       rel: 'noopener noreferrer',
     };

--- a/src/server/helpers/render.js
+++ b/src/server/helpers/render.js
@@ -48,7 +48,7 @@ export async function renderHtml(req, html, context, props) {
 
   if (context.url) {
     return {
-      status: MOVED_PERMANENTLY,
+      status: context.status || MOVED_PERMANENTLY,
       data: {
         Location: context.url,
       },

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -17,6 +17,7 @@ import {
   INTERNAL_SERVER_ERROR,
   MOVED_PERMANENTLY,
   NOT_ACCEPTABLE,
+  TEMPORARY_REDIRECT,
 } from 'http-status';
 import matchPath from 'react-router-dom/matchPath';
 import { getToken } from './helpers/auth';
@@ -115,7 +116,7 @@ async function sendInternalServerError(req, res) {
 }
 
 function sendResponse(res, data, status = OK) {
-  if (status === MOVED_PERMANENTLY) {
+  if (status === MOVED_PERMANENTLY || status === TEMPORARY_REDIRECT) {
     res.writeHead(status, data);
     res.end();
   } else if (res.getHeader('Content-Type') === 'application/json') {
@@ -187,7 +188,7 @@ app.get(
   '/*',
   (req, res, next) => {
     const { basepath: path } = getLocaleInfoFromPath(req.path);
-    const route = appRoutes.find(r => matchPath(path, r)); // match with routes  used in frontend
+    const route = appRoutes.find(r => matchPath(path, r)); // match with routes used in frontend
     if (!route) {
       next('route'); // skip to next route (i.e. proxy)
     } else {


### PR DESCRIPTION
N.B. The following tests require the frontend to use production api

- [ ] test that `/nb/node/168432` routes to stier.ndla.no with status code 301
- [ ] test that `/subjects/subject:3/topic:1:55163/topic:1:168398/resource:1:168432` routes to stier.ndla.no with status code 307