### PR TITLE
Breadcrumb metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@ndla/safelink": "^0.0.7",
     "@ndla/tabs": "^0.11.39",
     "@ndla/tracker": "^0.4.3",
-    "@ndla/ui": "^0.29.0",
+    "@ndla/ui": "^0.29.3",
     "@ndla/util": "^0.4.4",
     "@ndla/zendesk": "^0.2.32",
     "apollo-cache-inmemory": "^1.6.3",

--- a/src/components/Learningpath/Learningpath.jsx
+++ b/src/components/Learningpath/Learningpath.jsx
@@ -21,16 +21,17 @@ import {
 } from '@ndla/ui';
 import { getCookie, setCookie } from '@ndla/util';
 import { withRouter } from 'react-router-dom';
-import { toLearningPath, toBreadcrumbItems } from '../../routeHelpers';
+import { toLearningPath } from '../../routeHelpers';
 import { getFiltersFromUrl } from '../../util/filterHelper';
 import LastLearningpathStepInfo from './LastLearningpathStepInfo';
 import {
-  TopicShape,
-  SubjectShape,
+  BreadCrumbShape,
   LearningpathShape,
-  ResourceTypeShape,
-  ResourceShape,
   LearningpathStepShape,
+  ResourceShape,
+  ResourceTypeShape,
+  SubjectShape,
+  TopicShape,
 } from '../../shapes';
 import LearningpathEmbed from './LearningpathEmbed';
 import config from '../../config';
