### PR TITLE
Test loadable components

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,11 @@
     "serialize-javascript": "^3.1.0",
     "source-map-support": "^0.5.9",
     "url-parse": "^1.4.7",
-    "warning": "^4.0.3"
+    "warning": "^4.0.3",
+    "@loadable/babel-plugin": "^5.13.2",
+    "@loadable/component": "^5.14.1",
+    "@loadable/webpack-plugin": "^5.14.0",
+    "@loadable/server": "^5.14.0"
   },
   "repository": {
     "type": "git",

--- a/razzle.config.js
+++ b/razzle.config.js
@@ -3,6 +3,8 @@ const webpack = require('webpack');
 const path = require('path');
 const addEntry = require('./razzle-add-entry-plugin');
 
+const LoadablePlugin = require('@loadable/webpack-plugin');
+
 module.exports = {
   plugins: [
     addEntry({ entry: '@ndla/polyfill', name: 'polyfill' }),
@@ -19,6 +21,7 @@ module.exports = {
     });
 
     appConfig.module.rules.shift(); // remove eslint-loader
+    appConfig.plugins.push(new LoadablePlugin());
 
     if (target === 'web') {
       appConfig.output.filename = dev

--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import loadable from '@loadable/component';
 import {
   Route as ReactRoute,
   matchPath,
@@ -16,10 +17,8 @@ import {
 } from 'react-router-dom';
 import { Content } from '@ndla/ui';
 import Page from './containers/Page/Page';
-import Masthead from './containers/Masthead';
 import { routes } from './routes';
 import handleError from './util/handleError';
-import ErrorPage from './containers/ErrorPage/ErrorPage';
 import {
   FILM_PAGE_PATH,
   MULTIDISCIPLINARY_SUBJECT_PAGE_PATH,
@@ -28,6 +27,9 @@ import {
 } from './constants';
 
 export const BasenameContext = React.createContext('');
+
+const Masthead = loadable(() => import('./containers/Masthead'));
+const ErrorPage = loadable(() => import('./containers/ErrorPage/ErrorPage'));
 
 const Route = ({
   component: Component,

--- a/src/client.jsx
+++ b/src/client.jsx
@@ -18,6 +18,7 @@ import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/core';
 
 import queryString from 'query-string';
+import { loadableReady } from '@loadable/component';
 import { createHistory } from './history';
 import { getLocaleInfoFromPath, isValidLocale } from './i18n';
 import { createApolloClient } from './util/apiHelpers';
@@ -95,22 +96,24 @@ const RouterComponent = ({ children }) =>
     <Router history={browserHistory}>{children}</Router>
   );
 
-renderOrHydrate(
-  <ApolloProvider client={client}>
-    <CacheProvider value={cache}>
-      <IntlProvider locale={abbreviation} messages={messages}>
-        <RouterComponent>
-          {routes({ ...initialProps, basename }, abbreviation)}
-        </RouterComponent>
-      </IntlProvider>
-    </CacheProvider>
-  </ApolloProvider>,
-  document.getElementById('root'),
-  () => {
-    // See: /src/util/transformArticle.js for info on why this is needed.
-    window.hasHydrated = true;
-  },
-);
+loadableReady(() => {
+  renderOrHydrate(
+    <ApolloProvider client={client}>
+      <CacheProvider value={cache}>
+        <IntlProvider locale={abbreviation} messages={messages}>
+          <RouterComponent>
+            {routes({ ...initialProps, basename }, abbreviation)}
+          </RouterComponent>
+        </IntlProvider>
+      </CacheProvider>
+    </ApolloProvider>,
+    document.getElementById('root'),
+    () => {
+      // See: /src/util/transformArticle.js for info on why this is needed.
+      window.hasHydrated = true;
+    },
+  );
+});
 
 if (module.hot) {
   module.hot.accept();

--- a/src/containers/ArticlePage/ArticlePage.jsx
+++ b/src/containers/ArticlePage/ArticlePage.jsx
@@ -178,7 +178,9 @@ class ArticlePage extends Component {
           ))}
 
           <script type="application/ld+json">
-            {JSON.stringify(getStructuredDataFromArticle(article, breadcrumbItems))}
+            {JSON.stringify(
+              getStructuredDataFromArticle(article, breadcrumbItems),
+            )}
           </script>
         </Helmet>
         <SocialMediaMetadata

--- a/src/containers/Masthead/components/MastheadMenu.jsx
+++ b/src/containers/Masthead/components/MastheadMenu.jsx
@@ -1,12 +1,14 @@
 import React, { Component, Fragment } from 'react';
+import loadable from '@loadable/component';
 import { node, shape, func, string, arrayOf, object, bool } from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import { TopicShape, ResourceShape, LocationShape } from '../../../shapes';
 import { getUrnIdsFromProps, isSubjectPagePath } from '../../../routeHelpers';
 import { getSelectedTopic } from '../mastheadHelpers';
 import { getFiltersFromUrlAsArray } from '../../../util/filterHelper';
-import MastheadTopics from './MastheadTopics';
-import MastheadMenuModal from './MastheadMenuModal';
+
+const MastheadMenuModal = loadable(() => import('./MastheadMenuModal'));
+const MastheadTopics = loadable(() => import('./MastheadTopics'));
 
 class MastheadMenu extends Component {
   constructor() {

--- a/src/containers/WelcomePage/WelcomePage.jsx
+++ b/src/containers/WelcomePage/WelcomePage.jsx
@@ -19,18 +19,19 @@ import {
 } from '@ndla/ui';
 import { injectT } from '@ndla/i18n';
 
-import WelcomePageInfo from './WelcomePageInfo';
-import FrontpageSubjects from './FrontpageSubjects';
 import { FILM_PAGE_PATH } from '../../constants';
-import SocialMediaMetadata from '../../components/SocialMediaMetadata';
 import config from '../../config';
 
 import { getLocaleUrls } from '../../util/localeHelpers';
 import { LocationShape } from '../../shapes';
-import BlogPosts from './BlogPosts';
-import WelcomePageSearch from './WelcomePageSearch';
 import { toSubject } from '../../routeHelpers';
 import { getSubjectById } from '../../data/subjects';
+
+const BlogPosts = loadable(() => import('./BlogPosts')) ;
+const WelcomePageSearch = loadable(() => import('./WelcomePageSearch')) ;
+const WelcomePageInfo = loadable(() => import('./WelcomePageInfo'));
+const FrontpageSubjects = loadable(() => import('./FrontpageSubjects'));
+const SocialMediaMetadata = loadable(() => import('../../components/SocialMediaMetadata')) ;
 
 const getUrlFromSubjectId = subjectId => {
   const subject = getSubjectById(subjectId);

--- a/src/containers/WelcomePage/WelcomePage.jsx
+++ b/src/containers/WelcomePage/WelcomePage.jsx
@@ -7,6 +7,7 @@
  */
 
 import React, { Fragment } from 'react';
+import loadable from '@loadable/component';
 import { HelmetWithTracker } from '@ndla/tracker';
 import PropTypes from 'prop-types';
 import {

--- a/src/containers/WelcomePage/WelcomePage.jsx
+++ b/src/containers/WelcomePage/WelcomePage.jsx
@@ -27,11 +27,13 @@ import { LocationShape } from '../../shapes';
 import { toSubject } from '../../routeHelpers';
 import { getSubjectById } from '../../data/subjects';
 
-const BlogPosts = loadable(() => import('./BlogPosts')) ;
-const WelcomePageSearch = loadable(() => import('./WelcomePageSearch')) ;
+const BlogPosts = loadable(() => import('./BlogPosts'));
+const WelcomePageSearch = loadable(() => import('./WelcomePageSearch'));
 const WelcomePageInfo = loadable(() => import('./WelcomePageInfo'));
 const FrontpageSubjects = loadable(() => import('./FrontpageSubjects'));
-const SocialMediaMetadata = loadable(() => import('../../components/SocialMediaMetadata')) ;
+const SocialMediaMetadata = loadable(() =>
+  import('../../components/SocialMediaMetadata'),
+);
 
 const getUrlFromSubjectId = subjectId => {
   const subject = getSubjectById(subjectId);

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -7,17 +7,7 @@
  */
 
 import React from 'react';
-import WelcomePage from './containers/WelcomePage/WelcomePage';
-import PlainArticlePage from './containers/PlainArticlePage/PlainArticlePage';
-import SearchPage from './containers/SearchPage/SearchPage';
-import AllSubjectsPage from './containers/AllSubjectsPage/AllSubjectsPage';
-import SubjectPage from './containers/SubjectPage/SubjectPage';
-import NotFoundPage from './containers/NotFoundPage/NotFoundPage';
-import FilmFrontpage from './containers/FilmFrontpage/NdlaFilmFrontpage';
-import PlainLearningpathPage from './containers/PlainLearningpathPage/PlainLearningpathPage';
-import ResourcePage from './containers/ResourcePage/ResourcePage';
-import MultidisciplinarySubjectPage from './containers/MultidisciplinarySubject/MultidisciplinarySubjectPage';
-import MultidisciplinarySubjectArticle from './containers/MultidisciplinarySubject/MultidisciplinarySubjectArticle';
+import loadable from '@loadable/component';
 
 import App from './App';
 import {
@@ -33,6 +23,40 @@ import {
   MULTIDISCIPLINARY_SUBJECT_PAGE_PATH,
 } from './constants';
 import ProgrammePage from './containers/ProgrammePage/ProgrammePage';
+
+const WelcomePage = loadable(() =>
+  import('./containers/WelcomePage/WelcomePage'),
+);
+const PlainArticlePage = loadable(() =>
+  import('./containers/PlainArticlePage/PlainArticlePage'),
+);
+const SearchPage = loadable(() => import('./containers/SearchPage/SearchPage'));
+const AllSubjectsPage = loadable(() =>
+  import('./containers/AllSubjectsPage/AllSubjectsPage'),
+);
+const SubjectPage = loadable(() =>
+  import('./containers/SubjectPage/SubjectPage'),
+);
+const NotFoundPage = loadable(() =>
+  import('./containers/NotFoundPage/NotFoundPage'),
+);
+const FilmFrontpage = loadable(() =>
+  import('./containers/FilmFrontpage/NdlaFilmFrontpage'),
+);
+const PlainLearningpathPage = loadable(() =>
+  import('./containers/PlainLearningpathPage/PlainLearningpathPage'),
+);
+const ResourcePage = loadable(() =>
+  import('./containers/ResourcePage/ResourcePage'),
+);
+const MultidisciplinarySubjectPage = loadable(() =>
+  import('./containers/MultidisciplinarySubject/MultidisciplinarySubjectPage'),
+);
+const MultidisciplinarySubjectArticle = loadable(() =>
+  import(
+    './containers/MultidisciplinarySubject/MultidisciplinarySubjectArticle'
+  ),
+);
 
 export const routes = [
   {

--- a/src/util/__tests__/getStructuredDataFromArticle-test.js
+++ b/src/util/__tests__/getStructuredDataFromArticle-test.js
@@ -103,10 +103,11 @@ test('util/getStructuredDataFromArticle article with breadcrumbs should return b
     {
       to: '/',
       name: 'NDLA',
-    }, {
+    },
+    {
       to: '/subjects/subject:1/',
       name: 'MEDIEUTTRYKK OG MEDIESAMFUNNET',
-    }
+    },
   ];
   const structuredData = getStructuredDataFromArticle(article, breadcrumbItems);
   expect(structuredData.length).toBe(2);

--- a/src/util/getStructuredDataFromArticle.js
+++ b/src/util/getStructuredDataFromArticle.js
@@ -96,7 +96,7 @@ const getStructuredDataFromArticle = (article, breadcrumbItems) => {
   articleData.headline = article.title;
   articleData.datePublished = format(article.published, 'YYYY-MM-DD');
   articleData.dateModified = format(article.updated, 'YYYY-MM-DD');
-  
+
   articleData = {
     ...articleData,
     ...getCopyrightData(article.copyright),

--- a/yarn.lock
+++ b/yarn.lock
@@ -419,7 +419,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-dynamic-import@^7.8.0", "@babel/plugin-syntax-dynamic-import@^7.8.3":
+"@babel/plugin-syntax-dynamic-import@^7.7.4", "@babel/plugin-syntax-dynamic-import@^7.8.0", "@babel/plugin-syntax-dynamic-import@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz#62bf98b2da3cd21d626154fc96ee5b3cb68eacb3"
   integrity sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
@@ -906,6 +906,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.7.7":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
+  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.9.2":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.6.tgz#a9102eb5cadedf3f31d08a9ecf294af7827ea29f"
@@ -1276,6 +1283,36 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
+
+"@loadable/babel-plugin@^5.13.2":
+  version "5.13.2"
+  resolved "https://registry.yarnpkg.com/@loadable/babel-plugin/-/babel-plugin-5.13.2.tgz#373cddc64ee5437814f7dca1c1b6a7b2c1665a9f"
+  integrity sha512-vSZUVeTH1S1sDbk8Tzft0plZSkN7W4zmVR5w/Bmy4UmvBiu9lin7ztrDpoUTUzxpoups+OJbTc/OosvN0aMXWg==
+  dependencies:
+    "@babel/plugin-syntax-dynamic-import" "^7.7.4"
+
+"@loadable/component@^5.14.1":
+  version "5.14.1"
+  resolved "https://registry.yarnpkg.com/@loadable/component/-/component-5.14.1.tgz#cacd807162430bb85ae085945318027a600adc85"
+  integrity sha512-UQBZfZrp1FLTf8RNhljXNHFNY4QhAA1L2+GOEeABBFre9TD0aFyQh3Sai5QxcOfy+FTbjIfti5iHaNRR7yUzEQ==
+  dependencies:
+    "@babel/runtime" "^7.7.7"
+    hoist-non-react-statics "^3.3.1"
+    react-is "^16.12.0"
+
+"@loadable/server@^5.14.0":
+  version "5.14.0"
+  resolved "https://registry.yarnpkg.com/@loadable/server/-/server-5.14.0.tgz#8aa83166aaad7401a14d8a1b04a7e1cc169ca6c4"
+  integrity sha512-oiZiHzUdkOsDzZNXU6fsZ7U0W3+nWZRljVCFCeR8CZSXEKUfXAllUf8tx5G385q7vapAQpXM7U8EzgDns3Q4vQ==
+  dependencies:
+    lodash "^4.17.15"
+
+"@loadable/webpack-plugin@^5.14.0":
+  version "5.14.0"
+  resolved "https://registry.yarnpkg.com/@loadable/webpack-plugin/-/webpack-plugin-5.14.0.tgz#656cb298c4b30d3b93cfe6ebf227d9709685f357"
+  integrity sha512-md9Nm6o+OjWJH6RgHcYsbko36YDKG2zuM19rFYkQsktdfq+JnbwOCp3hVhZM7L8V1M4MP3uJfmxKh6QGOnk4+w==
+  dependencies:
+    make-dir "^3.0.2"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -6109,7 +6146,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -10753,7 +10790,7 @@ react-helmet@^6.1.0:
     react-fast-compare "^3.1.1"
     react-side-effect "^2.1.0"
 
-react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
+react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==


### PR DESCRIPTION
Siden vi gjør SSR så funker ikke `React.lazy`, men [react selv](https://reactjs.org/docs/code-splitting.html#reactlazy) anbefaler loadable components libet.

Skal jeg være ærlig så klarer jeg ikke komme på noe nedside ved å lazyloade komponenter og sende de i en separat bundle så kom veldig pretty please med innspill!

Jeg har bare tatt noen komponenter willynilly og importert dem med loadable for å teste det ut.
Reduserte ubrukt js om man bare loader forsida fra 2.3 til 2.0 mb, 300kb(!).
Kan sikkert reduseres mer ved å gå løs på flere importer.

Ser jeg får en warning, så kan ikke merges ennå, men ville få litt tilbakemeldinger før jeg brukte mer tid på det :smile: