### PR TITLE
Added correct filter-name for search filters, so concatination for se…

### DIFF
--- a/src/containers/SearchPage/SearchContainer.jsx
+++ b/src/containers/SearchPage/SearchContainer.jsx
@@ -130,7 +130,7 @@ const SearchContainer = ({
                   ...subject,
                   value: subject.id,
                   title: subject.name,
-                  filterName: subject.name,
+                  filterName: 'filter_subjects',
                 }
               : undefined;
           })


### PR DESCRIPTION
…arch filters works on desktop.

Missing `filterName === 'filter_subjects'`
Ref frontend-packages: https://github.com/NDLANO/frontend-packages/pull/492