@@ -51,6 +52,7 @@ const Learningpath = ({
   history,
   onKeyUpEvent,
   ndlaFilm,
+  breadcrumbItems,
   t,
 }) => {
   const {
@@ -101,25 +103,7 @@ const Learningpath = ({
     <LearningPathWrapper>
       <div className="c-hero__content">
         <section>
-          {subject && topicPath ? (
-            <Breadcrumb
-              invertedStyle={ndlaFilm}
-              items={toBreadcrumbItems(
-                t('breadcrumb.toFrontpage'),
-                [subject, ...topicPath, { name: learningpath.title, url: '' }],
-                filterIds,
-              )}
-            />
-          ) : (
-            <Breadcrumb
-              invertedStyle={ndlaFilm}
-              items={toBreadcrumbItems(
-                t('breadcrumb.toFrontpage'),
-                [{ name: learningpath.title, url: '' }],
-                filterIds,
-              )}
-            />
-          )}
+          <Breadcrumb invertedStyle={ndlaFilm} items={breadcrumbItems} />
         </section>
       </div>
       <LearningPathContent>
@@ -154,6 +138,7 @@ const Learningpath = ({
               locale={locale}
               topic={topic}
               learningpathStep={learningpathStep}
+              breadcrumbItems={breadcrumbItems}
             />
             <LastLearningpathStepInfo
               topic={topic}
@@ -221,6 +206,7 @@ Learningpath.propTypes = {
     push: PropTypes.func.isRequired,
   }).isRequired,
   onKeyUpEvent: func.isRequired,
+  breadcrumbItems: PropTypes.arrayOf(BreadCrumbShape),
 };
 
 export default injectT(withRouter(Learningpath));

--- a/src/components/Learningpath/LearningpathEmbed.jsx
+++ b/src/components/Learningpath/LearningpathEmbed.jsx
@@ -18,7 +18,7 @@ import { transformArticle } from '../../util/transformArticle';
 import { getArticleScripts } from '../../util/getArticleScripts';
 import getStructuredDataFromArticle from '../../util/getStructuredDataFromArticle';
 import { getArticleProps } from '../../util/getArticleProps';
-import { TopicShape } from '../../shapes';
+import { BreadCrumbShape, TopicShape } from '../../shapes';
 
 const StyledIframeContainer = styled.div`
   margin-bottom: ${spacing.normal};
@@ -36,6 +36,7 @@ const LearningpathEmbed = ({
   skipToContentId,
   locale,
   topic,
+  breadcrumbItems,
 }) => {
   if (
     !learningpathStep ||
@@ -80,7 +81,9 @@ const LearningpathEmbed = ({
         ))}
 
         <script type="application/ld+json">
-          {JSON.stringify(getStructuredDataFromArticle(article))}
+          {JSON.stringify(
+            getStructuredDataFromArticle(article, breadcrumbItems),
+          )}
         </script>
       </Helmet>
       <Article
@@ -98,5 +101,6 @@ LearningpathEmbed.propTypes = {
   topic: TopicShape,
   skipToContentId: PropTypes.string,
   locale: PropTypes.string.isRequired,
+  breadcrumbItems: BreadCrumbShape,
 };
 export default LearningpathEmbed;

--- a/src/containers/ArticlePage/ArticlePage.jsx
+++ b/src/containers/ArticlePage/ArticlePage.jsx
@@ -25,7 +25,7 @@ import ArticleHero from './components/ArticleHero';
 import ArticleErrorMessage from './components/ArticleErrorMessage';
 import { getContentType } from '../../util/getContentType';
 import { getArticleScripts } from '../../util/getArticleScripts';
-import getStructuredDataFromArticle from '../../util/getStructuredDataFromArticle';
+import getStructuredData from '../../util/getStructuredDataFromArticle';
 import { getArticleProps } from '../../util/getArticleProps';
 import { getAllDimensions } from '../../util/trackingUtil';
 import { transformArticle } from '../../util/transformArticle';
@@ -143,7 +143,7 @@ class ArticlePage extends Component {
     }/${resource.id.replace('urn:', '')}${filterParam}`;
 
     const breadcrumbItems = toBreadcrumbItems(
-      'NDLA',
+      t('breadcrumb.toFrontpage'),
       [subject, ...topicPath, resource],
       getFiltersFromUrl(location),
       locale,
@@ -177,7 +177,7 @@ class ArticlePage extends Component {
           ))}
 
           <script type="application/ld+json">
-            {JSON.stringify(getStructuredDataFromArticle(article, breadcrumbItems))}
+            {JSON.stringify(getStructuredData(article, breadcrumbItems))}
           </script>
         </Helmet>
         <SocialMediaMetadata

--- a/src/containers/ArticlePage/ArticlePage.jsx
+++ b/src/containers/ArticlePage/ArticlePage.jsx
@@ -36,7 +36,7 @@ import {
 } from '../Resources/resourceHelpers';
 import { RedirectExternal, Status } from '../../components';
 import SocialMediaMetadata from '../../components/SocialMediaMetadata';
-import { toSubjects } from '../../routeHelpers';
+import { toBreadcrumbItems, toSubjects } from '../../routeHelpers';
 import {
   getFiltersFromUrl,
   getLongNameFromFilters,
@@ -95,7 +95,15 @@ class ArticlePage extends Component {
   }
 
   render() {
-    const { data, locale, errors, skipToContentId, ndlaFilm } = this.props;
+    const {
+      data,
+      locale,
+      location,
+      errors,
+      skipToContentId,
+      ndlaFilm,
+      t,
+    } = this.props;
     const { resource, topic, resourceTypes, subject, topicPath } = data;
     const { scripts, subjectPageUrl, filterIds } = this.state;
     if (isLearningPathResource(resource)) {
@@ -134,6 +142,13 @@ class ArticlePage extends Component {
       topic.path
     }/${resource.id.replace('urn:', '')}${filterParam}`;
 
+    const breadcrumbItems = toBreadcrumbItems(
+      'NDLA',
+      [subject, ...topicPath, resource],
+      getFiltersFromUrl(location),
+      locale,
+    );
+
     return (
       <div>
         <ArticleHero
@@ -144,6 +159,7 @@ class ArticlePage extends Component {
           resourceType={resourceType}
           locale={locale}
           metaImage={article.metaImage}
+          breadcrumbItems={breadcrumbItems}
         />
         <Helmet>
           <title>{`${this.constructor.getDocumentTitle(this.props)}`}</title>
@@ -161,7 +177,7 @@ class ArticlePage extends Component {
           ))}
 
           <script type="application/ld+json">
-            {JSON.stringify(getStructuredDataFromArticle(article))}
+            {JSON.stringify(getStructuredDataFromArticle(article, breadcrumbItems))}
           </script>
         </Helmet>
         <SocialMediaMetadata

--- a/src/containers/ArticlePage/ArticlePage.jsx
+++ b/src/containers/ArticlePage/ArticlePage.jsx
@@ -25,7 +25,7 @@ import ArticleHero from './components/ArticleHero';
 import ArticleErrorMessage from './components/ArticleErrorMessage';
 import { getContentType } from '../../util/getContentType';
 import { getArticleScripts } from '../../util/getArticleScripts';
-import getStructuredData from '../../util/getStructuredDataFromArticle';
+import getStructuredDataFromArticle from '../../util/getStructuredDataFromArticle';
 import { getArticleProps } from '../../util/getArticleProps';
 import { getAllDimensions } from '../../util/trackingUtil';
 import { transformArticle } from '../../util/transformArticle';
@@ -177,7 +177,7 @@ class ArticlePage extends Component {
           ))}
 
           <script type="application/ld+json">
-            {JSON.stringify(getStructuredData(article, breadcrumbItems))}
+            {JSON.stringify(getStructuredDataFromArticle(article, breadcrumbItems))}
           </script>
         </Helmet>
         <SocialMediaMetadata

--- a/src/containers/ArticlePage/components/ArticleHero.jsx
+++ b/src/containers/ArticlePage/components/ArticleHero.jsx
@@ -11,14 +11,12 @@ import PropTypes from 'prop-types';
 import { injectT } from '@ndla/i18n';
 import { Hero, OneColumn, Breadcrumb, NdlaFilmHero } from '@ndla/ui';
 import { withRouter } from 'react-router-dom';
-import { toBreadcrumbItems } from '../../../routeHelpers';
 import {
   ResourceShape,
   SubjectShape,
   TopicShape,
   LocationShape,
 } from '../../../shapes';
-import { getFiltersFromUrl } from '../../../util/filterHelper';
 
 const WrapperComponent = ({ children, resourceType, ndlaFilm, metaImage }) => {
   if (ndlaFilm) {
@@ -49,6 +47,7 @@ const ArticleHero = ({
   topicPath,
   location,
   locale,
+  breadcrumbItems,
   t,
 }) => (
   <WrapperComponent
@@ -62,18 +61,7 @@ const ArticleHero = ({
     )}
     <OneColumn>
       <div className="c-hero__content">
-        <section>
-          {subject && (
-            <Breadcrumb
-              items={toBreadcrumbItems(
-                t('breadcrumb.toFrontpage'),
-                [subject, ...topicPath, resource],
-                getFiltersFromUrl(location),
-                locale,
-              )}
-            />
-          )}
-        </section>
+        <section>{subject && <Breadcrumb items={breadcrumbItems} />}</section>
       </div>
     </OneColumn>
   </WrapperComponent>
@@ -90,6 +78,7 @@ ArticleHero.propTypes = {
     url: PropTypes.string,
     alt: PropTypes.string,
   }),
+  breadcrumbItems: PropTypes.arrayOf(PropTypes.object),
   ndlaFilm: PropTypes.bool,
 };
 export default withRouter(injectT(ArticleHero));

--- a/src/containers/ArticlePage/components/ArticleHero.jsx
+++ b/src/containers/ArticlePage/components/ArticleHero.jsx
@@ -12,10 +12,11 @@ import { injectT } from '@ndla/i18n';
 import { Hero, OneColumn, Breadcrumb, NdlaFilmHero } from '@ndla/ui';
 import { withRouter } from 'react-router-dom';
 import {
+  BreadCrumbShape,
+  LocationShape,
   ResourceShape,
   SubjectShape,
   TopicShape,
-  LocationShape,
 } from '../../../shapes';
 
 const WrapperComponent = ({ children, resourceType, ndlaFilm, metaImage }) => {
@@ -78,7 +79,7 @@ ArticleHero.propTypes = {
     url: PropTypes.string,
     alt: PropTypes.string,
   }),
-  breadcrumbItems: PropTypes.arrayOf(PropTypes.object),
+  breadcrumbItems: PropTypes.arrayOf(BreadCrumbShape),
   ndlaFilm: PropTypes.bool,
 };
 export default withRouter(injectT(ArticleHero));

--- a/src/containers/LearningpathPage/LearningpathPage.jsx
+++ b/src/containers/LearningpathPage/LearningpathPage.jsx
@@ -27,7 +27,7 @@ import {
   GraphQLTopicShape,
   GraphQLSubjectShape,
 } from '../../graphqlShapes';
-import { toLearningPath } from '../../routeHelpers';
+import { toBreadcrumbItems, toLearningPath } from '../../routeHelpers';
 import { LocationShape } from '../../shapes';
 
 class LearningpathPage extends Component {
@@ -122,9 +122,11 @@ class LearningpathPage extends Component {
       locale,
       skipToContentId,
       ndlaFilm,
+      location,
       match: {
         params: { stepId },
       },
+      t,
     } = this.props;
 
     if (
@@ -139,6 +141,7 @@ class LearningpathPage extends Component {
     }
     const { resource, topic, resourceTypes, subject, topicPath } = data;
     const { learningpath } = resource;
+    const filterIds = getFiltersFromUrl(location);
 
     const learningpathStep = stepId
       ? learningpath.learningsteps.find(
@@ -149,6 +152,19 @@ class LearningpathPage extends Component {
     if (!learningpathStep) {
       return null;
     }
+
+    const breadcrumbItems =
+      subject && topicPath
+        ? toBreadcrumbItems(
+            t('breadcrumb.toFrontpage'),
+            [subject, ...topicPath, { name: learningpath.title, url: '' }],
+            filterIds,
+          )
+        : toBreadcrumbItems(
+            t('breadcrumb.toFrontpage'),
+            [{ name: learningpath.title, url: '' }],
+            filterIds,
+          );
 
     return (
       <div>
@@ -178,6 +194,7 @@ class LearningpathPage extends Component {
           topicPath={topicPath}
           locale={locale}
           ndlaFilm={ndlaFilm}
+          breadcrumbItems={breadcrumbItems}
           {...getArticleProps()}
         />
       </div>

--- a/src/shapes.js
+++ b/src/shapes.js
@@ -214,11 +214,8 @@ export const H5pShape = PropTypes.shape({
 });
 
 export const BreadCrumbShape = PropTypes.shape({
-  id: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
-  url: PropTypes.string.isRequired,
-  typename: PropTypes.string,
-  isCurrent: PropTypes.bool,
+  name: PropTypes.string.isRequired,
+  to: PropTypes.string.isRequired,
 });
 
 export const ConceptLicenseShape = PropTypes.shape({

--- a/src/util/__tests__/getStructuredDataFromArticle-test.js
+++ b/src/util/__tests__/getStructuredDataFromArticle-test.js
@@ -57,7 +57,7 @@ test('util/getStructuredDataFromArticle article with copyright should return str
     article.copyright.rightsholders[0].name,
   );
   expect(structuredData[0].copyrightHolder['@type']).toBe('Organization');
-  expect(structuredData[0]['@type']).toBe('CreativeWork');
+  expect(structuredData[0]['@type']).toBe('Article');
   expect(structuredData[0].name).toBe(article.title);
 });
 
@@ -95,4 +95,21 @@ test('util/getStructuredDataFromArticle article with video should return video s
   expect(structuredData[1].name).toBe(article.metaData.brightcoves[0].title);
   expect(structuredData[1].embedUrl).toBe(article.metaData.brightcoves[0].src);
   expect(structuredData[1]['@type']).toBe('VideoObject');
+});
+
+test('util/getStructuredDataFromArticle article with breadcrumbs should return breadcrumbitems', () => {
+  const article = getBaseArticle();
+  const breadcrumbItems = [
+    {
+      to: '/',
+      name: 'NDLA',
+    }, {
+      to: '/subjects/subject:1/',
+      name: 'MEDIEUTTRYKK OG MEDIESAMFUNNET',
+    }
+  ];
+  const structuredData = getStructuredDataFromArticle(article, breadcrumbItems);
+  expect(structuredData.length).toBe(2);
+  expect(structuredData[1]['@type']).toBe('BreadcrumbList');
+  expect(structuredData[1].numberOfItems).toBe(2);
 });

--- a/src/util/getStructuredDataFromArticle.js
+++ b/src/util/getStructuredDataFromArticle.js
@@ -93,7 +93,10 @@ const getStructuredDataFromArticle = (article, breadcrumbItems) => {
   let articleData = getStructuredDataBase();
   articleData['@type'] = CREATIVE_WORK_TYPE;
   articleData.name = article.title;
-
+  articleData.headline = article.title;
+  articleData.datePublished = format(article.published, 'YYYY-MM-DD');
+  articleData.dateModified = format(article.updated, 'YYYY-MM-DD');
+  
   articleData = {
     ...articleData,
     ...getCopyrightData(article.copyright),

--- a/src/util/getStructuredDataFromArticle.js
+++ b/src/util/getStructuredDataFromArticle.js
@@ -8,7 +8,12 @@
 
 import format from 'date-fns/format';
 
-const CREATIVE_WORK_TYPE = 'CreativeWork';
+import config from '../config'
+
+const CREATIVE_WORK_TYPE = 'WebPage';
+const BREADCRUMB_TYPE = 'BreadcrumbList';
+const ITEM_TYPE = 'ListItem';
+
 const PERSON_TYPE = 'Person';
 const ORGANIZATION_TYPE = 'Organization';
 const IMAGE_TYPE = 'ImageObject';
@@ -57,7 +62,29 @@ const getCopyrightData = ({ creators, rightsholders, license, processors }) => {
   return data;
 };
 
-const getStructuredDataFromArticle = article => {
+const getBreadcrumbs = breadcrumbItems => {
+  const items = breadcrumbItems.map((item, index) => {
+    return {
+      '@type': ITEM_TYPE,
+      name: item.name,
+      position: index + 1,
+      item: {
+        '@type': 'Thing',
+        id: `${config.ndlaFrontendDomain}${item.to}`,
+      }
+    }
+  });
+
+  const breadcrumbList = {
+    '@type': BREADCRUMB_TYPE,
+    numberOfItems: breadcrumbItems.length,
+    ...items
+  };
+
+  return  breadcrumbList;
+};
+
+const getStructuredDataFromArticle = (article, breadcrumbItems) => {
   if (!article) return [];
 
   let articleData = getStructuredDataBase();
@@ -66,6 +93,7 @@ const getStructuredDataFromArticle = article => {
 
   articleData = {
     ...articleData,
+    breadcrumbs: getBreadcrumbs(breadcrumbItems),
     ...getCopyrightData(article.copyright),
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1435,10 +1435,10 @@
   dependencies:
     warning "^4.0.3"
 
-"@ndla/ui@^0.29.0":
-  version "0.29.0"
-  resolved "https://registry.yarnpkg.com/@ndla/ui/-/ui-0.29.0.tgz#bb8bd4dbbe7c4731233a9961a85f26a66ae85fbc"
-  integrity sha512-LmEEcaZsrT+roRng1hnKzCFkIzXtsxp1lILLhunnxjZB9LL/OXtoEsDgYHvFKEI/9lCQ3wZvsJtTYRjkUOVuCA==
+"@ndla/ui@^0.29.3":
+  version "0.29.3"
+  resolved "https://registry.yarnpkg.com/@ndla/ui/-/ui-0.29.3.tgz#6f131fa5c11d0b66acfa4b3f74e89c2530d2776b"
+  integrity sha512-jtoauInY5OkqS0pvFF1fRgOU11/4O1qF7YuE6tJimo1LstuQcFWAP4LpPt6dlcGGqbuX/jvfOERZ3jA0CIc0Xg==
   dependencies:
     "@ndla/button" "^0.3.41"
     "@ndla/carousel" "^0.3.31"


### PR DESCRIPTION
Fixes NDLANO/Issues#2357

Legger på BreadcrumbList som json-metadata. Dette gjør at vi kan omgå problemer med uleselige urler ved visning av ndla--urler i google.

Test: 
Versjonen er deploya til test på grunn av manglende travisbygg.
Finn en url som viser en artikkel og sjekk i head på dokumentet at ls-json-script-tagen har breadcrumbs.
Du kan også teste adressa på https://search.google.com/structured-data/testing-tool/