### PR TITLE
fixing history.replace adding duplicate locale to path

### DIFF
--- a/src/containers/SubjectPage/SubjectContainer.jsx
+++ b/src/containers/SubjectPage/SubjectContainer.jsx
@@ -201,8 +201,8 @@ const SubjectPage = ({
       lowermost?.filters?.length && !getFiltersFromUrl(location)
         ? `?filters=${lowermost.filters[0].id}`
         : `?filters=${getFiltersFromUrl(location)}`;
-    const path = parseAndMatchUrl(e.currentTarget.href);
-    history.replace(`${path.url}${filterParam}`);
+    const path = parseAndMatchUrl(e.currentTarget.href, true);
+    history.replace({ pathname: path.url, search: filterParam });
   };
 
   // show/hide breadcrumb based on intersection

--- a/src/util/urlHelper.js
+++ b/src/util/urlHelper.js
@@ -31,10 +31,11 @@ function matchUrl(pathname, type, lang = false) {
   );
 }
 
-export function parseAndMatchUrl(url) {
+export function parseAndMatchUrl(url, withoutLocale = false) {
   const { pathname } = new Url(url);
-  const paths = pathname.split('/');
+  let paths = pathname.split('/');
   paths[1] = paths[1] === 'unknown' ? 'nb' : paths[1];
+  if (withoutLocale && isValidLocale(paths[1])) paths.splice(1, 1);
   const path = paths.join('/');
 
   if (isValidLocale(paths[1])) {

--- a/src/util/urlHelper.js
+++ b/src/util/urlHelper.js
@@ -31,11 +31,11 @@ function matchUrl(pathname, type, lang = false) {
   );
 }
 
-export function parseAndMatchUrl(url, withoutLocale = false) {
+export function parseAndMatchUrl(url, ignoreLocale = false) {
   const { pathname } = new Url(url);
   let paths = pathname.split('/');
   paths[1] = paths[1] === 'unknown' ? 'nb' : paths[1];
-  if (withoutLocale && isValidLocale(paths[1])) paths.splice(1, 1);
+  if (ignoreLocale && isValidLocale(paths[1])) paths.splice(1, 1);
   const path = paths.join('/');
 
   if (isValidLocale(paths[1])) {


### PR DESCRIPTION
Fikser det at navigering til topic når man har locale valgt legger på duplikat locale string. 
F.eks navigering til topic her http://localhost:3000/nn/subjects/subject:26?filters=urn:filter:ca607ca1-4dd0-4bbd-954f-67461f4b96fc resulterer i at man ender opp her http://localhost:3000/nn/nn/subjects/subject:26/topic:1:191103/?filters=urn:filter:ca607ca1-4dd0-4bbd-954f-67461f4b96fc

Er en litt scuffed fiks for dette, men klarte ikke å finne noen måte å overstyre det at `history.replace` bruker `http://localhost:3000/nn` som base path.