### PR TITLE
Replace fixed with relative to give div height

### DIFF
--- a/public/static/h5p-custom-css.css
+++ b/public/static/h5p-custom-css.css
@@ -1,4 +1,4 @@
-.h5p-dialogcards li{
+.h5p-dialogcards li {
   text-align: left;
 }
 
@@ -7,8 +7,13 @@
   padding: 0;
 }
 
-.h5p-dialogcards .h5p-dialogcards-card-text-inner {
+.h5p-dialogcards .h5p-dialogcards-card-text-inner {
   padding: 3em 1.5em;
+  position: relative;
+}
+
+.h5p-dialogcards .h5p-dialogcards-card-text-inner-content {
+  position: relative;
 }
 
 .h5p-dialogcards .h5p-dialogcards-card-text {
@@ -18,4 +23,3 @@
 .h5p-dialogcards.h5p-text-scaling .h5p-dialogcards-card-text-wrapper {
   height: auto;
 }
-


### PR DESCRIPTION
dialogkort har en posisjonering fixed som gjør at diven har en høgde 0, så derfor klarer ikkje innholdet å bli vist som tidligere.
Overstyrer posisjoneringa til relative

Før:
![image](https://user-images.githubusercontent.com/8956884/109475403-f976b200-7a75-11eb-9d49-38cc5ed9a75a.png)

Etter:
![image](https://user-images.githubusercontent.com/8956884/109475428-00052980-7a76-11eb-9c56-61e7d411200f.png)
