### PR TITLE
Fetch resource id based on pattern

### DIFF
--- a/src/iframe/IframeArticlePage.js
+++ b/src/iframe/IframeArticlePage.js
@@ -24,6 +24,11 @@ import { SocialMediaMetadata } from '../components/SocialMediaMetadata';
 import { fetchResource } from '../containers/Resources/resourceApi';
 import config from '../config';
 
+export const fetchResourceId = props => {
+  const paths = props.location.pathname.split('/');
+  return paths.find(path => path.startsWith('urn'));
+};
+
 class IframeArticlePage extends Component {
   constructor(props) {
     super(props);
@@ -33,8 +38,7 @@ class IframeArticlePage extends Component {
   }
 
   componentDidMount() {
-    const resourceId = this.props.location.pathname.split('/')[3];
-    fetchResource(resourceId).then(resource => {
+    fetchResource(fetchResourceId(this.props)).then(resource => {
       this.setState({
         path: resource.path || resource.paths?.[0],
       });

--- a/src/iframe/__tests__/IframeArticlePage-test.js
+++ b/src/iframe/__tests__/IframeArticlePage-test.js
@@ -12,6 +12,7 @@ import renderer from 'react-test-renderer';
 import serializer from 'jest-emotion';
 import { IframePage } from '../IframePage';
 import { getLocaleObject } from '../../i18n';
+import { fetchResourceId } from '../IframeArticlePage';
 
 expect.addSnapshotSerializer(serializer);
 
@@ -75,4 +76,18 @@ test('IframePage with article displays error message on status === error', () =>
   );
 
   expect(component.toJSON()).toMatchSnapshot();
+});
+
+test('fetchResourceId fetches correct resource id from path', () => {
+  const url =
+    'https://ndla.no/article-iframe/urn:resource:670ac97d-1d4d-4515-9554-07e0870e66aa/24835?removeRelatedContent=true';
+  expect(fetchResourceId({ location: { pathname: url } })).toMatch(
+    'urn:resource:670ac97d-1d4d-4515-9554-07e0870e66aa',
+  );
+
+  const urlWithLang =
+    'https://ndla.no/article-iframe/nb/urn:resource:670ac97d-1d4d-4515-9554-07e0870e66aa/24835?removeRelatedContent=true';
+  expect(fetchResourceId({ location: { pathname: urlWithLang } })).toMatch(
+    'urn:resource:670ac97d-1d4d-4515-9554-07e0870e66aa',
+  );
 });


### PR DESCRIPTION
Etter at vi endra iframe-urler til å kunne være uten språk så feiler dette. Fiksen er ikkje avhengig av at pathen har x antall ledd.