### PR TITLE
#2274: Make site work under google translate with language paths and without queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "react": "^16.9.0",
     "react-bem-helper": "^1.4.1",
     "react-dom": "^16.9.0",
-    "react-helmet": "^5.2.1",
+    "react-helmet": "^6.1.0",
     "react-is": "^16.9.0",
     "react-prop-types": "^0.4.0",
     "react-router": "^5.1.2",

--- a/src/App.js
+++ b/src/App.js
@@ -208,29 +208,20 @@ class App extends React.Component {
     const {
       initialProps: { basename },
       location,
-      serverLocation,
       locale,
     } = this.props;
     if (this.state.hasError) {
       return <ErrorPage locale={this.props.locale} location={location} />;
     }
 
-    // Dirty hack to allow for page to render on google translate
-    const testLocation = serverLocation?.pathname + serverLocation?.search;
-    const isGoogleUrl =
-      decodeURIComponent(location.search).indexOf(testLocation) > -1;
-
-    const switchLocation = isGoogleUrl ? serverLocation : location;
-
     const isNdlaFilm = location.pathname.includes(FILM_PAGE_PATH);
     return (
       <BasenameContext.Provider value={basename}>
-        <Switch location={switchLocation}>
+        <Switch>
           {routes
             .filter(route => route !== undefined)
             .map(route => (
               <Route
-                location={switchLocation}
                 key={`route_${route.path}`}
                 exact={route.exact}
                 hideMasthead={route.hideMasthead}
@@ -252,10 +243,6 @@ class App extends React.Component {
 App.propTypes = {
   locale: PropTypes.string.isRequired,
   location: PropTypes.shape({
-    pathname: PropTypes.string.isRequired,
-    search: PropTypes.string.isRequired,
-  }),
-  serverLocation: PropTypes.shape({
     pathname: PropTypes.string.isRequired,
     search: PropTypes.string.isRequired,
   }),

--- a/src/client.jsx
+++ b/src/client.jsx
@@ -27,11 +27,16 @@ import './style/index.css';
 const {
   DATA: { initialProps, config, serverPath, serverQuery },
 } = window;
-const { abbreviation, messages, basename } = getLocaleInfoFromPath(serverPath);
+const { abbreviation, messages, basename, basepath } = getLocaleInfoFromPath(
+  serverPath,
+);
 
+const serverQueryString = decodeURIComponent(
+  queryString.stringify(serverQuery),
+);
 const locationFromServer = {
-  pathname: serverPath,
-  search: `?${decodeURIComponent(queryString.stringify(serverQuery))}`,
+  pathname: basepath || '/',
+  search: serverQueryString ? `?${serverQueryString}` : '',
 };
 
 const storedLanguage = getCookie('language', document.cookie);

--- a/src/components/Learningpath/LearningpathEmbed.jsx
+++ b/src/components/Learningpath/LearningpathEmbed.jsx
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 import { spacing } from '@ndla/core';
 import styled from '@emotion/styled';
 import Article from '../Article';

--- a/src/components/SocialMediaMetadata.jsx
+++ b/src/components/SocialMediaMetadata.jsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import { BasenameContext } from '../App';

--- a/src/containers/ArticlePage/ArticlePage.jsx
+++ b/src/containers/ArticlePage/ArticlePage.jsx
@@ -9,7 +9,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 import { OneColumn, LayoutItem } from '@ndla/ui';
 import { injectT } from '@ndla/i18n';
 import { withTracker } from '@ndla/tracker';

--- a/src/containers/FilmFrontpage/FilmFrontpage.jsx
+++ b/src/containers/FilmFrontpage/FilmFrontpage.jsx
@@ -8,7 +8,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 import { css } from '@emotion/core';
 import { spacing } from '@ndla/core';
 import {

--- a/src/containers/LearningpathPage/LearningpathPage.jsx
+++ b/src/containers/LearningpathPage/LearningpathPage.jsx
@@ -9,7 +9,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 import { injectT } from '@ndla/i18n';
 import { withTracker } from '@ndla/tracker';
 import { getArticleProps } from '../../util/getArticleProps';

--- a/src/containers/Page/Page.jsx
+++ b/src/containers/Page/Page.jsx
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 import { PageContainer } from '@ndla/ui';
 import { injectT } from '@ndla/i18n';
 import ZendeskButton from '@ndla/zendesk';

--- a/src/containers/PlainArticlePage/PlainArticlePage.jsx
+++ b/src/containers/PlainArticlePage/PlainArticlePage.jsx
@@ -9,7 +9,7 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 import { OneColumn } from '@ndla/ui';
 import { injectT } from '@ndla/i18n';
 import { withTracker } from '@ndla/tracker';

--- a/src/containers/PlainLearningpathPage/PlainLearningpathPage.jsx
+++ b/src/containers/PlainLearningpathPage/PlainLearningpathPage.jsx
@@ -8,7 +8,7 @@
 
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 import { injectT } from '@ndla/i18n';
 import { withTracker } from '@ndla/tracker';
 

--- a/src/containers/ProgrammePage/ProgrammePage.jsx
+++ b/src/containers/ProgrammePage/ProgrammePage.jsx
@@ -10,7 +10,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { injectT } from '@ndla/i18n';
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 import { withTracker } from '@ndla/tracker';
 
 import { Programme } from '@ndla/ui';

--- a/src/containers/SubjectPage/SubjectContainer.jsx
+++ b/src/containers/SubjectPage/SubjectContainer.jsx
@@ -8,7 +8,7 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 import {
   OneColumn,
   NavigationHeading,

--- a/src/containers/TopicPage/TopicContainer.jsx
+++ b/src/containers/TopicPage/TopicContainer.jsx
@@ -16,7 +16,7 @@ import {
   constants,
   NdlaFilmHero,
 } from '@ndla/ui';
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 import { injectT } from '@ndla/i18n';
 import { withTracker } from '@ndla/tracker';
 

--- a/src/iframe/FixDialogPosition.js
+++ b/src/iframe/FixDialogPosition.js
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 import {
   forEachElement,
   findAncestorByClass,

--- a/src/iframe/IframeArticlePage.js
+++ b/src/iframe/IframeArticlePage.js
@@ -8,7 +8,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 
 import { OneColumn, CreatedBy } from '@ndla/ui';
 import { withTracker } from '@ndla/tracker';

--- a/src/iframe/IframePageWrapper.jsx
+++ b/src/iframe/IframePageWrapper.jsx
@@ -9,7 +9,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 import { PageContainer } from '@ndla/ui';
 import IntlProvider from '@ndla/i18n';
 import { ApolloProvider } from '@apollo/react-hooks';

--- a/src/iframe/IframeTopicPage.jsx
+++ b/src/iframe/IframeTopicPage.jsx
@@ -8,7 +8,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 import { injectT } from '@ndla/i18n';
 import { withTracker } from '@ndla/tracker';
 import { OneColumn, CreatedBy, constants } from '@ndla/ui';

--- a/src/lti/LtiProvider.jsx
+++ b/src/lti/LtiProvider.jsx
@@ -8,7 +8,7 @@
 
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 import { injectT } from '@ndla/i18n';
 
 import { ResourceShape } from '../shapes';

--- a/src/server/helpers/__tests__/Document-test.js
+++ b/src/server/helpers/__tests__/Document-test.js
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import renderer from 'react-test-renderer';
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 import { PageContainer } from '@ndla/ui';
 import Document from '../Document';
 

--- a/src/server/helpers/render.js
+++ b/src/server/helpers/render.js
@@ -12,7 +12,7 @@ import { renderToStringWithData } from '@apollo/react-ssr';
 import defined from 'defined';
 import { resetIdCounter } from '@ndla/tabs';
 import { OK, MOVED_PERMANENTLY } from 'http-status';
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 import createEmotionServer from 'create-emotion-server';
 
 import Document from './Document';

--- a/src/server/routes/iframeArticleRoute.js
+++ b/src/server/routes/iframeArticleRoute.js
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import defined from 'defined';
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 import { INTERNAL_SERVER_ERROR, OK } from 'http-status';
 
 import { getHtmlLang, getLocaleObject } from '../../i18n';

--- a/src/server/routes/ltiRoute.js
+++ b/src/server/routes/ltiRoute.js
@@ -7,7 +7,7 @@
  */
 
 import defined from 'defined';
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 import { BAD_REQUEST, OK } from 'http-status';
 import { getHtmlLang, getLocaleObject } from '../../i18n';
 import { renderPage, renderHtml } from '../helpers/render';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3259,14 +3259,14 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001036:
-  version "1.0.30001036"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001036.tgz#930ea5272010d8bf190d859159d757c0b398caf0"
-  integrity sha512-jU8CIFIj2oR7r4W+5AKcsvWNVIb6Q6OZE3UsrXrZBHFtreT4YgTeOJtTucp+zSedEpTi3L5wASSP0LYIE3if6w==
+  version "1.0.30001150"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001150.tgz"
+  integrity sha512-kiNKvihW0m36UhAFnl7bOAv0i1K1f6wpfVtTF5O5O82XzgtBnb05V0XeV3oZ968vfg2sRNChsHw8ASH2hDfoYQ==
 
 caniuse-lite@^1.0.30001043:
-  version "1.0.30001055"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001055.tgz#7b52c3537f7a8c0408aca867e83d2b04268b54cd"
-  integrity sha512-MbwsBmKrBSKIWldfdIagO5OJWZclpJtS4h0Jrk/4HFrXJxTdVdH23Fd+xCiHriVGvYcWyW8mR/CPsYajlH8Iuw==
+  version "1.0.30001150"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001150.tgz"
+  integrity sha512-kiNKvihW0m36UhAFnl7bOAv0i1K1f6wpfVtTF5O5O82XzgtBnb05V0XeV3oZ968vfg2sRNChsHw8ASH2hDfoYQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -10360,7 +10360,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.4"
 
-prop-types@^15.5.0, prop-types@^15.5.4, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.0, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -10705,10 +10705,10 @@ react-facebook@^6.0.15:
     can-use-dom "^0.1.0"
     react-spinner-children "^1.0.8"
 
-react-fast-compare@^2.0.2:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
-  integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
+react-fast-compare@^3.1.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
+  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
 react-focus-lock@^1.17.7:
   version "1.19.1"
@@ -10720,15 +10720,15 @@ react-focus-lock@^1.17.7:
     prop-types "^15.6.2"
     react-clientside-effect "^1.2.0"
 
-react-helmet@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-5.2.1.tgz#16a7192fdd09951f8e0fe22ffccbf9bb3e591ffa"
-  integrity sha512-CnwD822LU8NDBnjCpZ4ySh8L6HYyngViTZLfBBb3NjtrpN8m49clH8hidHouq20I51Y6TpCTISCBbqiY5GamwA==
+react-helmet@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-6.1.0.tgz#a750d5165cb13cf213e44747502652e794468726"
+  integrity sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==
   dependencies:
     object-assign "^4.1.1"
-    prop-types "^15.5.4"
-    react-fast-compare "^2.0.2"
-    react-side-effect "^1.1.0"
+    prop-types "^15.7.2"
+    react-fast-compare "^3.1.1"
+    react-side-effect "^2.1.0"
 
 react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
   version "16.13.1"
@@ -10797,12 +10797,10 @@ react-router@5.1.2, react-router@^5.1.2:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-side-effect@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-1.2.0.tgz#0e940c78faba0c73b9b0eba9cd3dda8dfb7e7dae"
-  integrity sha512-v1ht1aHg5k/thv56DRcjw+WtojuuDHFUgGfc+bFHOWsF4ZK6C2V57DO0Or0GPsg6+LSTE0M6Ry/gfzhzSwbc5w==
-  dependencies:
-    shallowequal "^1.0.1"
+react-side-effect@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.0.tgz#1ce4a8b4445168c487ed24dab886421f74d380d3"
+  integrity sha512-IgmcegOSi5SNX+2Snh1vqmF0Vg/CbkycU9XZbOHJlZ6kMzTmi3yc254oB1WCkgA7OQtIAoLmcSFuHTc/tlcqXg==
 
 react-spinner-children@^1.0.8:
   version "1.0.8"
@@ -11679,11 +11677,6 @@ shallow-clone@^3.0.0:
   integrity sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==
   dependencies:
     kind-of "^6.0.2"
-
-shallowequal@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
-  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Fixes NDLANO/Issues#2274

Fikser så både adresser uten queries / `?` og adresser med språkkode funker i google translate.

~Navigering på forsiden og sånn blir blokkert av translate siden det er javascript som manipulerer på url'en (tror jeg).
Mulig vi kan hacke oss rundt det med å bruke en [annen router](https://reactrouter.com/web/api/MemoryRouter)? Men vet ikke hvor mye tid vi har lyst til å bruke på det.~

Stryk det, testa med `MemoryRouter` under google translate og det fungerer _bedre_, men ikke perfekt.
Funker ikke når vi gjør graphql-queries client side på fagsidene for eksempel, men tror siden er _relativt_ brukbar nå.

