### PR TITLE
#1575: Enable 'trust proxy' for express

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -41,6 +41,7 @@ const allowedBodyContentTypes = [
 ];
 
 app.disable('x-powered-by');
+app.enable('trust proxy');
 
 const ndlaMiddleware = [
   express.static(process.env.RAZZLE_PUBLIC_DIR, {


### PR DESCRIPTION
connects to NDLANO/Issues#1575

The service mesh uses the `Host` header for outgoing requests.
This means that the proxy cannot keep the `Host` header as ex: "ndla.no" .
Enabling `trust proxy` makes `req.hostname` use `X-Forwarded-Host` if it exists.