### PR TITLE
Ndlano/issue#1660 ending path with slash

### DIFF
--- a/src/__tests__/__snapshots__/routeHelpers-test.js.snap
+++ b/src/__tests__/__snapshots__/routeHelpers-test.js.snap
@@ -8,15 +8,15 @@ Array [
   },
   Object {
     "name": "Historie vg2 og vg3",
-    "to": "/subjects/subject:9",
+    "to": "/subjects/subject:9/",
   },
   Object {
     "name": "Om Utforskeren ",
-    "to": "/subjects/subject:9/topic:1:179373",
+    "to": "/subjects/subject:9/topic:1:179373/",
   },
   Object {
     "name": "Samfunnsfaglige tenkemåter",
-    "to": "/subjects/subject:9/topic:1:179373/topic:1:170165",
+    "to": "/subjects/subject:9/topic:1:179373/topic:1:170165/",
   },
 ]
 `;
@@ -29,15 +29,15 @@ Array [
   },
   Object {
     "name": "Historie vg2 og vg3",
-    "to": "/subjects/subject:9",
+    "to": "/subjects/subject:9/",
   },
   Object {
     "name": "Om Utforskeren ",
-    "to": "/subjects/subject:9/topic:1:179373",
+    "to": "/subjects/subject:9/topic:1:179373/",
   },
   Object {
     "name": "Samfunnsfaglige tenkemåter",
-    "to": "/subjects/subject:9/topic:1:179373/topic:1:170165",
+    "to": "/subjects/subject:9/topic:1:179373/topic:1:170165/",
   },
   Object {
     "name": "Utforskeren",
@@ -54,7 +54,7 @@ Array [
   },
   Object {
     "name": "Historie vg2 og vg3",
-    "to": "/subjects/subject:9",
+    "to": "/subjects/subject:9/",
   },
 ]
 `;

--- a/src/containers/ArticlePage/ArticlePage.jsx
+++ b/src/containers/ArticlePage/ArticlePage.jsx
@@ -120,7 +120,6 @@ class ArticlePage extends Component {
         query: resourceTypesQuery,
       },
     ]);
