### PR TITLE
Added toolbox and multidisciplinary-subject to front-page

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -383,3 +383,30 @@ export const PLAIN_LEARNINGPATHSTEP_PAGE_PATH =
 
 export const SKIP_TO_CONTENT_ID = 'SkipToContentId';
 export const SUPPORTED_LANGUAGES = ['nb', 'nn', 'en'];
+
+export const TOOLBOX_PAGE_PATH =
+  '/subjects/subject:ee3f7a15-feb6-4e78-8b37-65930ad73a09';
+
+export const MULTIDISCIPLINARY_SUBJECT_PAGE_PATH =
+  '/subjects/subject:d1fe9d0a-a54d-49db-a4c2-fd5463a7c9e7';
+
+export const MULTIDISCIPLINARY_SUBJECTS = [
+  {
+    title: 'Folkehelse og livsmestring',
+    url:
+      '/subjects/subject:d1fe9d0a-a54d-49db-a4c2-fd5463a7c9e7?filters=urn:filter:3645d7c4-63af-469a-a502-38e53d03d6c7',
+    id: 'Folkehelse og livsmestring',
+  },
+  {
+    title: 'Demokrati og medborgerskap',
+    url:
+      '/subjects/subject:d1fe9d0a-a54d-49db-a4c2-fd5463a7c9e7?filters=urn:filter:1e3b4fd0-3245-42b5-8685-db02c5592acc',
+    id: 'Demokrati og medborgerskap',
+  },
+  {
+    title: 'Bærekraftig utvikling',
+    url:
+      '/subjects/subject:d1fe9d0a-a54d-49db-a4c2-fd5463a7c9e7?filters=urn:filter:7ab1cc5c-4f79-4bb4-b1ab-bef7c41aed66',
+    id: 'Bærekraftig utvikling',
+  },
+];

--- a/src/containers/WelcomePage/WelcomePage.jsx
+++ b/src/containers/WelcomePage/WelcomePage.jsx
@@ -63,11 +63,11 @@ const WelcomePage = ({ t, locale, history, location }) => {
           <FrontpageSubjects />
         </div>
         <OneColumn wide>
-          <FrontpageToolbox url={TOOLBOX_PAGE_PATH} />
           <FrontpageMultidisciplinarySubject
             url={MULTIDISCIPLINARY_SUBJECT_PAGE_PATH}
             topics={MULTIDISCIPLINARY_SUBJECTS}
           />
+          <FrontpageToolbox url={TOOLBOX_PAGE_PATH} />
           <BlogPosts locale={locale} />
           <FrontpageFilm
             imageUrl="/static/film_illustrasjon.svg"

--- a/src/containers/WelcomePage/WelcomePage.jsx
+++ b/src/containers/WelcomePage/WelcomePage.jsx
@@ -9,12 +9,23 @@
 import React, { Fragment } from 'react';
 import { HelmetWithTracker } from '@ndla/tracker';
 import PropTypes from 'prop-types';
-import { FrontpageHeader, FrontpageFilm, OneColumn } from '@ndla/ui';
+import {
+  FrontpageHeader,
+  FrontpageFilm,
+  OneColumn,
+  FrontpageToolbox,
+  FrontpageMultidisciplinarySubject,
+} from '@ndla/ui';
 import { injectT } from '@ndla/i18n';
 
 import WelcomePageInfo from './WelcomePageInfo';
 import FrontpageSubjects from './FrontpageSubjects';
-import { FILM_PAGE_PATH } from '../../constants';
+import {
+  FILM_PAGE_PATH,
+  MULTIDISCIPLINARY_SUBJECT_PAGE_PATH,
+  MULTIDISCIPLINARY_SUBJECTS,
+  TOOLBOX_PAGE_PATH,
+} from '../../constants';
 import SocialMediaMetadata from '../../components/SocialMediaMetadata';
 import config from '../../config';
 
@@ -52,6 +63,11 @@ const WelcomePage = ({ t, locale, history, location }) => {
           <FrontpageSubjects />
         </div>
         <OneColumn wide>
+          <FrontpageToolbox url={TOOLBOX_PAGE_PATH} />
+          <FrontpageMultidisciplinarySubject
+            url={MULTIDISCIPLINARY_SUBJECT_PAGE_PATH}
+            topics={MULTIDISCIPLINARY_SUBJECTS}
+          />
           <BlogPosts locale={locale} />
           <FrontpageFilm
             imageUrl="/static/film_illustrasjon.svg"


### PR DESCRIPTION
Artikkelen på forsiden på ff hadde lenker til verktøykassa og tverrfaglige temaer. Etter sammenslåing til en server er det ikke lenker inn til dette lenger. Denne PR legger de to nye boksene med innganger til dette på forsiden.