### PR TITLE
Forcing scroll to top when showing resource

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -111,8 +111,8 @@ function shouldScrollToTop(location, prevLocation) {
   const subjectMatch = matchPath(location.pathname, SUBJECT_PAGE_PATH);
   if (subjectMatch?.isExact) {
     return (
-      !subjectMatch?.params?.topics ||
-      subjectMatch?.params?.topics?.includes('resource:')
+      !subjectMatch?.params?.topicPath ||
+      subjectMatch?.params?.topicPath?.includes('resource:')
     );
   }
   return true;

--- a/src/containers/ResourcePage/ResourcePage.jsx
+++ b/src/containers/ResourcePage/ResourcePage.jsx
@@ -72,6 +72,9 @@ const ResourcePage = props => {
   if (!data.resource) {
     return <NotFoundPage />;
   }
+  if (typeof window != 'undefined' && window.scrollY) {
+    window.scroll(0, 0);
+  }
   const { subject, resource, topic } = data;
   const relevanceId = resource.filters?.find(f => f.id === filters?.[0])
     ?.relevanceId;

--- a/src/server/contentSecurityPolicy.js
+++ b/src/server/contentSecurityPolicy.js
@@ -151,7 +151,7 @@ export default {
       'https://optimize.google.com',
       'https://www.youtube.com',
       'ndla.no',
-      'https://*.ndlah5p.com',
+      '*.ndlah5p.com',
       'https://h5p.org',
       '*.ndla.no',
       '*.slideshare.net',

--- a/src/server/contentSecurityPolicy.js
+++ b/src/server/contentSecurityPolicy.js
@@ -142,6 +142,7 @@ export default {
     defaultSrc: ["'self'", 'blob:'],
     scriptSrc,
     frameSrc: [
+      'blob:',
       '*.nrk.no',
       'nrk.no',
       '*.vg.no',


### PR DESCRIPTION
Forsøker å fikse problemet med vindusposisjon etter å ha gått fra søkeresultat til ressurs.

Dersom du søker på ny søkeside og scroller litt ned og finner et søketreff som har fleire kontekster, så kan du klikke på  "+3 flere steder" og så velge en av lenkene i dialogen. Då kjem du til artikkelen med sida scrolla til toppen. Dersom du så bruker tilbakeknappen og velger akkurat samme lenka i dialog, så kjem du til samme sida men scrolla like langt ned som du var på søkesida.

Endringa går på at ved visning av ressurs, så sendes du til toppen dersom du er scrolla ned på sida. Sikkert ikkje optimal løsning, så kom gjerne med bedre forslag.