### PR TITLE
Remove use of taxonomy path

### DIFF
--- a/src/__tests__/__snapshots__/routeHelpers-test.js.snap
+++ b/src/__tests__/__snapshots__/routeHelpers-test.js.snap
@@ -16,7 +16,7 @@ Array [
   },
   Object {
     "name": "Samfunnsfaglige tenkemåter",
-    "to": "/subjects/subject:3/topic:1:179373/topic:1:170165",
+    "to": "/subjects/subject:9/topic:1:179373/topic:1:170165",
   },
 ]
 `;
@@ -37,7 +37,7 @@ Array [
   },
   Object {
     "name": "Samfunnsfaglige tenkemåter",
-    "to": "/subjects/subject:3/topic:1:179373/topic:1:170165",
+    "to": "/subjects/subject:9/topic:1:179373/topic:1:170165",
   },
   Object {
     "name": "Utforskeren",

--- a/src/__tests__/routeHelpers-test.js
+++ b/src/__tests__/routeHelpers-test.js
@@ -9,36 +9,39 @@
 import { toBreadcrumbItems } from '../routeHelpers';
 
 const subject = {
+  id: 'urn:subject:9',
   name: 'Historie vg2 og vg3',
   path: '/subject:9',
 };
-
-const topicPath = [
+const topics = [
   {
+    id: 'urn:topic:1:179373',
     name: 'Om Utforskeren ',
     path: '/subject:9/topic:1:179373',
   },
   {
+    id: 'urn:topic:1:170165',
     name: 'Samfunnsfaglige tenkemåter',
     path: '/subject:3/topic:1:179373/topic:1:170165',
   },
 ];
 
 const resource = {
+  id: 'urn:resource:1:168389',
   name: 'Utforskeren',
   path: '/subject:9/topic:1:179373/topic:1:170165/resource:1:168389',
 };
 
 test('breadcrumb items from subject ', () => {
-  expect(toBreadcrumbItems('Home', subject)).toMatchSnapshot();
+  expect(toBreadcrumbItems('Home', [subject])).toMatchSnapshot();
 });
 
 test('breadcrumb items from from subject and topicpath', () => {
-  expect(toBreadcrumbItems('Home', subject, topicPath)).toMatchSnapshot();
+  expect(toBreadcrumbItems('Home', [subject, ...topics])).toMatchSnapshot();
 });
 
 test('breadcrumb items from from subject, topicpath and resouce', () => {
   expect(
-    toBreadcrumbItems('Home', subject, topicPath, resource),
+    toBreadcrumbItems('Home', [subject, ...topics, resource]),
   ).toMatchSnapshot();
 });

--- a/src/containers/ArticlePage/components/ArticleHero.jsx
+++ b/src/containers/ArticlePage/components/ArticleHero.jsx
@@ -32,9 +32,7 @@ const ArticleHero = ({ resource, subject, topicPath, location, t }) => {
               <Breadcrumb
                 items={toBreadcrumbItems(
                   t('breadcrumb.toFrontpage'),
-                  subject,
-                  topicPath,
-                  resource,
+                  [subject, ...topicPath, resource],
                   getFiltersFromUrl(location),
                 )}
               />

--- a/src/containers/Masthead/MastheadContainer.jsx
+++ b/src/containers/Masthead/MastheadContainer.jsx
@@ -182,9 +182,7 @@ class MastheadContainer extends React.PureComponent {
     const breadcrumbBlockItems = subject
       ? toBreadcrumbItems(
           t('breadcrumb.toFrontpage'),
-          subject,
-          topicPath,
-          resource,
+          [subject, ...topicPath, resource],
           getFiltersFromUrl(location),
         )
       : [];

--- a/src/containers/Masthead/components/MastheadTopics.jsx
+++ b/src/containers/Masthead/components/MastheadTopics.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { node, shape, func, string, arrayOf, object } from 'prop-types';
 import { TopicMenu } from '@ndla/ui';
-import { toSubject } from '../../../routeHelpers';
+import { toSubject, removeUrn } from '../../../routeHelpers';
 import { resourceToLinkProps } from '../../Resources/resourceHelpers';
 import {
   mapTopicResourcesToTopic,
@@ -31,13 +31,17 @@ const MastheadTopics = props => {
     expandedSubtopicsId,
   );
 
-  const resourceToLinkPropsWithFilters = (resource, subjectTopicPath) =>
-    resourceToLinkProps(
+  const resourceToLinkPropsWithFilters = resource => {
+    const subjectTopicPath = [subject.id, ...expandedSubtopicsId]
+      .map(removeUrn)
+      .join('/');
+    return resourceToLinkProps(
       resource,
-      subjectTopicPath,
+      '/' + subjectTopicPath,
       activeFilters.join(','),
       locale,
     );
+  };
 
   return (
     <TopicMenu

--- a/src/containers/Masthead/mastheadHelpers.js
+++ b/src/containers/Masthead/mastheadHelpers.js
@@ -23,11 +23,7 @@ function getContentTypeResults(
   }
   return topicResourcesByType.map(type => ({
     contentType: contentTypeMapping[type.id],
-    resources: type.resources.map(resource => ({
-      ...resource,
-      path: resource.path,
-      additional: resource.additional,
-    })),
+    resources: type.resources,
     title: type.name,
   }));
 }

--- a/src/containers/SubjectPage/components/SubjectPageContent.jsx
+++ b/src/containers/SubjectPage/components/SubjectPageContent.jsx
@@ -22,12 +22,7 @@ import SubjectPageStacked from './layout/SubjectPageStacked';
 
 const SubjectBreadCrumb = injectT(({ t, subject }) => (
   <Breadcrumb
-    items={toBreadcrumbItems(
-      t('breadcrumb.toFrontpage'),
-      subject,
-      undefined,
-      undefined,
-    )}
+    items={toBreadcrumbItems(t('breadcrumb.toFrontpage'), [subject], undefined)}
   />
 ));
 

--- a/src/containers/TopicPage/TopicPage.jsx
+++ b/src/containers/TopicPage/TopicPage.jsx
@@ -164,9 +164,7 @@ class TopicPage extends Component {
                   <Breadcrumb
                     items={toBreadcrumbItems(
                       t('breadcrumb.toFrontpage'),
-                      subject,
-                      topicPath,
-                      undefined,
+                      [subject, ...topicPath],
                       getFiltersFromUrl(location),
                     )}
                   />

--- a/src/routeHelpers.jsx
+++ b/src/routeHelpers.jsx
@@ -74,29 +74,30 @@ export const toTopicPartial = (
   ...topicIds
 ) => topicId => toTopic(subjectId, filters, ...topicIds, topicId);
 
-export function toBreadcrumbItems(
-  rootName,
-  subject,
-  topicPath = [],
-  resource,
-  filters = '',
-) {
+export function toBreadcrumbItems(rootName, path, filters = '') {
   const filterParam = filters.length > 0 ? `?filters=${filters}` : '';
-  const topicLinks = topicPath.map(topic => ({
-    to: toSubjects() + topic.path + filterParam,
-    name: topic.name,
-  }));
 
-  const resourceLink = resource
-    ? [{ to: toSubjects() + resource.path + filterParam, name: resource.name }]
-    : [];
+  const links = path
+    .filter(path => path !== undefined)
+    .reduce(
+      (links, item) => [
+        ...links,
+        {
+          to:
+            (links.length ? links[links.length - 1].to : '') +
+            '/' +
+            removeUrn(item.id),
+          name: item.name,
+        },
+      ],
+      [],
+    )
+    .map(links => ({
+      ...links,
+      to: toSubjects() + links.to + filterParam,
+    }));
 
-  return [
-    { to: '/', name: rootName },
-    { to: toSubjects() + subject.path + filterParam, name: subject.name },
-    ...topicLinks,
-    ...resourceLink,
-  ];
+  return [{ to: '/', name: rootName }, ...links];
 }
 
 export function toLinkProps(linkObject, locale) {

--- a/src/routeHelpers.jsx
+++ b/src/routeHelpers.jsx
@@ -74,10 +74,10 @@ export const toTopicPartial = (
   ...topicIds
 ) => topicId => toTopic(subjectId, filters, ...topicIds, topicId);
 
-export function toBreadcrumbItems(rootName, path, filters = '') {
+export function toBreadcrumbItems(rootName, paths, filters = '') {
   const filterParam = filters.length > 0 ? `?filters=${filters}` : '';
 
-  const links = path
+  const links = paths
     .filter(path => path !== undefined)
     .reduce(
       (links, item) => [


### PR DESCRIPTION
Need to be tested against prod api:


- [x] Test menu links
1. Go to /subjects/subject:33
2. Click on «Meny»
3. Check that links to resources contains `subject:33`.
- [x] Test breadcrumbs
1. Go to /subjects/subject:33
2. Click on «Funksjoner» topic link
3. Click on «Funksjonsbegrepet» topic link
4. Check that the «Funksjoner» breadcrumb link point to correct subject (`subject:33`)