### PR TITLE
saving in localstorage if additional resources should be shown

### DIFF
--- a/src/containers/Resources/Resources.jsx
+++ b/src/containers/Resources/Resources.jsx
@@ -33,10 +33,24 @@ class Resources extends Component {
     this.toggleAdditionalDialog = this.toggleAdditionalDialog.bind(this);
   }
 
+  componentDidMount() {
+    const showAdditional = window
+      ? window.localStorage.getItem('showAdditionalResources')
+      : 'false';
+    this.setState(prevState => ({
+      showAdditionalResources: showAdditional === 'true',
+    }));
+  }
+
   toggleAdditionalResources() {
     this.setState(prevState => ({
       showAdditionalResources: !prevState.showAdditionalResources,
     }));
+    window &&
+      window.localStorage.setItem(
+        'showAdditionalResources',
+        `${!this.state.showAdditionalResources}`,
+      );
   }
 
   toggleAdditionalDialog() {


### PR DESCRIPTION
Fixes NDLANO/Issues#2358

Henter om tilleggsressurser skal vises fra localstorage.

Test:
Finn et emne som har tilleggsressurser, feks: http://localhost:3000/subjects/subject:19/topic:1:186558/topic:1:123879/?filters=urn:filter:f3d2143b-66e3-428c-89ca-72c1abc659ea

Om du velger Tilleggstoff og laster sida på nytt skal det huskes. Det skal også hugses på andre sider som har tilleggstoff.