### PR TITLE
Adjust filters on "Tverrfaglige tema", "Verktøykassa" and "Brønnteknikk"

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -371,32 +371,5 @@ export const PLAIN_LEARNINGPATHSTEP_PAGE_PATH =
 export const SKIP_TO_CONTENT_ID = 'SkipToContentId';
 export const SUPPORTED_LANGUAGES = ['nb', 'nn', 'en'];
 
-export const TOOLBOX_PAGE_PATH =
-  '/subjects/subject:ee3f7a15-feb6-4e78-8b37-65930ad73a09';
-
-export const MULTIDISCIPLINARY_SUBJECT_PAGE_PATH =
-  '/subjects/subject:d1fe9d0a-a54d-49db-a4c2-fd5463a7c9e7';
-
-export const MULTIDISCIPLINARY_SUBJECTS = [
-  {
-    title: 'Folkehelse og livsmestring',
-    url:
-      '/subjects/subject:d1fe9d0a-a54d-49db-a4c2-fd5463a7c9e7?filters=urn:filter:3645d7c4-63af-469a-a502-38e53d03d6c7',
-    id: 'Folkehelse og livsmestring',
-  },
-  {
-    title: 'Demokrati og medborgerskap',
-    url:
-      '/subjects/subject:d1fe9d0a-a54d-49db-a4c2-fd5463a7c9e7?filters=urn:filter:1e3b4fd0-3245-42b5-8685-db02c5592acc',
-    id: 'Demokrati og medborgerskap',
-  },
-  {
-    title: 'Bærekraftig utvikling',
-    url:
-      '/subjects/subject:d1fe9d0a-a54d-49db-a4c2-fd5463a7c9e7?filters=urn:filter:7ab1cc5c-4f79-4bb4-b1ab-bef7c41aed66',
-    id: 'Bærekraftig utvikling',
-  },
-];
-
 export const PROGRAMME_PATH = '/utdanning';
 export const PROGRAMME_PAGE_PATH = '/utdanning/:programme';

--- a/src/constants.js
+++ b/src/constants.js
@@ -373,3 +373,6 @@ export const SUPPORTED_LANGUAGES = ['nb', 'nn', 'en'];
 
 export const PROGRAMME_PATH = '/utdanning';
 export const PROGRAMME_PAGE_PATH = '/utdanning/:programme';
+
+export const MULTIDISCIPLINARY_SUBJECT_PAGE_PATH =
+  '/subjects/subject:d1fe9d0a-a54d-49db-a4c2-fd5463a7c9e7';

