### PR TITLE
#2113: Use graphql-api to fetch plain articles

### DIFF
--- a/src/containers/PlainArticlePage/PlainArticlePage.jsx
+++ b/src/containers/PlainArticlePage/PlainArticlePage.jsx
@@ -6,23 +6,25 @@
  *
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import Helmet from 'react-helmet';
 import { OneColumn } from '@ndla/ui';
 import { injectT } from '@ndla/i18n';
 import { withTracker } from '@ndla/tracker';
+import { DefaultErrorMessage } from '../../components/DefaultErrorMessage';
+import NotFoundPage from '../NotFoundPage/NotFoundPage';
 import { transformArticle } from '../../util/transformArticle';
 import Article from '../../components/Article';
 import ArticleHero from '../ArticlePage/components/ArticleHero';
-import ArticleErrorMessage from '../ArticlePage/components/ArticleErrorMessage';
-import { fetchArticle } from '../ArticlePage/articleApi';
 import { getArticleScripts } from '../../util/getArticleScripts';
 import getStructuredDataFromArticle from '../../util/getStructuredDataFromArticle';
 import { getArticleProps } from '../../util/getArticleProps';
 import { getAllDimensions } from '../../util/trackingUtil';
 import SocialMediaMetadata from '../../components/SocialMediaMetadata';
+import { plainArticleQuery } from '../../queries';
+import { useGraphQuery } from '../../util/runQueries';
 
 const getTitle = article => article?.title || '';
 
@@ -38,39 +40,28 @@ const PlainArticlePage = ({
     params: { articleId },
   },
 }) => {
-  const [rawArticle, setArticle] = useState({});
-  const getArticle = async (articleId, locale) => {
-    try {
-      const article = await fetchArticle(articleId, locale);
-      setArticle({ article, status: 'success' });
-    } catch (error) {
-      const status = error.json?.status === 404 ? 'error404' : 'error';
-      setArticle({ status });
-    }
-  };
+  const { loading, data } = useGraphQuery(plainArticleQuery, {
+    variables: { articleId, removeRelatedContent: 'true' },
+  });
+
   useEffect(() => {
     if (window.MathJax) {
       window.MathJax.Hub.Queue(['Typeset', window.MathJax.Hub]);
     }
-    if (!rawArticle.status) {
-      getArticle(articleId, locale);
-    }
   });
 
-  if (!rawArticle.status) {
+  if (loading) {
     return null;
   }
 
-  if (rawArticle.status !== 'success') {
-    return (
-      <div>
-        <ArticleHero resource={{}} />
-        <ArticleErrorMessage status={rawArticle.status} />
-      </div>
-    );
+  if (!data) {
+    return <DefaultErrorMessage />;
+  }
+  if (!data.article) {
+    return <NotFoundPage />;
   }
 
-  const article = transformArticle(rawArticle.article, locale);
+  const article = transformArticle(data.article, locale);
   const scripts = getArticleScripts(article);
 
   return (

--- a/src/containers/ResourcePage/ResourcePage.jsx
+++ b/src/containers/ResourcePage/ResourcePage.jsx
@@ -23,7 +23,6 @@ import { useGraphQuery } from '../../util/runQueries';
 const ResourcePage = props => {
   useEffect(() => {
     if (window.MathJax) {
-      console.log('running matjax thing');
       window.MathJax.Hub.Queue(['Typeset', window.MathJax.Hub]);
     }
   });

--- a/src/gqlSchema.json
+++ b/src/gqlSchema.json
@@ -85,6 +85,16 @@
                   "ofType": null
                 },
                 "defaultValue": null
+              },
+              {
+                "name": "removeRelatedContent",
+                "description": "",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null
               }
             ],
             "type": {

--- a/src/queries.js
+++ b/src/queries.js
@@ -609,6 +609,15 @@ export const resourceQuery = gql`
   ${articleInfoFragment}
 `;
 
+export const plainArticleQuery = gql`
+  query plainArticleQuery($articleId: String!, $removeRelatedContent: String) {
+    article(id: $articleId, removeRelatedContent: $removeRelatedContent) {
+      ...ArticleInfo
+    }
+  }
+  ${articleInfoFragment}
+`;
+
 export const topicQuery = gql`
   query topicQuery($topicId: String!, $filterIds: String, $subjectId: String) {
     topic(id: $topicId, subjectId: $subjectId) {


### PR DESCRIPTION
Depends on https://github.com/NDLANO/graphql-api/pull/96
Fixes NDLANO/Issues#2113

When doing SSR we use apollos `renderToStringWithData`. This waits for
graphql requests to finish before returning. When using regular fetch
calls only the initial html will be rendered.

If one wanted to use fetch to aquire data it would have to be done
before the `renderToStringWithData` function is called, and to be used
from props. (IE: Use a class component or rewrite the
`loadGetInitialProps` in defaultRoute.js)