### PR TITLE
add h5p-custom-css file in public folder

### DIFF
--- a/public/static/h5p-custom-css.css
+++ b/public/static/h5p-custom-css.css
@@ -1,0 +1,7 @@
+.h5p-dialogcards li{
+  text-align: left;
+}
+
+.h5p-dialogcards .h5p-dialogcards-card-text-inner {
+  padding: 0;
+}

--- a/public/static/h5p-custom-css.css
+++ b/public/static/h5p-custom-css.css
@@ -7,6 +7,14 @@
   padding: 0;
 }
 
+.h5p-dialogcards .h5p-dialogcards-card-text-inner {
+  padding: 0em 1.5em;
+}
+
+.h5p-dialogcards .h5p-dialogcards-card-text {
+  height: auto;
+}
+
 .h5p-dialogcards.h5p-text-scaling .h5p-dialogcards-card-text-wrapper {
   height: auto;
 }

--- a/public/static/h5p-custom-css.css
+++ b/public/static/h5p-custom-css.css
@@ -2,6 +2,11 @@
   text-align: left;
 }
 
-.h5p-dialogcards .h5p-dialogcards-card-text-inner {
+.h5p-dialogcards .h5p-dialogcards-card-text-wrapper {
+  min-height: auto;
   padding: 0;
+}
+
+.h5p-dialogcards.h5p-text-scaling .h5p-dialogcards-card-text-wrapper {
+  height: auto;
 }


### PR DESCRIPTION
- Issue https://github.com/NDLANO/Issues/issues/2300
- Trello https://trello.com/c/u9KIMobD/760-knowit-ed-sjekk-dialogkort-i-fagpresentasjon-den-er-altfor-h%C3%B8y

Css fil som inneholder:
- css fil for å oppdatere custom css på h5per med for høye dialogbokser.
- css for å venstrestille tekst i lister i dialogkort i h5per

Legger til custom css fil fra ndla. 
Har brukt disse for testing: http://test.ndla.no/nn/article/22668 og https://test.ndla.no/nb/article/22668
Test på h5p'er med dialogkort

Denne må merges **først** for å få testet ferdig:
* PR i ed: https://github.com/NDLANO/editorial-frontend/pull/853
* PR i article-converter: https://github.com/NDLANO/article-converter/pull/215