### PR TITLE
Fjerner card fra url fordi om du går til case via meny så feiler det

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -44,4 +44,4 @@ export const MULTIDISCIPLINARY_SUBJECT_PAGE_PATH =
   '/subject\\::subjectId(d1fe9d0a-a54d-49db-a4c2-fd5463a7c9e7)/:topicPath*/';
 
 export const MULTIDISCIPLINARY_SUBJECT_ARTICLE_PAGE_PATH =
-  '/subject\\::subjectId(d1fe9d0a-a54d-49db-a4c2-fd5463a7c9e7)/:topicPath*/card';
+  '/subject\\::subjectId(d1fe9d0a-a54d-49db-a4c2-fd5463a7c9e7)/topic\\::topic1/topic\\::topic2/:topicId';

--- a/src/containers/MultidisciplinarySubject/MultidisciplinarySubjectPage.jsx
+++ b/src/containers/MultidisciplinarySubject/MultidisciplinarySubjectPage.jsx
@@ -67,7 +67,7 @@ const MultidisciplinarySubjectPage = ({ match, history, location, locale }) => {
           image: topic.meta.metaImage?.url,
           imageAlt: topic.meta.metaImage?.alt,
           subjects: [selectedSubject.name],
-          url: `${topic.path}/card`,
+          url: topic.path,
           ...topic,
         }));
 

--- a/src/data/subjects.js
+++ b/src/data/subjects.js
@@ -888,11 +888,7 @@ export const commonSubjects = [
     id: 'common_subject_59',
   },
   {
-    filters: [
-      'urn:filter:7ab1cc5c-4f79-4bb4-b1ab-bef7c41aed66',
-      'urn:filter:3645d7c4-63af-469a-a502-38e53d03d6c7',
-      'urn:filter:1e3b4fd0-3245-42b5-8685-db02c5592acc',
-    ],
+    filters: [],
     longName: {
       en: 'Tverrfaglige tema',
       nb: 'Tverrfaglige tema',


### PR DESCRIPTION
Om du går på side for tverrfaglige tema og manuvrerer deg til en case via menyen så mister du /card fra urlen og dermed vises ikkje caset som det skal. Denne endringa tvinger gjennom at emne på tredje nivå alltid vises som case.

Test: Gå på side for tverrfaglige tema. Bruk Innhold-knappen og naviger fram til emne på tredje nivå. Du skal få opp case-visning. 