### PR TITLE
#2382 søkeboks fra ndla i google

### DIFF
--- a/src/containers/WelcomePage/WelcomePage.jsx
+++ b/src/containers/WelcomePage/WelcomePage.jsx
@@ -64,9 +64,25 @@ const WelcomePage = ({ t, locale, history, location }) => {
     },
   ];
 
+  const googleSearchJSONLd = () => {
+    const data = {
+      '@context': 'https://schema.org',
+      '@type': 'WebSite',
+      url: 'https://ndla.no/',
+      potentialAction: {
+        '@type': 'SearchAction',
+        target: 'https://ndla.no/search?query={search_term_string}',
+        'query-input': 'required name=search_term_string',
+      },
+    };
+    return JSON.stringify(data);
+  };
+
   return (
     <Fragment>
-      <HelmetWithTracker title={t('htmlTitles.welcomePage')} />
+      <HelmetWithTracker title={t('htmlTitles.welcomePage')}>
+        <script type="application/ld+json">{googleSearchJSONLd()}</script>
+      </HelmetWithTracker>
       <SocialMediaMetadata
         title={t('welcomePage.heading.heading')}
         description={t('meta.description')}


### PR DESCRIPTION
Fixes NDLANO/Issues#2382

Lagt til et script for å få opp en søkeboks under søkeresultat på ndla i google (se eksempelbilde). Går så vidt jeg vet ikke an å teste lokalt, og må kanskje deployes til prod for å sjekke om det funker (correct me if im wrong🤷‍♀️). Ifølge [googles dokumentasjon](https://developers.google.com/search/docs/data-types/sitelinks-searchbox) holder det å legge til json-ld i header, men hvis noen vet at det mangler noe mer så si fra😁

Et potensielt problem: I følge [SearchEngineJournal](https://www.searchenginejournal.com/sitelinks-search-box-not-shown/365290) er det ikke garantert at en sånn søkeboks dukker opp selv om man har implementert json-ld, men det kommer an på hva Google velger (og det står også i dokumentasjonen). Per nå dukker det opp en sånn søkeboks når man søker på `ndla.no` (med sitelinks i google search som resultater), men ikke når man bare søker på `ndla`, så det er jo sannsynlig at det vil være samme oppførsel selv om vi legger til scriptet.

<img width="888" alt="Skjermbilde 2021-01-06 kl  11 03 43" src="https://user-images.githubusercontent.com/55005434/103762623-e963c880-5018-11eb-8f79-9ca90a1344f6.png">
<img width="911" alt="Skjermbilde 2021-01-06 kl  12 15 30" src="https://user-images.githubusercontent.com/55005434/103762624-eb2d8c00-5018-11eb-93fd-bd2307e5147b.png">
