### PR TITLE
#2375: Rewrite multidisciplinary subjects to use topics instead of filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@ndla/safelink": "^0.0.7",
     "@ndla/tabs": "^0.11.41",
     "@ndla/tracker": "^0.4.3",
-    "@ndla/ui": "^0.29.10",
+    "@ndla/ui": "^0.30.0",
     "@ndla/util": "^0.4.4",
     "@ndla/zendesk": "^0.2.33",
     "apollo-cache-inmemory": "^1.6.3",

--- a/src/constants.js
+++ b/src/constants.js
@@ -41,4 +41,7 @@ export const PROGRAMME_PATH = '/utdanning';
 export const PROGRAMME_PAGE_PATH = '/utdanning/:programme';
 
 export const MULTIDISCIPLINARY_SUBJECT_PAGE_PATH =
-  '/subject:d1fe9d0a-a54d-49db-a4c2-fd5463a7c9e7';
+  '/subject:d1fe9d0a-a54d-49db-a4c2-fd5463a7c9e7/:topicPath*/';
+
+export const MULTIDISCIPLINARY_SUBJECT_ARTICLE_PAGE_PATH =
+  '/subject:d1fe9d0a-a54d-49db-a4c2-fd5463a7c9e7/:topicPath*/card';

--- a/src/constants.js
+++ b/src/constants.js
@@ -41,7 +41,7 @@ export const PROGRAMME_PATH = '/utdanning';
 export const PROGRAMME_PAGE_PATH = '/utdanning/:programme';
 
 export const MULTIDISCIPLINARY_SUBJECT_PAGE_PATH =
-  '/subject:d1fe9d0a-a54d-49db-a4c2-fd5463a7c9e7/:topicPath*/';
+  '/subject\\::subjectId(d1fe9d0a-a54d-49db-a4c2-fd5463a7c9e7)/:topicPath*/';
 
 export const MULTIDISCIPLINARY_SUBJECT_ARTICLE_PAGE_PATH =
-  '/subject:d1fe9d0a-a54d-49db-a4c2-fd5463a7c9e7/:topicPath*/card';
+  '/subject\\::subjectId(d1fe9d0a-a54d-49db-a4c2-fd5463a7c9e7)/:topicPath*/card';

