### PR TITLE
feat: handle different paths to node id

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -179,13 +179,22 @@ app.get('/oembed', ndlaMiddleware, async (req, res) => {
 
 app.get('/:lang?/search/apachesolr_search(/*)?', proxy(config.oldNdlaProxyUrl));
 
-app.get('/:lang?/node/:nodeId', async (req, res, next) =>
-  forwardingRoute(req, res, next),
-);
-
-app.get('/:lang?/node/:nodeId/*', async (req, res, next) =>
-  forwardingRoute(req, res, next),
-);
+/** Handle different paths to a node in old ndla. */
+[
+  'node',
+  'printpdf',
+  'easyreader',
+  'contentbrowser/node',
+  'print',
+  'aktualitet',
+].forEach(path => {
+  app.get(`/:lang?/${path}/:nodeId`, async (req, res, next) =>
+    forwardingRoute(req, res, next),
+  );
+  app.get(`/:lang?/${path}/:nodeId/*`, async (req, res, next) =>
+    forwardingRoute(req, res, next),
+  );
+});
 
 app.get('/favicon.ico', ndlaMiddleware);
 app.get(


### PR DESCRIPTION
Test needs to be done with prod api

- [x] /nb/node/170165?fag=36 redirects to /subjects/subject:3/topic:1:179373/topic:1:170165
- [x] /nb/print/170165?fag=36 redirects to /subjects/subject:3/topic:1:179373/topic:1:170165
- [x] /nb/printpdf/170165?fag=36 redirects to /subjects/subject:3/topic:1:179373/topic:1:170165
- [x] /nb/easyreader/170165?fag=36 redirects to /subjects/subject:3/topic:1:179373/topic:1:170165
- [x] /nb/contentbrowser/node/170165?fag=36 redirects to /subjects/subject:3/topic:1:179373/topic:1:170165
- [x] /nb/aktualitet/170165?fag=36 redirects to /subjects/subject:3/topic:1:179373/topic:1:170165