### PR TITLE
Redirects user

### DIFF
--- a/src/containers/ResourcePage/ResourcePage.jsx
+++ b/src/containers/ResourcePage/ResourcePage.jsx
@@ -7,6 +7,7 @@
  */
 
 import React, { useEffect } from 'react';
+import { Redirect } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { injectT } from '@ndla/i18n';
 
@@ -59,7 +60,13 @@ const ResourcePage = props => {
   }
 
   if (data.resource && !urlInPaths(props.location, data.resource)) {
-    return <MovedResourcePage resource={data.resource} locale={props.locale} />;
+    if (data.resource.paths?.length === 1) {
+      return <Redirect to={data.resource.paths[0]} />;
+    } else {
+      return (
+        <MovedResourcePage resource={data.resource} locale={props.locale} />
+      );
+    }
   }
 
   if (!data.resource) {

--- a/src/lti/LtiProvider.jsx
+++ b/src/lti/LtiProvider.jsx
@@ -107,7 +107,7 @@ const LtiProvider = ({ t, locale: { abbreviation: locale }, ltiData }) => {
       {
         value: 'topic-article',
         type: 'contextTypes',
-        name: t('contentTypes.subject'),
+        name: t('contentTypes.topic'),
       },
       ...resourceTypeTabs,
     ];


### PR DESCRIPTION
Fixes NDLANO/Issues#2370

Dersom en ressurs er flytta og kun finnes på en plass, sendes brukeren direkte til den nye plassen.
Fikser også feil label i LTI-sida.

Test:
Finn en vilkårlig ressurs-url og endre i pathen, enten ved å fjerne en topic eller berre endre et tegn. Du skal få en 301 redirect til original url.