### PR TITLE
#2274: Don't crash when rendering under a different location

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -200,7 +200,8 @@ class App extends React.Component {
 
     // Dirty hack to allow for page to render on google translate
     const testLocation = serverLocation?.pathname + serverLocation?.search;
-    const isGoogleUrl = decodeURIComponent(location.search).indexOf(testLocation) > -1;
+    const isGoogleUrl =
+      decodeURIComponent(location.search).indexOf(testLocation) > -1;
 
     const switchLocation = isGoogleUrl ? serverLocation : location;
 
@@ -233,8 +234,14 @@ class App extends React.Component {
 
 App.propTypes = {
   locale: PropTypes.string.isRequired,
-  location: PropTypes.shape({ pathname: PropTypes.string.isRequired, search: PropTypes.string.isRequired }),
-  serverLocation: PropTypes.shape({ pathname: PropTypes.string.isRequired, search: PropTypes.string.isRequired }),
+  location: PropTypes.shape({
+    pathname: PropTypes.string.isRequired,
+    search: PropTypes.string.isRequired,
+  }),
+  serverLocation: PropTypes.shape({
+    pathname: PropTypes.string.isRequired,
+    search: PropTypes.string.isRequired,
+  }),
   initialProps: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
 };
 

--- a/src/App.js
+++ b/src/App.js
@@ -197,10 +197,12 @@ class App extends React.Component {
     if (this.state.hasError) {
       return <ErrorPage locale={this.props.locale} location={location} />;
     }
-    console.log("ServerLoc", serverLocation);
-    console.log("Loc", location);
 
-    const switchLocation = location; // TOOD:
+    // Dirty hack to allow for page to render on google translate
+    const testLocation = serverLocation?.pathname + serverLocation?.search;
+    const isGoogleUrl = decodeURIComponent(location.search).indexOf(testLocation) > -1;
+
+    const switchLocation = isGoogleUrl ? serverLocation : location;
 
     const isNdlaFilm = location.pathname.includes(FILM_PAGE_PATH);
     return (
@@ -231,8 +233,8 @@ class App extends React.Component {
 
 App.propTypes = {
   locale: PropTypes.string.isRequired,
-  location: PropTypes.shape({ pathname: PropTypes.string.isRequired }),
-  serverLocation: PropTypes.shape({ pathname: PropTypes.string.isRequired }),
+  location: PropTypes.shape({ pathname: PropTypes.string.isRequired, search: PropTypes.string.isRequired }),
+  serverLocation: PropTypes.shape({ pathname: PropTypes.string.isRequired, search: PropTypes.string.isRequired }),
   initialProps: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
 };
 

--- a/src/App.js
+++ b/src/App.js
@@ -99,7 +99,6 @@ async function loadInitialProps(pathname, ctx) {
 class App extends React.Component {
   constructor(props) {
     super(props);
-    console.log('App->props', props);
     this.location = null;
     this.state = {
       hasError: false,

--- a/src/App.js
+++ b/src/App.js
@@ -99,7 +99,7 @@ async function loadInitialProps(pathname, ctx) {
 class App extends React.Component {
   constructor(props) {
     super(props);
-    console.log("App->props", props);
+    console.log('App->props', props);
     this.location = null;
     this.state = {
       hasError: false,
@@ -200,7 +200,7 @@ class App extends React.Component {
     const isNdlaFilm = location.pathname.includes(FILM_PAGE_PATH);
     return (
       <BasenameContext.Provider value={basename}>
-        <Switch>
+        <Switch location={location}>
           {routes
             .filter(route => route !== undefined)
             .map(route => (

--- a/src/App.js
+++ b/src/App.js
@@ -98,6 +98,7 @@ async function loadInitialProps(pathname, ctx) {
 class App extends React.Component {
   constructor(props) {
     super(props);
+    console.log("App->props", props);
     this.location = null;
     this.state = {
       hasError: false,

--- a/src/App.js
+++ b/src/App.js
@@ -245,4 +245,4 @@ App.propTypes = {
   initialProps: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
 };
 
-export default App;
+export default withRouter(App);

--- a/src/App.js
+++ b/src/App.js
@@ -191,20 +191,26 @@ class App extends React.Component {
     const {
       initialProps: { basename },
       location,
+      serverLocation,
       locale,
     } = this.props;
     if (this.state.hasError) {
       return <ErrorPage locale={this.props.locale} location={location} />;
     }
+    console.log("ServerLoc", serverLocation);
+    console.log("Loc", location);
+
+    const switchLocation = location; // TOOD:
+
     const isNdlaFilm = location.pathname.includes(FILM_PAGE_PATH);
     return (
       <BasenameContext.Provider value={basename}>
-        <Switch location={location}>
+        <Switch location={switchLocation}>
           {routes
             .filter(route => route !== undefined)
             .map(route => (
               <Route
-                location={location}
+                location={switchLocation}
                 key={`route_${route.path}`}
                 exact={route.exact}
                 hideMasthead={route.hideMasthead}
@@ -226,6 +232,7 @@ class App extends React.Component {
 App.propTypes = {
   locale: PropTypes.string.isRequired,
   location: PropTypes.shape({ pathname: PropTypes.string.isRequired }),
+  serverLocation: PropTypes.shape({ pathname: PropTypes.string.isRequired }),
   initialProps: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
 };
 

--- a/src/App.js
+++ b/src/App.js
@@ -228,4 +228,4 @@ App.propTypes = {
   initialProps: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
 };
 
-export default withRouter(App);
+export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -41,6 +41,7 @@ const Route = ({
   ...rest
 }) => (
   <ReactRoute
+    location={location}
     {...rest}
     render={props => (
       <Page

--- a/src/client.jsx
+++ b/src/client.jsx
@@ -78,7 +78,11 @@ renderOrHydrate(
     <CacheProvider value={cache}>
       <IntlProvider locale={abbreviation} messages={messages}>
         <Router history={browserHistory}>
-          {routes({ ...initialProps, basename }, abbreviation, locationFromServer)}
+          {routes(
+            { ...initialProps, basename },
+            abbreviation,
+            locationFromServer,
+          )}
         </Router>
       </IntlProvider>
     </CacheProvider>

--- a/src/client.jsx
+++ b/src/client.jsx
@@ -17,6 +17,7 @@ import { configureTracker } from '@ndla/tracker';
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/core';
 
+import queryString from 'query-string';
 import { createHistory } from './history';
 import { getLocaleInfoFromPath, isValidLocale } from './i18n';
 import { createApolloClient } from './util/apiHelpers';
@@ -30,7 +31,7 @@ const { abbreviation, messages, basename } = getLocaleInfoFromPath(serverPath);
 
 const fakeLocation = {
   pathname: serverPath,
-  search: serverQuery,
+  search: `?${queryString.stringify(serverQuery)}`,
 };
 
 const storedLanguage = getCookie('language', document.cookie);

--- a/src/client.jsx
+++ b/src/client.jsx
@@ -24,11 +24,14 @@ import routes from './routes';
 import './style/index.css';
 
 const {
-  DATA: { initialProps, config },
+  DATA: { initialProps, config, serverPath, serverQuery },
 } = window;
-const { abbreviation, messages, basename } = getLocaleInfoFromPath(
-  window.location.pathname,
-);
+const { abbreviation, messages, basename } = getLocaleInfoFromPath(serverPath);
+
+const fakeLocation = {
+  pathname: serverPath,
+  search: serverQuery,
+};
 
 const storedLanguage = getCookie('language', document.cookie);
 if (
@@ -74,7 +77,7 @@ renderOrHydrate(
     <CacheProvider value={cache}>
       <IntlProvider locale={abbreviation} messages={messages}>
         <Router history={browserHistory}>
-          {routes({ ...initialProps, basename }, abbreviation)}
+          {routes({ ...initialProps, basename }, abbreviation, fakeLocation)}
         </Router>
       </IntlProvider>
     </CacheProvider>

--- a/src/client.jsx
+++ b/src/client.jsx
@@ -29,7 +29,7 @@ const {
 } = window;
 const { abbreviation, messages, basename } = getLocaleInfoFromPath(serverPath);
 
-const fakeLocation = {
+const locationFromServer = {
   pathname: serverPath,
   search: `?${queryString.stringify(serverQuery)}`,
 };
@@ -78,7 +78,7 @@ renderOrHydrate(
     <CacheProvider value={cache}>
       <IntlProvider locale={abbreviation} messages={messages}>
         <Router history={browserHistory}>
-          {routes({ ...initialProps, basename }, abbreviation, fakeLocation)}
+          {routes({ ...initialProps, basename }, abbreviation, locationFromServer)}
         </Router>
       </IntlProvider>
     </CacheProvider>

--- a/src/client.jsx
+++ b/src/client.jsx
@@ -31,7 +31,7 @@ const { abbreviation, messages, basename } = getLocaleInfoFromPath(serverPath);
 
 const locationFromServer = {
   pathname: serverPath,
-  search: `?${queryString.stringify(serverQuery)}`,
+  search: `?${decodeURIComponent(queryString.stringify(serverQuery))}`,
 };
 
 const storedLanguage = getCookie('language', document.cookie);

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -113,12 +113,12 @@ export const routes = [
 
 export default function(initialProps = {}, locale, location) {
   if (location) {
-    console.log("loc", location);
+    console.log('loc', location);
     return (
       <App initialProps={initialProps} locale={locale} location={location} />
     );
   }
-  console.log("fails?")
+  console.log('fails?');
   const AppWithRouter = withRouter(App);
   return <AppWithRouter initialProps={initialProps} locale={locale} />;
 }

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -7,6 +7,7 @@
  */
 
 import React from 'react';
+import { withRouter } from 'react-router-dom';
 import WelcomePage from './containers/WelcomePage/WelcomePage';
 import FFFrontPage from './containers/FFFrontPage/FFFrontPage';
 import PlainArticlePage from './containers/PlainArticlePage/PlainArticlePage';
@@ -110,6 +111,12 @@ export const routes = [
   },
 ];
 
-export default function(initialProps = {}, locale) {
-  return <App initialProps={initialProps} locale={locale} />;
+export default function(initialProps = {}, locale, location) {
+  if (location) {
+    return (
+      <App initialProps={initialProps} locale={locale} location={location} />
+    );
+  }
+  const AppWithRouter = withRouter(App);
+  return <AppWithRouter initialProps={initialProps} locale={locale} />;
 }

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -113,5 +113,11 @@ export const routes = [
 
 export default function(initialProps = {}, locale, location) {
   const AppWithRouter = withRouter(App);
-  return <AppWithRouter initialProps={initialProps} locale={locale} serverLocation={location} />;
+  return (
+    <AppWithRouter
+      initialProps={initialProps}
+      locale={locale}
+      serverLocation={location}
+    />
+  );
 }

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -113,10 +113,12 @@ export const routes = [
 
 export default function(initialProps = {}, locale, location) {
   if (location) {
+    console.log("loc", location);
     return (
       <App initialProps={initialProps} locale={locale} location={location} />
     );
   }
+  console.log("fails?")
   const AppWithRouter = withRouter(App);
   return <AppWithRouter initialProps={initialProps} locale={locale} />;
 }

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -113,12 +113,10 @@ export const routes = [
 
 export default function(initialProps = {}, locale, location) {
   if (location) {
-    console.log('loc', location);
     return (
       <App initialProps={initialProps} locale={locale} location={location} />
     );
   }
-  console.log('fails?');
   const AppWithRouter = withRouter(App);
   return <AppWithRouter initialProps={initialProps} locale={locale} />;
 }

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -7,7 +7,6 @@
  */
 
 import React from 'react';
-import { withRouter } from 'react-router-dom';
 import WelcomePage from './containers/WelcomePage/WelcomePage';
 import FFFrontPage from './containers/FFFrontPage/FFFrontPage';
 import PlainArticlePage from './containers/PlainArticlePage/PlainArticlePage';
@@ -111,13 +110,12 @@ export const routes = [
   },
 ];
 
-export default function(initialProps = {}, locale, location) {
-  const AppWithRouter = withRouter(App);
+export default function(initialProps = {}, locale, serverLocation) {
   return (
-    <AppWithRouter
+    <App
       initialProps={initialProps}
       locale={locale}
-      serverLocation={location}
+      serverLocation={serverLocation}
     />
   );
 }

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -112,11 +112,6 @@ export const routes = [
 ];
 
 export default function(initialProps = {}, locale, location) {
-  if (location) {
-    return (
-      <App initialProps={initialProps} locale={locale} location={location} />
-    );
-  }
   const AppWithRouter = withRouter(App);
-  return <AppWithRouter initialProps={initialProps} locale={locale} />;
+  return <AppWithRouter initialProps={initialProps} locale={locale} serverLocation={location} />;
 }

--- a/src/server/routes/defaultRoute.js
+++ b/src/server/routes/defaultRoute.js
@@ -107,6 +107,8 @@ async function doRender(req) {
     {
       initialProps,
       apolloState,
+      serverPath: req.path,
+      serverQuery: req.query,
     },
     cache,
   );


### PR DESCRIPTION
Fixes NDLANO/Issues#2274

Om noen har noe bedre forslag til hvordan vi kan løse dette så er jeg _veldig_ åpen for det :smile: 
Problemet er at google re-hoster siden vår når vi og da får vi en path som ser ish sånn ut `/translate_c`.
Det gjør at react-router prøver å vise den siden (og vi har jo ikke den siden så da ender vi med en 404).

Løser det med å bruke serveren sin path+query når vi er på google-translate (Og kanskje andre sider).
- Serveren sender med requesten sin path + query
- Klienten sjekker om server requesten finnes i queryen fra `withRouter` (I praksis det samme som `window.location`)
- Dersom den gjør det så bruker vi bare "location" objektet fra serveren.


