### PR TITLE
Check subject filters before choosing filter from topic

### DIFF
--- a/src/containers/Masthead/components/MastheadSearch.jsx
+++ b/src/containers/Masthead/components/MastheadSearch.jsx
@@ -104,7 +104,7 @@ const MastheadSearch = ({
   const searchString = queryString.stringify({
     query: query && query.length > 0 ? query : undefined,
     subjects,
-    levels: filterIds || undefined,
+    levels: subjects ? filterIds || undefined : undefined,
   });
 
   const onSearch = evt => {

--- a/src/containers/SubjectPage/SubjectContainer.jsx
+++ b/src/containers/SubjectPage/SubjectContainer.jsx
@@ -78,7 +78,10 @@ const SubjectPage = ({
     const lowermostId = urlSubSubTopicId || urlSubTopicId || urlTopicId;
     const lowermost =
       subject.allTopics.find(topic => topic.id === lowermostId) || subject;
-    const filters = activeFilterId || lowermost?.filters?.[0]?.id;
+    const subjectFilters = lowermost?.filters?.filter(f =>
+      subject.filters?.map(f2 => f2.id).includes(f.id),
+    );
+    const filters = activeFilterId || subjectFilters?.[0]?.id;
     const filterParam = filters ? `?filters=${filters}` : '';
     const path = parseAndMatchUrl(location.pathname, true);
     if (path) {


### PR DESCRIPTION
På grunn av manglende vask i taksonomi kan emner ha filter fra andre fag enn det dei ligger i. Det vil sei at det er mulig å automatisk plukke filter som ikkje hører heime i faget, og dermed få kombinasjoner som gir tomme fag.

Eksempel er url https://test.ndla.no/subjects/subject:8b18253e-8b0e-49d7-a97b-2240b46708cf?filters=urn:filter:6b35c125-5a82-4a30-9d60-0646c31dce32 der filteret som plukkes ikkje finnes på faget. PR gjør en ekstra sjekk på filter på subject på om filteret skal velges.