### PR TITLE
Update robots.txt

### DIFF
--- a/src/server/robots.txt
+++ b/src/server/robots.txt
@@ -93,6 +93,7 @@ Disallow: /health/
 Disallow: /oembed/
 Disallow: /article-iframe/
 Disallow: /lti/
+Disallow: /*/article/
 
 Allow: /sites/default/files/*.pdf
 Allow: /sites/default/files/images/*

--- a/src/server/robots.txt
+++ b/src/server/robots.txt
@@ -94,6 +94,7 @@ Disallow: /oembed/
 Disallow: /article-iframe/
 Disallow: /lti/
 Disallow: /*/article/
+Disallow: /article/
 
 Allow: /sites/default/files/*.pdf
 Allow: /sites/default/files/images/*


### PR DESCRIPTION
Google indekserer artiklar utan taksonomi på ndla.no/*/article
Me vil heller vise dei med taksonomi.