### PR TITLE
2432: Increasing padding for h5p-dialogcards-card-text-inner

### DIFF
--- a/public/static/h5p-custom-css.css
+++ b/public/static/h5p-custom-css.css
@@ -8,7 +8,7 @@
 }
 
 .h5p-dialogcards .h5p-dialogcards-card-text-inner {
-  padding: 0em 1.5em;
+  padding: 3em 1.5em;
 }
 
 .h5p-dialogcards .h5p-dialogcards-card-text {
@@ -18,3 +18,4 @@
 .h5p-dialogcards.h5p-text-scaling .h5p-dialogcards-card-text-wrapper {
   height: auto;
 }
+


### PR DESCRIPTION
Fixes NDLANO/Issues#2432
Øker padding på tekst i h5p kort slik at tekst ikke skjules bak bilder.

Før:
![image](https://user-images.githubusercontent.com/43534577/107646682-85b56680-6c7a-11eb-8722-66a064a02a15.png)

Etter:
![image](https://user-images.githubusercontent.com/43534577/107646709-8fd76500-6c7a-11eb-9258-6b38a57626c4.png)