-
     return {
       ...response,
       data: transformData(response.data),

--- a/src/containers/Masthead/components/__tests__/MastheadTopics-test.js
+++ b/src/containers/Masthead/components/__tests__/MastheadTopics-test.js
@@ -21,7 +21,7 @@ test('Get path to main topicId', () => {
     expandedTopicIds,
   )('urn:topic:main');
 
-  expect(pathToMain).toBe('/subjects/subject:1/topic:main');
+  expect(pathToMain).toBe('/subjects/subject:1/topic:main/');
 });
 
 test('Get path to sub topicId', () => {
@@ -31,7 +31,7 @@ test('Get path to sub topicId', () => {
     expandedTopicIds,
   )('urn:topic:sub');
 
-  expect(pathToSub).toBe('/subjects/subject:1/topic:main/topic:sub');
+  expect(pathToSub).toBe('/subjects/subject:1/topic:main/topic:sub/');
 });
 
 test('Get path to leaf topicId', () => {
@@ -42,6 +42,6 @@ test('Get path to leaf topicId', () => {
   )('urn:topic:subsubsub');
 
   expect(pathToLeaf).toBe(
-    '/subjects/subject:1/topic:main/topic:sub/topic:subsub/topic:subsubsub',
+    '/subjects/subject:1/topic:main/topic:sub/topic:subsub/topic:subsubsub/',
   );
 });

--- a/src/containers/SubjectPage/components/SubjectPageContent.jsx
+++ b/src/containers/SubjectPage/components/SubjectPageContent.jsx
@@ -19,6 +19,7 @@ import { TopicShape } from '../../../shapes';
 import SubjectPageSingle from './layout/SubjectPageSingle';
 import SubjectPageDouble from './layout/SubjectPageDouble';
 import SubjectPageStacked from './layout/SubjectPageStacked';
+import { fixEndSlash } from '../../../routeHelpers';
 
 const SubjectBreadCrumb = injectT(({ t, subject }) => (
   <Breadcrumb
@@ -37,13 +38,18 @@ const SubjectPageContent = ({ layout, subject, ...rest }) => {
   const { filters, topics } = subject;
   const defaultProps = {
     topics: topics
-      ? topics.map(topic => ({
-          ...topic,
-          introduction:
-            topic.meta && topic.meta.metaDescription
-              ? topic.meta.metaDescription
-              : '',
-        }))
+      ? topics.map(topic => {
+          if (topic && topic.path) {
+            topic.path = fixEndSlash(topic.path);
+          }
+          return {
+            ...topic,
+            introduction:
+              topic.meta && topic.meta.metaDescription
+                ? topic.meta.metaDescription
+                : '',
+          };
+        })
       : [],
     breadcrumb: <SubjectBreadCrumb subject={subject} />,
     filters: filters

--- a/src/containers/SubjectPage/components/SubjectPageTopics.jsx
+++ b/src/containers/SubjectPage/components/SubjectPageTopics.jsx
@@ -30,7 +30,6 @@ const SubjectPageTopics = props => {
     twoColumns,
     subjectPage,
   } = props;
-
   return (
     <ResourcesWrapper
       subjectPage

--- a/src/containers/SubjectPage/components/layout/SubjectPageSingle.jsx
+++ b/src/containers/SubjectPage/components/layout/SubjectPageSingle.jsx
@@ -31,7 +31,6 @@ const SubjectPageSingle = props => {
     locale,
   } = props;
   const { editorsChoices } = subjectpage;
-
   return (
     <OneColumn>
       <SubjectContent breadcrumb={breadcrumb}>

--- a/src/containers/TopicPage/SubTopics.jsx
+++ b/src/containers/TopicPage/SubTopics.jsx
@@ -63,7 +63,6 @@ class TopicResources extends Component {
     if (subtopics.length === 0) {
       return null;
     }
-
     return (
       <ResourcesWrapper
         header={

--- a/src/containers/TopicPage/TopicPage.jsx
+++ b/src/containers/TopicPage/TopicPage.jsx
@@ -106,7 +106,6 @@ class TopicPage extends Component {
 
   render() {
     const { locale, t, loading, data, location, errors } = this.props;
-
     const { subjectId } = getUrnIdsFromProps(this.props);
 
     if (loading) {

--- a/src/routeHelpers.jsx
+++ b/src/routeHelpers.jsx
@@ -78,7 +78,6 @@ export const toTopicPartial = (
 
 export function toBreadcrumbItems(rootName, paths, filters = '') {
   const filterParam = filters.length > 0 ? `?filters=${filters}` : '';
-  const pattern = new RegExp(/resource/gi);
   const links = paths
     .filter(path => path !== undefined)
     .reduce(
@@ -96,8 +95,8 @@ export function toBreadcrumbItems(rootName, paths, filters = '') {
     )
     .map(link => {
       // making sure we have the ending slash in breadCrumbs and it dosen't contain it allready
-      if (link.to && !pattern.test(link.to) && !(/\/$/.test(link.to)) ) {
-        link.to = `${link.to}/`;
+      if (link.to) {
+        link.to = fixEndSlash(link.to);
       }
       return link;
     })
@@ -106,6 +105,15 @@ export function toBreadcrumbItems(rootName, paths, filters = '') {
       to: toSubjects() + links.to + filterParam,
     }));
   return [{ to: '/', name: rootName }, ...links];
+}
+
+
+export function fixEndSlash(link){
+  const pattern = new RegExp(/resource/gi);
+  if (link && !pattern.test(link) && !(/\/$/.test(link)) ) {
+    link = `${link}/`;
+  }
+  return link;
 }
 
 export function toLinkProps(linkObject, locale) {

--- a/src/routeHelpers.jsx
+++ b/src/routeHelpers.jsx
@@ -107,10 +107,9 @@ export function toBreadcrumbItems(rootName, paths, filters = '') {
   return [{ to: '/', name: rootName }, ...links];
 }
 
-
-export function fixEndSlash(link){
+export function fixEndSlash(link) {
   const pattern = new RegExp(/resource/gi);
-  if (link && !pattern.test(link) && !(/\/$/.test(link)) ) {
+  if (link && !pattern.test(link) && !/\/$/.test(link)) {
     link = `${link}/`;
   }
   return link;

--- a/src/routeHelpers.jsx
+++ b/src/routeHelpers.jsx
@@ -64,9 +64,10 @@ export function toTopic(subjectId, filters, ...topicIds) {
   const urnFreeTopicIds = topicIds.filter(id => !!id).map(removeUrn);
   const filterParam =
     filters && filters.length > 0 ? `?filters=${filters}` : '';
-  const t = `${toSubjects()}/${urnFreeSubjectId}/${urnFreeTopicIds.join(
-    '/',
-  )}${filterParam}`;
+  const t =
+    fixEndSlash(
+      `${toSubjects()}/${urnFreeSubjectId}/${urnFreeTopicIds.join('/')}`,
+    ) + filterParam;
   return t;
 }
 

--- a/src/routeHelpers.jsx
+++ b/src/routeHelpers.jsx
@@ -78,7 +78,7 @@ export const toTopicPartial = (
 
 export function toBreadcrumbItems(rootName, paths, filters = '') {
   const filterParam = filters.length > 0 ? `?filters=${filters}` : '';
-
+  const pattern = new RegExp(/resource/gi);
   const links = paths
     .filter(path => path !== undefined)
     .reduce(
@@ -94,11 +94,17 @@ export function toBreadcrumbItems(rootName, paths, filters = '') {
       ],
       [],
     )
+    .map(link => {
+      // making sure we have the ending slash in breadCrumbs and it dosen't contain it allready
+      if (link.to && !pattern.test(link.to) && !(/\/$/.test(link.to)) ) {
+        link.to = `${link.to}/`;
+      }
+      return link;
+    })
     .map(links => ({
       ...links,
       to: toSubjects() + links.to + filterParam,
     }));
-
   return [{ to: '/', name: rootName }, ...links];
 }
 

--- a/src/util/getTopicPath.js
+++ b/src/util/getTopicPath.js
@@ -22,6 +22,5 @@ export const getTopicPath = (subjectId, topicId, topics) => {
   };
 
   const topicPath = toBreadcrumb(leaf);
-
   return topicPath;
 };

--- a/src/util/getTopicPath.js
+++ b/src/util/getTopicPath.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-
 export const getTopicPath = (subjectId, topicId, topics) => {
   const leaf = topics.find(topic => topicId === topic.id);
   if (!leaf) {

--- a/src/util/topicsHelper.js
+++ b/src/util/topicsHelper.js
@@ -7,8 +7,8 @@
  */
 
 import defined from 'defined';
-
 import groupBy from './groupBy';
+import { fixEndSlash } from '../routeHelpers';
 
 export const groupedSubtopicsByParent = (topics = []) =>
   groupBy(topics.filter(topic => topic.parent), 'parent');
@@ -19,6 +19,9 @@ export const toTopicMenu = (topic, topics) => {
   const subtopicsWithSubtopics = subtopics.map(child =>
     toTopicMenu(child, topics),
   );
+  if (topic && topic.path) {
+    topic.path = fixEndSlash(topic.path);
+  }
   return {
     ...topic,
     introduction:


### PR DESCRIPTION
fix end-slash in search and breadcrumb path. It might be some other places that uses other parameter to rebuild the path, but we should open up another issue for those scenarios. 
This push is related to graph-api push for fixing the end-slashes.