--- a/src/containers/WelcomePage/FrontpageSubjects.jsx
+++ b/src/containers/WelcomePage/FrontpageSubjects.jsx
@@ -33,14 +33,19 @@ const createSubjectFilterUrl = (subject, filter) => {
 
 export const getCategoriesSubjects = locale => {
   return subjectsCategories.map(category => {
-    const subjects = category.subjects.map(subject => ({
-      name: subject.longName[locale],
-      url: createSubjectFilterUrl(subject, subject.filters),
-    }));
+    const subjects = category.subjects.map(subject => {
+      if (subject.hideOnFrontpage) {
+        return null;
+      }
+      return {
+        name: subject.longName[locale],
+        url: createSubjectFilterUrl(subject, subject.filters),
+      };
+    });
 
     return {
       name: category.name[locale],
-      subjects: sortBy(subjects),
+      subjects: sortBy(subjects.filter(Boolean)),
     };
   });
 };

--- a/src/containers/WelcomePage/WelcomePage.jsx
+++ b/src/containers/WelcomePage/WelcomePage.jsx
@@ -20,12 +20,7 @@ import { injectT } from '@ndla/i18n';
 
 import WelcomePageInfo from './WelcomePageInfo';
 import FrontpageSubjects from './FrontpageSubjects';
-import {
-  FILM_PAGE_PATH,
-  MULTIDISCIPLINARY_SUBJECT_PAGE_PATH,
-  MULTIDISCIPLINARY_SUBJECTS,
-  TOOLBOX_PAGE_PATH,
-} from '../../constants';
+import { FILM_PAGE_PATH } from '../../constants';
 import SocialMediaMetadata from '../../components/SocialMediaMetadata';
 import config from '../../config';
 
@@ -33,6 +28,33 @@ import { getLocaleUrls } from '../../util/localeHelpers';
 import { LocationShape } from '../../shapes';
 import BlogPosts from './BlogPosts';
 import WelcomePageSearch from './WelcomePageSearch';
+import { toSubject } from '../../routeHelpers';
+import { getSubjectById } from '../../data/subjects';
+
+const getUrlFromSubjectId = subjectId => {
+  const subject = getSubjectById(subjectId);
+  const filters = subject.filters ? subject.filters.join(',') : '';
+  return toSubject(subject.subjectId, filters);
+};
+
+const getMultidisciplinarySubjects = locale => {
+  const subjectIds = [
+    'common_subject_57',
+    'common_subject_58',
+    'common_subject_59',
+  ];
+  return subjectIds.map(subjectId => {
+    const subject = getSubjectById(subjectId);
+    return {
+      id: subject.id,
+      title: subject.name[locale],
+      url: getUrlFromSubjectId(subjectId),
+    };
+  });
+};
+
+const MULTIDISCIPLINARY_SUBJECT_ID = 'common_subject_60';
+const TOOLBOX_SUBJECT_ID = 'common_subject_61';
 
 const WelcomePage = ({ t, locale, history, location }) => {
   const headerLinks = [
@@ -66,10 +88,10 @@ const WelcomePage = ({ t, locale, history, location }) => {
         </OneColumn>
         <OneColumn wide>
           <FrontpageMultidisciplinarySubject
-            url={MULTIDISCIPLINARY_SUBJECT_PAGE_PATH}
-            topics={MULTIDISCIPLINARY_SUBJECTS}
+            url={getUrlFromSubjectId(MULTIDISCIPLINARY_SUBJECT_ID)}
+            topics={getMultidisciplinarySubjects(locale)}
           />
-          <FrontpageToolbox url={TOOLBOX_PAGE_PATH} />
+          <FrontpageToolbox url={getUrlFromSubjectId(TOOLBOX_SUBJECT_ID)} />
           <BlogPosts locale={locale} />
           <FrontpageFilm
             imageUrl="/static/film_illustrasjon.svg"

--- a/src/data/programmes.js
+++ b/src/data/programmes.js
@@ -2148,7 +2148,7 @@ export const programmes = [
             },
             subjects: [
               {
-                id: 'programme_subject_52',
+                id: 'programme_subject_62',
               },
               {
                 id: 'programme_subject_53',

--- a/src/data/subjects.js
+++ b/src/data/subjects.js
@@ -887,6 +887,43 @@ export const commonSubjects = [
     subjectId: 'urn:subject:d1fe9d0a-a54d-49db-a4c2-fd5463a7c9e7',
     id: 'common_subject_59',
   },
+  {
+    filters: [
+      'urn:filter:7ab1cc5c-4f79-4bb4-b1ab-bef7c41aed66',
+      'urn:filter:3645d7c4-63af-469a-a502-38e53d03d6c7',
+      'urn:filter:1e3b4fd0-3245-42b5-8685-db02c5592acc',
+    ],
+    longName: {
+      en: 'Tverrfaglige tema',
+      nb: 'Tverrfaglige tema',
+      nn: 'Tverrfaglege tema',
+    },
+    name: {
+      en: 'Tverrfaglige tema',
+      nb: 'Tverrfaglige tema',
+      nn: 'Tverrfaglege tema',
+    },
+    subjectId: 'urn:subject:d1fe9d0a-a54d-49db-a4c2-fd5463a7c9e7',
+    id: 'common_subject_60',
+  },
+  {
+    filters: [
+      'urn:filter:54b1727c-2d91-4512-901c-8434e13339b4',
+      'urn:filter:9bb7b427-3f5b-4c45-9719-efc509f3d9cc',
+    ],
+    longName: {
+      en: 'Verktøykassa',
+      nb: 'Verktøykassa',
+      nn: 'Verktøykassa',
+    },
+    name: {
+      en: 'Verktøykassa',
+      nb: 'Verktøykassa',
+      nn: 'Verktøykassa',
+    },
+    subjectId: 'urn:subject:ee3f7a15-feb6-4e78-8b37-65930ad73a09',
+    id: 'common_subject_61',
+  },
 ];
 export const programmeSubjects = [
   {
@@ -1588,22 +1625,29 @@ export const programmeSubjects = [
     id: 'programme_subject_51',
   },
   {
-    filters: [],
+    filters: [
+      'urn:filter:765ff687-efd9-4fd9-82e7-19ba59908d26',
+      'urn:filter:01c27030-e8f8-4a7c-a5b3-489fdb8fea30',
+    ],
     longName: {
-      en: 'Leting og boring (TP Vg2)',
-      nb: 'Leting og boring (TP Vg2)',
-      nn: 'Leiting og boring (TP Vg2)',
+      en: 'Brønnteknikk',
+      nb: 'Brønnteknikk',
+      nn: 'Brønnteknikk',
     },
     name: {
-      en: 'Leting og boring',
-      nb: 'Leting og boring',
-      nn: 'Leiting og boring',
+      en: 'Brønnteknikk',
+      nb: 'Brønnteknikk',
+      nn: 'Brønnteknikk',
     },
     subjectId: 'urn:subject:6',
     id: 'programme_subject_52',
+    hideOnFrontpage: true,
   },
   {
-    filters: [],
+    filters: [
+      'urn:filter:765ff687-efd9-4fd9-82e7-19ba59908d26',
+      'urn:filter:01c27030-e8f8-4a7c-a5b3-489fdb8fea30',
+    ],
     longName: {
       en: 'Komplettering, produksjon og brønnvedlikehold (TP Vg2)',
       nb: 'Komplettering, produksjon og brønnvedlikehold (TP Vg2)',
@@ -1618,7 +1662,10 @@ export const programmeSubjects = [
     id: 'programme_subject_53',
   },
   {
-    filters: [],
+    filters: [
+      'urn:filter:765ff687-efd9-4fd9-82e7-19ba59908d26',
+      'urn:filter:01c27030-e8f8-4a7c-a5b3-489fdb8fea30',
+    ],
     longName: {
       en: 'HMS og kvalitet (TP Vg2)',
       nb: 'HMS og kvalitet (TP Vg2)',
@@ -1736,6 +1783,24 @@ export const programmeSubjects = [
     subjectId: 'urn:subject:7',
     filters: [],
     id: 'programme_subject_61',
+  },
+  {
+    filters: [
+      'urn:filter:765ff687-efd9-4fd9-82e7-19ba59908d26',
+      'urn:filter:01c27030-e8f8-4a7c-a5b3-489fdb8fea30',
+    ],
+    longName: {
+      en: 'Leting og boring (TP Vg2)',
+      nb: 'Leting og boring (TP Vg2)',
+      nn: 'Leiting og boring (TP Vg2)',
+    },
+    name: {
+      en: 'Leting og boring',
+      nb: 'Leting og boring',
+      nn: 'Leiting og boring',
+    },
+    subjectId: 'urn:subject:6',
+    id: 'programme_subject_62',
   },
 ];
 export const studySpecializationSubjects = [


### PR DESCRIPTION
https://trello.com/c/2A8kKX4t/671-endre-lenker-til-nye-fagforsider

Dette er endringer på Brønnteknikk faga. Men ser at når man velger ett emne så feiler sida. F.eks på /nb/subjects/subject:6/topic:1:182061/?filters=urn:filter:765ff687-efd9-4fd9-82e7-19ba59908d26,urn:filter:01c27030-e8f8-4a7c-a5b3-489fdb8fea30

Kan du sjekke dette Gunnar? Ser ut til at det er Graphql-error

EDIT: Feiler vist berre lokalt mot prod-api. Snodigt