### PR TITLE
wip fikse css for forklarings iframe

### DIFF
--- a/public/static/h5p-custom-css.css
+++ b/public/static/h5p-custom-css.css
@@ -1,3 +1,7 @@
+.h5p-content .h5p-wrapper{
+  max-width:100%;
+}
+
 .h5p-dialogcards li{
   text-align: left;
 }


### PR DESCRIPTION
Sjekker om det funker å tilpasse custom css for h5p for å fikse at innholdet i iframes blir for bred i ed