### PR TITLE
2399 fix mathjax rendering

### DIFF
--- a/src/containers/ArticlePage/ArticlePage.jsx
+++ b/src/containers/ArticlePage/ArticlePage.jsx
@@ -95,12 +95,6 @@ class ArticlePage extends Component {
     this.setState({ scripts, subjectPageUrl, filterIds });
   }
 
-  componentDidUpdate() {
-    if (window.MathJax) {
-      window.MathJax.typeset();
-    }
-  }
-
   render() {
     const {
       data,

--- a/src/containers/ResourcePage/ResourcePage.jsx
+++ b/src/containers/ResourcePage/ResourcePage.jsx
@@ -90,6 +90,9 @@ const ResourcePage = props => {
       />
     );
   }
+  if (typeof window !== 'undefined' && window.MathJax) {
+    window.MathJax.typeset();
+  }
   return (
     <ArticlePage
       {...props}

--- a/src/util/getStructuredDataFromArticle.js
+++ b/src/util/getStructuredDataFromArticle.js
@@ -68,6 +68,8 @@ const getPublisher = () => {
   data.publisher = {
     '@type': ORGANIZATION_TYPE,
     name: 'NDLA',
+    url: 'https://ndla.no',
+    logo: 'https://ndla.no/static/logo.png',
   };
   return data;
 };


### PR DESCRIPTION
Fixes NDLANO/Issues#2399

Matteformler skal formateres når artikkelen vises, men det ser ut som om dette ikkje alltid fungerer som det skal. I prod kan du gå på [denne sida](https://ndla.no/subject:32/topic:1:165808/topic:1:165816/resource:1:111123?filters=urn:filter:fbdf693f-58d7-448e-ad5b-5d5c8fb685f3) og få formatert matte ok. Scroll ned til launchpad og klikk på lenka "Den deriverte av et produkt av to funksjoner". Sida vil av og til feile med oops-melding og det er fordi window.MathJax er definert men i nokre tilfeller uten metoden typeset.