--- a/src/containers/MultidisciplinarySubject/MultidisciplinarySubjectArticle.jsx
+++ b/src/containers/MultidisciplinarySubject/MultidisciplinarySubjectArticle.jsx
@@ -29,7 +29,7 @@ const filterCodes = {
 };
 
 const MultidisciplinarySubjectArticle = ({ match, locale }) => {
-  const subjectId = `urn:${match.path.split('/')[2]}`;
+  const subjectId = `urn:${match.path.split('/')[1]}`;
   const { topicId } = getUrnIdsFromProps({ match });
 
   const { data, loading } = useGraphQuery(topicQuery, {

--- a/src/containers/MultidisciplinarySubject/MultidisciplinarySubjectArticle.jsx
+++ b/src/containers/MultidisciplinarySubject/MultidisciplinarySubjectArticle.jsx
@@ -18,7 +18,7 @@ import {
 import Article from '../../components/Article/Article';
 import Resources from '../Resources/Resources';
 import { useGraphQuery } from '../../util/runQueries';
-import { topicQuery } from '../../queries';
+import { topicQueryWithPathTopics } from '../../queries';
 import { scrollToRef } from '../SubjectPage/subjectPageHelpers';
 import { getUrnIdsFromProps } from '../../routeHelpers';
 
@@ -29,18 +29,11 @@ const filterCodes = {
 };
 
 const MultidisciplinarySubjectArticle = ({ match, locale }) => {
-  const { topicList, topicId } = getUrnIdsFromProps({ match });
+  const { topicId } = getUrnIdsFromProps({ match });
 
-  const { data, loading } = useGraphQuery(topicQuery, {
+  const { data, loading } = useGraphQuery(topicQueryWithPathTopics, {
     variables: { topicId },
   });
-
-  const { data: baseTopicData, loading: baseTopicLoading } = useGraphQuery(
-    topicQuery,
-    {
-      variables: { topicId: topicList[0] },
-    },
-  );
 
   const [pageUrl, setPageUrl] = useState('');
   useEffect(() => {
@@ -49,7 +42,7 @@ const MultidisciplinarySubjectArticle = ({ match, locale }) => {
 
   const resourcesRef = useRef(null);
 
-  if (loading || baseTopicLoading) {
+  if (loading) {
     return null;
   }
 
@@ -60,13 +53,12 @@ const MultidisciplinarySubjectArticle = ({ match, locale }) => {
 
   const { topic, resourceTypes } = data;
 
-  const subjects = [filterCodes[baseTopicData.topic.name]];
-  const subjectsLinks = [
-    {
-      label: baseTopicData.topic.name,
-      url: baseTopicData.topic.path,
-    },
-  ];
+  // "Base topics" are considered subjects
+  const subjects = topic.pathTopics.map(listOfTopics => filterCodes[listOfTopics[0].name]);
+  const subjectsLinks = topic.pathTopics.map(listOfTopics => ( {
+    label: listOfTopics[0].name,
+      url: listOfTopics[0].path,
+  }));
 
   return (
     <>

--- a/src/containers/MultidisciplinarySubject/MultidisciplinarySubjectArticle.jsx
+++ b/src/containers/MultidisciplinarySubject/MultidisciplinarySubjectArticle.jsx
@@ -54,10 +54,12 @@ const MultidisciplinarySubjectArticle = ({ match, locale }) => {
   const { topic, resourceTypes } = data;
 
   // "Base topics" are considered subjects
-  const subjects = topic.pathTopics.map(listOfTopics => filterCodes[listOfTopics[0].name]);
-  const subjectsLinks = topic.pathTopics.map(listOfTopics => ( {
+  const subjects = topic.pathTopics.map(
+    listOfTopics => filterCodes[listOfTopics[0].name],
+  );
+  const subjectsLinks = topic.pathTopics.map(listOfTopics => ({
     label: listOfTopics[0].name,
-      url: listOfTopics[0].path,
+    url: listOfTopics[0].path,
   }));
 
   return (

--- a/src/containers/MultidisciplinarySubject/MultidisciplinarySubjectPage.jsx
+++ b/src/containers/MultidisciplinarySubject/MultidisciplinarySubjectPage.jsx
@@ -69,7 +69,7 @@ const MultidisciplinarySubjectPage = ({ match, history, location, locale }) => {
           image: topic.meta.metaImage?.url,
           imageAlt: topic.meta.metaImage?.alt,
           subjects: [selectedSubject.name],
-          url: `${toTopic(subjectId, undefined, topic.id)}card`,
+          url: `${topic.path}/card`,
           ...topic,
         }));
 

--- a/src/containers/MultidisciplinarySubject/MultidisciplinarySubjectPage.jsx
+++ b/src/containers/MultidisciplinarySubject/MultidisciplinarySubjectPage.jsx
@@ -8,18 +8,24 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { MultidisciplinarySubject } from '@ndla/ui';
+import { MultidisciplinarySubject, NavigationBox } from '@ndla/ui';
 
-import { toTopic } from '../../routeHelpers';
-import { getFiltersFromUrlAsArray } from '../../util/filterHelper';
+import queryString from 'query-string';
+import { getUrnIdsFromProps, toTopic } from '../../routeHelpers';
 import { useGraphQuery } from '../../util/runQueries';
 import { subjectPageQuery } from '../../queries';
 import { LocationShape } from '../../shapes';
+import { DefaultErrorMessage } from '../../components/DefaultErrorMessage';
+import MultidisciplinaryTopicWrapper from './components/MultidisciplinaryTopicWrapper';
 
-const MultidisciplinarySubjectPage = ({ match, history, location }) => {
-  const selectedFilters = getFiltersFromUrlAsArray(location);
+const MultidisciplinarySubjectPage = ({ match, history, location, locale }) => {
+  const { topicList: selectedTopics } = getUrnIdsFromProps({
+    ndlaFilm: false,
+    match,
+  });
 
   const subjectId = `urn:${match.path.split('/')[1]}`;
+
   const { loading, data } = useGraphQuery(subjectPageQuery, {
     variables: {
       subjectId,
@@ -30,57 +36,54 @@ const MultidisciplinarySubjectPage = ({ match, history, location }) => {
     return null;
   }
 
-  const onFilterClick = id => {
-    const newFilters = [...selectedFilters];
-    const idIndex = newFilters.indexOf(id);
-    if (idIndex > -1) {
-      newFilters.splice(idIndex, 1);
-    } else {
-      newFilters.push(id);
-    }
-    history.push({
-      search: newFilters.length && `?filters=${newFilters}`,
-    });
-  };
+  if (!data) {
+    return <DefaultErrorMessage />;
+  }
 
-  const filterItems = items => {
-    if (!selectedFilters.length) {
-      return items;
-    }
-    return items.filter(item =>
-      item.filters.some(filter => selectedFilters.includes(filter.id)),
-    );
-  };
+  const onClickTopics = () => {};
 
-  const {
-    subject: { filters, topics },
-  } = data;
+  const items = [];
+  const { subject = {} } = data;
 
-  const itemFilters = filters.map(filter => ({
-    label: filter.name,
-    selected: selectedFilters.includes(filter.id),
-    ...filter,
-  }));
+  console.log('sub', subject);
 
-  const items = topics.map(topic => ({
-    title: topic.name,
-    introduction: topic.meta.metaDescription,
-    image: topic.meta.metaImage?.url,
-    imageAlt: topic.meta.metaImage?.alt,
-    subjects: topic.filters.map(filter => filter.name),
-    url: toTopic(subjectId, undefined, topic.id),
-    ...topic,
-  }));
-
-  const filteredItems = filterItems(items);
+  const mainTopics = subject.topics.map(topic => {
+    return {
+      ...topic,
+      label: topic.name,
+      selected: topic.id === selectedTopics[0],
+      url: toTopic(subject.id, [], topic.id),
+    };
+  });
 
   return (
-    <MultidisciplinarySubject
-      filters={itemFilters}
-      onFilterClick={onFilterClick}
-      items={filteredItems}
-      totalItemsCount={filteredItems.length}
-    />
+    <MultidisciplinarySubject cards={items} totalCardCount={0}>
+      <NavigationBox
+        items={mainTopics}
+        listDirection="horizontal"
+        onClick={e => {
+          onClickTopics(e);
+        }}
+      />
+      {selectedTopics.map((topicId, index) => {
+        return (
+          <div key={index}>
+            <MultidisciplinaryTopicWrapper
+              disableNav={index >= 1}
+              setBreadCrumb={() => {}}
+              topicId={topicId}
+              subjectId={subject.id}
+              subTopicId={selectedTopics[index + 1]}
+              locale={locale}
+              onClickTopics={onClickTopics}
+              index={index}
+              showResources={false}
+              subject={subject}
+            />
+          </div>
+        );
+      })}
+    </MultidisciplinarySubject>
   );
 };
 
@@ -92,6 +95,7 @@ MultidisciplinarySubjectPage.propTypes = {
     push: PropTypes.func.isRequired,
   }).isRequired,
   location: LocationShape,
+  locale: PropTypes.string.isRequired,
 };
 
 export default MultidisciplinarySubjectPage;

--- a/src/containers/MultidisciplinarySubject/MultidisciplinarySubjectPage.jsx
+++ b/src/containers/MultidisciplinarySubject/MultidisciplinarySubjectPage.jsx
@@ -18,12 +18,10 @@ import { DefaultErrorMessage } from '../../components/DefaultErrorMessage';
 import MultidisciplinaryTopicWrapper from './components/MultidisciplinaryTopicWrapper';
 
 const MultidisciplinarySubjectPage = ({ match, history, location, locale }) => {
-  const { topicList: selectedTopics } = getUrnIdsFromProps({
+  const { subjectId, topicList: selectedTopics } = getUrnIdsFromProps({
     ndlaFilm: false,
     match,
   });
-
-  const subjectId = `urn:${match.path.split('/')[1]}`;
 
   const { loading, data } = useGraphQuery(subjectPageQuery, {
     variables: {

--- a/src/containers/MultidisciplinarySubject/MultidisciplinarySubjectPage.jsx
+++ b/src/containers/MultidisciplinarySubject/MultidisciplinarySubjectPage.jsx
@@ -39,7 +39,6 @@ const MultidisciplinarySubjectPage = ({ match, history, location, locale }) => {
     return <DefaultErrorMessage />;
   }
 
-  const onClickTopics = () => {};
   const { subject = {} } = data;
 
   const mainTopics = subject.topics.map(topic => {
@@ -74,36 +73,31 @@ const MultidisciplinarySubjectPage = ({ match, history, location, locale }) => {
           ...topic,
         }));
 
+  const TopicBoxes = () =>
+    selectedTopics.map((topicId, index) => {
+      return (
+        <div key={index}>
+          <MultidisciplinaryTopicWrapper
+            disableNav={index >= selectionLimit - 1}
+            topicId={topicId}
+            subjectId={subject.id}
+            subTopicId={selectedTopics[index + 1]}
+            locale={locale}
+            index={index}
+            showResources={false}
+            subject={subject}
+          />
+        </div>
+      );
+    });
+
   return (
     <MultidisciplinarySubject
       hideCards={isNotLastTopic}
       cards={cards}
       totalCardCount={cards.length}>
-      <NavigationBox
-        items={mainTopics}
-        listDirection="horizontal"
-        onClick={e => {
-          onClickTopics(e);
-        }}
-      />
-      {selectedTopics.map((topicId, index) => {
-        return (
-          <div key={index}>
-            <MultidisciplinaryTopicWrapper
-              disableNav={index >= selectionLimit - 1}
-              setBreadCrumb={() => {}}
-              topicId={topicId}
-              subjectId={subject.id}
-              subTopicId={selectedTopics[index + 1]}
-              locale={locale}
-              onClickTopics={onClickTopics}
-              index={index}
-              showResources={false}
-              subject={subject}
-            />
-          </div>
-        );
-      })}
+      <NavigationBox items={mainTopics} listDirection="horizontal" />
+      <TopicBoxes />
     </MultidisciplinarySubject>
   );
 };

--- a/src/containers/MultidisciplinarySubject/components/MultidisciplinaryTopic.jsx
+++ b/src/containers/MultidisciplinarySubject/components/MultidisciplinaryTopic.jsx
@@ -72,7 +72,7 @@ const MultidisciplinaryTopic = ({
           modifier="in-topic"
         />
       </NavigationTopicAbout>
-      {(subTopics.length !== 0 && disableNav !== true) && (
+      {subTopics.length !== 0 && disableNav !== true && (
         <NavigationBox
           colorMode="light"
           heading="emner"

--- a/src/containers/MultidisciplinarySubject/components/MultidisciplinaryTopic.jsx
+++ b/src/containers/MultidisciplinarySubject/components/MultidisciplinaryTopic.jsx
@@ -32,7 +32,6 @@ const MultidisciplinaryTopic = ({
   locale,
   subTopicId,
   ndlaFilm,
-  onClickTopics,
   data,
   disableNav,
 }) => {
@@ -79,9 +78,6 @@ const MultidisciplinaryTopic = ({
           items={subTopics}
           listDirection="horizontal"
           invertedStyle={ndlaFilm}
-          onClick={e => {
-            onClickTopics(e);
-          }}
         />
       )}
     </>
@@ -132,7 +128,6 @@ MultidisciplinaryTopic.propTypes = {
   subTopicId: PropTypes.string,
   locale: PropTypes.string,
   ndlaFilm: PropTypes.bool,
-  onClickTopics: PropTypes.func,
   setBreadCrumb: PropTypes.func,
   index: PropTypes.number,
   subject: GraphQLSubjectShape,

--- a/src/containers/MultidisciplinarySubject/components/MultidisciplinaryTopic.jsx
+++ b/src/containers/MultidisciplinarySubject/components/MultidisciplinaryTopic.jsx
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2020-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { NavigationTopicAbout, NavigationBox } from '@ndla/ui';
+import { injectT } from '@ndla/i18n';
+import { withTracker } from '@ndla/tracker';
+import config from '../../../config';
+import ArticleContents from '../../../components/Article/ArticleContents';
+import { toTopic } from '../../../routeHelpers';
+import { getAllDimensions } from '../../../util/trackingUtil';
+import { getSubjectBySubjectIdFilters } from '../../../data/subjects';
+import {
+  GraphQLResourceTypeShape,
+  GraphQLSubjectShape,
+  GraphQLTopicShape,
+} from '../../../graphqlShapes';
+
+const getDocumentTitle = ({ t, data }) => {
+  return `${data?.topic?.name || ''}${t('htmlTitles.titleTemplate')}`;
+};
+
+const MultidisciplinaryTopic = ({
+  topicId,
+  subjectId,
+  filterIds,
+  locale,
+  subTopicId,
+  ndlaFilm,
+  onClickTopics,
+  data,
+  disableNav,
+}) => {
+  const [showContent, setShowContent] = useState(false);
+
+  useEffect(() => {
+    setShowContent(false);
+  }, [topicId]);
+
+  const topic = data.topic;
+  const topicPath = topic.path
+    .split('/')
+    .slice(2)
+    .map(id => `urn:${id}`);
+  const subTopics = topic.subtopics.map(item => ({
+    id: item.id,
+    label: item.name,
+    selected: item.id === subTopicId,
+    url: toTopic(subjectId, filterIds, ...topicPath, item.id),
+  }));
+  const filterParam = filterIds ? `?filters=${filterIds}` : '';
+  const copyPageUrlLink = config.ndlaFrontendDomain + topic.path + filterParam;
+
+  return (
+    <>
+      <NavigationTopicAbout
+        heading={topic.name}
+        ingress={topic.article?.introduction}
+        showContent={showContent}
+        invertedStyle={ndlaFilm}
+        onToggleShowContent={() => setShowContent(!showContent)}
+        isLoading={false}>
+        <ArticleContents
+          topic={topic}
+          copyPageUrlLink={copyPageUrlLink}
+          locale={locale}
+          modifier="in-topic"
+        />
+      </NavigationTopicAbout>
+      {(subTopics.length !== 0 && disableNav !== true) && (
+        <NavigationBox
+          colorMode="light"
+          heading="emner"
+          items={subTopics}
+          listDirection="horizontal"
+          invertedStyle={ndlaFilm}
+          onClick={e => {
+            onClickTopics(e);
+          }}
+        />
+      )}
+    </>
+  );
+};
+
+MultidisciplinaryTopic.getDocumentTitle = getDocumentTitle;
+
+MultidisciplinaryTopic.willTrackPageView = (trackPageView, currentProps) => {
+  const { data, loading, showResources } = currentProps;
+  if (showResources && !loading && data?.topic?.article) {
+    trackPageView(currentProps);
+  }
+};
+
+MultidisciplinaryTopic.getDimensions = props => {
+  const { filterIds, data, locale, subject } = props;
+  const topicPath = data.topic.path
+    .split('/')
+    .slice(2)
+    .map(t =>
+      subject.allTopics.find(topic => topic.id.replace('urn:', '') === t),
+    );
+
+  const subjectBySubjectIdFiltes = getSubjectBySubjectIdFilters(
+    subject.id,
+    filterIds.split(','),
+  );
+  const longName = subjectBySubjectIdFiltes?.longName[locale];
+
+  return getAllDimensions(
+    {
+      subject: subject,
+      topicPath,
+      article: data.topic.article,
+      filter: longName,
+    },
+    undefined,
+    true,
+  );
+};
+
+MultidisciplinaryTopic.propTypes = {
+  topicId: PropTypes.string.isRequired,
+  subjectId: PropTypes.string,
+  filterIds: PropTypes.string,
+  setSelectedTopic: PropTypes.func,
+  subTopicId: PropTypes.string,
+  locale: PropTypes.string,
+  ndlaFilm: PropTypes.bool,
+  onClickTopics: PropTypes.func,
+  setBreadCrumb: PropTypes.func,
+  index: PropTypes.number,
+  subject: GraphQLSubjectShape,
+  data: PropTypes.shape({
+    topic: GraphQLTopicShape,
+    resourceTypes: PropTypes.arrayOf(GraphQLResourceTypeShape),
+  }),
+  loading: PropTypes.bool,
+  disableNav: PropTypes.bool,
+};
+
+export default injectT(withTracker(MultidisciplinaryTopic));

--- a/src/containers/MultidisciplinarySubject/components/MultidisciplinaryTopicWrapper.jsx
+++ b/src/containers/MultidisciplinarySubject/components/MultidisciplinaryTopicWrapper.jsx
@@ -14,8 +14,6 @@ const MultidisciplinaryTopicWrapper = ({
   locale,
   subTopicId,
   ndlaFilm,
-  onClickTopics,
-  setBreadCrumb,
   index,
   showResources,
   subject,
@@ -23,13 +21,6 @@ const MultidisciplinaryTopicWrapper = ({
 }) => {
   const { data, loading } = useGraphQuery(topicQuery, {
     variables: { topicId, subjectId, filterIds },
-    onCompleted: data => {
-      setBreadCrumb({
-        id: data.topic.id,
-        label: data.topic.name,
-        index: index,
-      });
-    },
   });
 
   if (loading) {
@@ -45,7 +36,6 @@ const MultidisciplinaryTopicWrapper = ({
       subTopicId={subTopicId}
       locale={locale}
       ndlaFilm={ndlaFilm}
-      onClickTopics={onClickTopics}
       showResources={showResources}
       subject={subject}
       loading={loading}
@@ -62,8 +52,6 @@ MultidisciplinaryTopicWrapper.propTypes = {
   subTopicId: PropTypes.string,
   locale: PropTypes.string,
   ndlaFilm: PropTypes.bool,
-  onClickTopics: PropTypes.func,
-  setBreadCrumb: PropTypes.func,
   index: PropTypes.number,
   showResources: PropTypes.bool,
   subject: GraphQLSubjectShape,

--- a/src/containers/MultidisciplinarySubject/components/MultidisciplinaryTopicWrapper.jsx
+++ b/src/containers/MultidisciplinarySubject/components/MultidisciplinaryTopicWrapper.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Spinner from '@ndla/ui/lib/Spinner';
+import { topicQuery } from '../../../queries';
+import { useGraphQuery } from '../../../util/runQueries';
+import { GraphQLSubjectShape } from '../../../graphqlShapes';
+import MultidisciplinaryTopic from './MultidisciplinaryTopic';
+
+const MultidisciplinaryTopicWrapper = ({
+  topicId,
+  subjectId,
+  filterIds,
+  locale,
+  subTopicId,
+  ndlaFilm,
+  onClickTopics,
+  setBreadCrumb,
+  index,
+  showResources,
+  subject,
+  disableNav,
+}) => {
+  const { data, loading } = useGraphQuery(topicQuery, {
+    variables: { topicId, subjectId, filterIds },
+    onCompleted: data => {
+      setBreadCrumb({
+        id: data.topic.id,
+        label: data.topic.name,
+        index: index,
+      });
+    },
+  });
+
+  if (loading) {
+    return <Spinner />;
+  }
+
+  return (
+    <MultidisciplinaryTopic
+      data={data}
+      topicId={topicId}
+      subjectId={subjectId}
+      filterIds={filterIds}
+      subTopicId={subTopicId}
+      locale={locale}
+      ndlaFilm={ndlaFilm}
+      onClickTopics={onClickTopics}
+      showResources={showResources}
+      subject={subject}
+      loading={loading}
+      disableNav={disableNav}
+    />
+  );
+};
+
+MultidisciplinaryTopicWrapper.propTypes = {
+  topicId: PropTypes.string.isRequired,
+  subjectId: PropTypes.string,
+  filterIds: PropTypes.string,
+  setSelectedTopic: PropTypes.func,
+  subTopicId: PropTypes.string,
+  locale: PropTypes.string,
+  ndlaFilm: PropTypes.bool,
+  onClickTopics: PropTypes.func,
+  setBreadCrumb: PropTypes.func,
+  index: PropTypes.number,
+  showResources: PropTypes.bool,
+  subject: GraphQLSubjectShape,
+  disableNav: PropTypes.bool,
+};
+
+export default MultidisciplinaryTopicWrapper;

--- a/src/containers/SubjectPage/SubjectContainer.jsx
+++ b/src/containers/SubjectPage/SubjectContainer.jsx
@@ -151,6 +151,7 @@ const SubjectPage = ({
           ...crumb,
           isCurrent: currentLevel === crumb.index,
           typename: crumb.index > 0 ? 'Subtopic' : 'Topic',
+          url: '#',
         }))
       : []),
   ];

--- a/src/containers/SubjectPage/SubjectContainer.jsx
+++ b/src/containers/SubjectPage/SubjectContainer.jsx
@@ -39,7 +39,7 @@ const getDocumentTitle = ({ t, data }) => {
   return `${data?.subject?.name || ''}${t('htmlTitles.titleTemplate')}`;
 };
 
-const SubjectPage = ({
+const SubjectContainer = ({
   history,
   location,
   locale,
@@ -293,16 +293,16 @@ const SubjectPage = ({
   );
 };
 
-SubjectPage.getDocumentTitle = getDocumentTitle;
+SubjectContainer.getDocumentTitle = getDocumentTitle;
 
-SubjectPage.willTrackPageView = (trackPageView, currentProps) => {
+SubjectContainer.willTrackPageView = (trackPageView, currentProps) => {
   const { data, loading, topics } = currentProps;
   if (!loading && data?.subject?.topics?.length > 0 && topics?.length === 0) {
     trackPageView(currentProps);
   }
 };
 
-SubjectPage.getDimensions = props => {
+SubjectContainer.getDimensions = props => {
   const { data, locale, location, topics } = props;
   const topicPath = topics.map(t =>
     data.subject.allTopics.find(topic => topic.id === t),
@@ -316,7 +316,7 @@ SubjectPage.getDimensions = props => {
   });
 };
 
-SubjectPage.propTypes = {
+SubjectContainer.propTypes = {
   history: PropTypes.shape({
     replace: PropTypes.func.isRequired,
   }).isRequired,
@@ -338,4 +338,4 @@ SubjectPage.propTypes = {
   loading: PropTypes.bool,
 };
 
-export default injectT(withTracker(SubjectPage));
+export default injectT(withTracker(SubjectContainer));

--- a/src/containers/SubjectPage/components/Topic.jsx
+++ b/src/containers/SubjectPage/components/Topic.jsx
@@ -16,7 +16,11 @@ import Resources from '../../Resources/Resources';
 import { toTopic } from '../../../routeHelpers';
 import { getAllDimensions } from '../../../util/trackingUtil';
 import { getSubjectBySubjectIdFilters } from '../../../data/subjects';
-import { GraphQLResourceTypeShape, GraphQLSubjectShape, GraphQLTopicShape } from '../../../graphqlShapes';
+import {
+  GraphQLResourceTypeShape,
+  GraphQLSubjectShape,
+  GraphQLTopicShape,
+} from '../../../graphqlShapes';
 
 const getDocumentTitle = ({ t, data }) => {
   return `${data?.topic?.name || ''}${t('htmlTitles.titleTemplate')}`;
@@ -70,7 +74,8 @@ const Topic = ({
             locale={locale}
             modifier="in-topic"
           />
-        }/>
+        }
+      />
       {subTopics.length !== 0 && (
         <NavigationBox
           colorMode="light"

--- a/src/containers/SubjectPage/components/Topic.jsx
+++ b/src/containers/SubjectPage/components/Topic.jsx
@@ -16,7 +16,7 @@ import Resources from '../../Resources/Resources';
 import { toTopic } from '../../../routeHelpers';
 import { getAllDimensions } from '../../../util/trackingUtil';
 import { getSubjectBySubjectIdFilters } from '../../../data/subjects';
-import { GraphQLSubjectShape, GraphQLTopicShape } from '../../../graphqlShapes';
+import { GraphQLResourceTypeShape, GraphQLSubjectShape, GraphQLTopicShape } from '../../../graphqlShapes';
 
 const getDocumentTitle = ({ t, data }) => {
   return `${data?.topic?.name || ''}${t('htmlTitles.titleTemplate')}`;
@@ -62,6 +62,7 @@ const Topic = ({
         showContent={showContent}
         invertedStyle={ndlaFilm}
         onToggleShowContent={() => setShowContent(!showContent)}
+        isLoading={false}
         children={
           <ArticleContents
             topic={topic}
@@ -69,8 +70,7 @@ const Topic = ({
             locale={locale}
             modifier="in-topic"
           />
-        }
-      />
+        }/>
       {subTopics.length !== 0 && (
         <NavigationBox
           colorMode="light"
@@ -144,7 +144,10 @@ Topic.propTypes = {
   index: PropTypes.number,
   showResources: PropTypes.bool,
   subject: GraphQLSubjectShape,
-  data: GraphQLTopicShape,
+  data: PropTypes.shape({
+    topic: GraphQLTopicShape,
+    resourceTypes: PropTypes.arrayOf(GraphQLResourceTypeShape),
+  }),
   loading: PropTypes.bool,
 };
 

--- a/src/containers/WelcomePage/WelcomePage.jsx
+++ b/src/containers/WelcomePage/WelcomePage.jsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { Fragment } from 'react';
+import React, { Fragment, useState } from 'react';
 import { HelmetWithTracker } from '@ndla/tracker';
 import PropTypes from 'prop-types';
 import {
@@ -28,7 +28,7 @@ import { getLocaleUrls } from '../../util/localeHelpers';
 import { LocationShape } from '../../shapes';
 import BlogPosts from './BlogPosts';
 import WelcomePageSearch from './WelcomePageSearch';
-import { toSubject } from '../../routeHelpers';
+import { toSubject, toTopic } from '../../routeHelpers';
 import { getSubjectById } from '../../data/subjects';
 
 const getUrlFromSubjectId = subjectId => {
@@ -37,24 +37,27 @@ const getUrlFromSubjectId = subjectId => {
   return toSubject(subject.subjectId, filters);
 };
 
+const MULTIDISCIPLINARY_SUBJECT_ID = 'common_subject_60';
+const TOOLBOX_SUBJECT_ID = 'common_subject_61';
+
 const getMultidisciplinarySubjects = locale => {
   const subjectIds = [
-    'common_subject_57',
-    'common_subject_58',
-    'common_subject_59',
+    'multidisciplinary_subject_1',
+    'multidisciplinary_subject_2',
+    'multidisciplinary_subject_3',
   ];
+
+  const baseSubject = getSubjectById(MULTIDISCIPLINARY_SUBJECT_ID);
+
   return subjectIds.map(subjectId => {
     const subject = getSubjectById(subjectId);
     return {
       id: subject.id,
       title: subject.name[locale],
-      url: getUrlFromSubjectId(subjectId),
+      url: toTopic(baseSubject.subjectId, null, subject.topicId),
     };
   });
 };
-
-const MULTIDISCIPLINARY_SUBJECT_ID = 'common_subject_60';
-const TOOLBOX_SUBJECT_ID = 'common_subject_61';
 
 const WelcomePage = ({ t, locale, history, location }) => {
   const headerLinks = [

--- a/src/containers/WelcomePage/WelcomePage.jsx
+++ b/src/containers/WelcomePage/WelcomePage.jsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { Fragment, useState } from 'react';
+import React, { Fragment } from 'react';
 import { HelmetWithTracker } from '@ndla/tracker';
 import PropTypes from 'prop-types';
 import {

--- a/src/data/subjects.js
+++ b/src/data/subjects.js
@@ -2118,6 +2118,36 @@ export const studySpecializationSubjects = [
   },
 ];
 
+export const multidisciplinarySubjects = [
+  {
+    name: {
+      nb: 'Folkehelse og livsmestring',
+      nn: 'Folkehelse og livsmestring',
+      en: 'Folkehelse og livsmestring',
+    },
+    topicId: 'urn:topic:3cdf9349-4593-498c-a899-9310133a4788',
+    id: 'multidisciplinary_subject_1',
+  },
+  {
+    name: {
+      nb: 'Demokrati og medborgerskap',
+      nn: 'Demokrati og medborgerskap',
+      en: 'Demokrati og medborgerskap',
+    },
+    topicId: 'urn:topic:077a5e01-6bb8-4c0b-b1d4-94b683d91803',
+    id: 'multidisciplinary_subject_2',
+  },
+  {
+    name: {
+      nb: 'Bærekraftig utvikling',
+      nn: 'Bærekraftig utvikling',
+      en: 'Bærekraftig utvikling',
+    },
+    topicId: 'urn:topic:a2f5aaa0-ab52-49d5-aabf-e7ffeac47fa2',
+    id: 'multidisciplinary_subject_3',
+  },
+];
+
 export const subjectsCategories = [
   {
     name: {
@@ -2153,6 +2183,7 @@ export const subjectObjectIds = () => {
       ...commonSubjects,
       ...programmeSubjects,
       ...studySpecializationSubjects,
+      ...multidisciplinarySubjects,
     ];
 
     subjectsIdx = subjects.reduce((obj, item) => {

--- a/src/gqlSchema.json
+++ b/src/gqlSchema.json
@@ -1,6 +1,5 @@
 {
   "__schema": {
-    "description": null,
     "queryType": {
       "name": "Query"
     },
@@ -1259,7 +1258,7 @@
           }
         ],
         "inputFields": null,
-        "interfaces": [],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": [
           {
@@ -4083,6 +4082,26 @@
             "deprecationReason": null
           },
           {
+            "name": "pathTopics",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Topic",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "coreResources",
             "description": "",
             "args": [
@@ -5485,7 +5504,7 @@
           }
         ],
         "inputFields": null,
-        "interfaces": [],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": [
           {
@@ -6255,18 +6274,6 @@
         "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
         "fields": [
           {
-            "name": "description",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "types",
             "description": "A list of all types supported by this server.",
             "args": [],
@@ -6363,7 +6370,7 @@
       {
         "kind": "OBJECT",
         "name": "__Type",
-        "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name, description and optional `specifiedByUrl`, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
+        "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
         "fields": [
           {
             "name": "kind",
@@ -6395,18 +6402,6 @@
           },
           {
             "name": "description",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "specifiedByUrl",
             "description": null,
             "args": [],
             "type": {
@@ -6522,18 +6517,7 @@
           {
             "name": "inputFields",
             "description": null,
-            "args": [
-              {
-                "name": "includeDeprecated",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                },
-                "defaultValue": "false"
-              }
-            ],
+            "args": [],
             "type": {
               "kind": "LIST",
               "name": null,
@@ -6590,7 +6574,7 @@
           },
           {
             "name": "INTERFACE",
-            "description": "Indicates this type is an interface. `fields`, `interfaces`, and `possibleTypes` are valid fields.",
+            "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -6663,18 +6647,7 @@
           {
             "name": "args",
             "description": null,
-            "args": [
-              {
-                "name": "includeDeprecated",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                },
-                "defaultValue": "false"
-              }
-            ],
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -6805,34 +6778,6 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
-          },
-          {
-            "name": "isDeprecated",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "deprecationReason",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -6936,22 +6881,6 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "isRepeatable",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -7552,7 +7481,6 @@
       {
         "name": "cacheControl",
         "description": "",
-        "isRepeatable": false,
         "locations": [
           "FIELD_DEFINITION",
           "OBJECT",
@@ -7584,7 +7512,6 @@
       {
         "name": "skip",
         "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
-        "isRepeatable": false,
         "locations": [
           "FIELD",
           "FRAGMENT_SPREAD",
@@ -7610,7 +7537,6 @@
       {
         "name": "include",
         "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
-        "isRepeatable": false,
         "locations": [
           "FIELD",
           "FRAGMENT_SPREAD",
@@ -7636,7 +7562,6 @@
       {
         "name": "deprecated",
         "description": "Marks an element of a GraphQL schema as no longer supported.",
-        "isRepeatable": false,
         "locations": [
           "FIELD_DEFINITION",
           "ENUM_VALUE"

--- a/src/queries.js
+++ b/src/queries.js
@@ -655,6 +655,52 @@ export const plainArticleQuery = gql`
   ${articleInfoFragment}
 `;
 
+export const topicQueryWithPathTopics = gql`
+  query topicQuery($topicId: String!, $filterIds: String, $subjectId: String) {
+    topic(id: $topicId, subjectId: $subjectId) {
+      id
+      name
+      path
+      pathTopics {
+        id
+        name
+        path
+      }
+      filters {
+        id
+        name
+      }
+      meta {
+        id
+        metaDescription
+        metaImage {
+          url
+          alt
+        }
+      }
+      subtopics(filterIds: $filterIds) {
+        id
+        name
+      }
+      article {
+        ...ArticleInfo
+      }
+      coreResources(filterIds: $filterIds, subjectId: $subjectId) {
+        ...ResourceInfo
+      }
+      supplementaryResources(filterIds: $filterIds, subjectId: $subjectId) {
+        ...ResourceInfo
+      }
+    }
+    resourceTypes {
+      id
+      name
+    }
+  }
+  ${articleInfoFragment}
+  ${resourceInfoFragment}
+`;
+
 export const topicQuery = gql`
   query topicQuery($topicId: String!, $filterIds: String, $subjectId: String) {
     topic(id: $topicId, subjectId: $subjectId) {

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -32,6 +32,7 @@ import {
   SEARCH_PATH,
   SUBJECTS,
   SUBJECT_PAGE_PATH,
+  MULTIDISCIPLINARY_SUBJECT_ARTICLE_PAGE_PATH,
 } from './constants';
 import ProgrammePage from './containers/ProgrammePage/ProgrammePage';
 
@@ -75,7 +76,7 @@ export const routes = [
     background: false,
   },
   {
-    path: `${MULTIDISCIPLINARY_SUBJECT_PAGE_PATH}/:topicId`,
+    path: MULTIDISCIPLINARY_SUBJECT_ARTICLE_PAGE_PATH,
     component: MultidisciplinarySubjectArticle,
     background: false,
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1476,10 +1476,10 @@
   dependencies:
     warning "^4.0.3"
 
-"@ndla/ui@^0.29.10":
-  version "0.29.11"
-  resolved "https://registry.yarnpkg.com/@ndla/ui/-/ui-0.29.11.tgz#04f1bcc3bb4fd4d008acd2116c142842893c9693"
-  integrity sha512-FOpffZbr4e2T8G5SvvjLR8YMYMphQIzT3+2tUpWS2UjPks+vZgWgmbDGkM66dw+6vfvglXmiADRRZarq/CIeuQ==
+"@ndla/ui@^0.30.0":
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/@ndla/ui/-/ui-0.30.0.tgz#753f19315de3586add7410e518df90f76e1c06ef"
+  integrity sha512-LMUAxW6YqRWDqjJu8NqFQ6Zc8JfMqzZPMbKJZD+4EIAdb7qE0gPDVNzCyVuGkVAy+8n+x04JXPHGarc6iGESEg==
   dependencies:
     "@ndla/button" "^0.3.43"
     "@ndla/carousel" "^0.3.32"


### PR DESCRIPTION
Fixes NDLANO/Issues#2375
~Depends on https://github.com/NDLANO/frontend-packages/pull/733~
~Depends on https://github.com/NDLANO/graphql-api/pull/130~

Endrer tverrfaglige emner til å være 2 nivå med emner og deretter emner som vises som kortene vi har i dag.
Kan testes på `/subject:d1fe9d0a-a54d-49db-a4c2-fd5463a7c9e7` url'en