### PR TITLE
Add route match for old node urls with trailing stuff

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -182,6 +182,10 @@ app.get('/:lang?/node/:nodeId', async (req, res, next) =>
   forwardingRoute(req, res, next),
 );
 
+app.get('/:lang?/node/:nodeId/*', async (req, res, next) =>
+  forwardingRoute(req, res, next),
+);
+
 app.get('/favicon.ico', ndlaMiddleware);
 app.get(
   '/*',


### PR DESCRIPTION
N.B. The following tests require the frontend to use production api

 

- [x] test that `nb/node/4334/menu?fag=36 ` routes to `/subjects/subject:3/topic:1:55212/topic:1:175218/resource:1:4334` with status code 301

