### PR TITLE
Bruker resource.path for standard søketreff

### DIFF
--- a/src/containers/SearchPage/searchHelpers.js
+++ b/src/containers/SearchPage/searchHelpers.js
@@ -293,7 +293,7 @@ const mapResourcesToItems = (resources, ltiData, isLti, t) =>
     url: isLti
       ? getLtiUrl(resource.path, resource.id)
       : resource.contexts?.length
-      ? getContextUrl(resource.contexts[0])
+      ? resource.path
       : plainUrl(resource.path),
     labels: [
       ...mapTraits(resource.traits, t),


### PR DESCRIPTION
I graphql-api settes resource.path til den konteksten som er gitt dersom det er valgt ett fag som søkeparameter til spørringa. Men i ndla-frontend har vi berre vist den første konteksten alltid som hovedurl. Denne endringa gjør at koden i graphql-api ikkje lenger ignoreres men benyttes for å vise lenke til en kontekst i det faget du har valgt i søket.

Test:
Gjør et tomt søk og sjå etter et treff med fleire paths: "+ x flere steder". Sjekk at hovedurl er det samme som den første i lista over ekstra steder. Finn en kontekst litt ned i lista og velg dette faget som filterparameter i søket og sjekk at treffet fremdeles vises. Men no skal hovedurlen være til det faget du nettopp valgte som filter.