### PR TITLE
fix helmet-csp version for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,9 @@
     "url-parse": "^1.4.7",
     "warning": "^4.0.3"
   },
+  "resolutions": {
+    "helmet/helmet-csp" : "2.8.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/NDLANO/ndla-frontend.git"

--- a/razzle.config.js
+++ b/razzle.config.js
@@ -43,7 +43,7 @@ module.exports = {
       // This change bundles node_modules into server.js. The result is smaller Docker images.
       // It triggers a couple of «Critical dependency: the request of a dependency is an
       // expression warning» which we can safely ignore.
-      appConfig.externals = [{ helmet: 'commonjs helmet' }];
+      appConfig.externals = [];
       // Razzle/CRA breaks the build on webpack warnings. Disable CI env to circumvent the check.
       process.env.CI = false;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2438,11 +2438,6 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
-bowser@^2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.7.0.tgz#96eab1fa07fab08c1ec4c75977a7c8ddf8e0fe1f"
-  integrity sha512-aIlMvstvu8x+34KEiOHD3AsBgdrzg6sxALYiukOWhFvGMbQI6TRP/iY0LMhUrHs56aD6P1G0Z7h45PUJaa5m9w==
-
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -5399,15 +5394,15 @@ helmet-crossdomain@0.4.0:
   resolved "https://registry.yarnpkg.com/helmet-crossdomain/-/helmet-crossdomain-0.4.0.tgz#5f1fe5a836d0325f1da0a78eaa5fd8429078894e"
   integrity sha512-AB4DTykRw3HCOxovD1nPR16hllrVImeFp5VBV9/twj66lJ2nU75DP8FPL0/Jp4jj79JhTfG+pFI2MD02kWJ+fA==
 
-helmet-csp@2.9.4:
-  version "2.9.4"
-  resolved "https://registry.yarnpkg.com/helmet-csp/-/helmet-csp-2.9.4.tgz#801382bac98f2f88706dc5c89d95c7e31af3a4a9"
-  integrity sha512-qUgGx8+yk7Xl8XFEGI4MFu1oNmulxhQVTlV8HP8tV3tpfslCs30OZz/9uQqsWPvDISiu/NwrrCowsZBhFADYqg==
+helmet-csp@2.8.0, helmet-csp@2.9.4:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/helmet-csp/-/helmet-csp-2.8.0.tgz#746d329e24ef39c4ebc00278a48abd3c209e0378"
+  integrity sha512-MlCPeM0Sm3pS9RACRihx70VeTHmkQwa7sum9EK1tfw1VZyvFU0dBWym9nHh3CRkTRNlyNm/WFCMvuh9zXkOjNw==
   dependencies:
-    bowser "^2.7.0"
     camelize "1.0.0"
     content-security-policy-builder "2.1.0"
     dasherize "2.0.0"
+    platform "1.3.5"
 
 helmet@^3.21.2:
   version "3.21.2"
@@ -8427,6 +8422,11 @@ pkg-up@2.0.0:
   integrity sha1-yBmscoBZpGHKscOImivjxJoATX8=
   dependencies:
     find-up "^2.1.0"
+
+platform@1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.5.tgz#fb6958c696e07e2918d2eeda0f0bc9448d733444"
+  integrity sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==
 
 pleeease-filters@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Var visst ikkje berre å sette helmet som external. Då måtte den inkluderes på ein anna måte og fant ikkje ut av det. Det enkleste er å la helmet være oppgradert og heller sette versjonen til helmet-csp til versjonen uten bowser. så kan vi heller fikse dette ein anna gong.