### PR TITLE
Option to show/hide ingress in ArticleContents

### DIFF
--- a/src/components/Article/ArticleContents.jsx
+++ b/src/components/Article/ArticleContents.jsx
@@ -29,6 +29,7 @@ const ArticleContents = ({
   copyPageUrlLink,
   locale,
   modifier = 'clean',
+  showIngress,
   t,
 }) => {
   const markdown = useMemo(() => {
@@ -46,13 +47,15 @@ const ArticleContents = ({
 
   return (
     <ArticleWrapper modifier={modifier}>
-      <LayoutItem layout="extend">
-        <ArticleHeaderWrapper>
-          <ArticleIntroduction renderMarkdown={renderMarkdown}>
-            {article.introduction}
-          </ArticleIntroduction>
-        </ArticleHeaderWrapper>
-      </LayoutItem>
+      {showIngress && (
+        <LayoutItem layout="extend">
+          <ArticleHeaderWrapper>
+            <ArticleIntroduction renderMarkdown={renderMarkdown}>
+              {article.introduction}
+            </ArticleIntroduction>
+          </ArticleHeaderWrapper>
+        </LayoutItem>
+      )}
       <LayoutItem layout="extend">
         <ArticleContent content={article.content} />
       </LayoutItem>
@@ -81,6 +84,7 @@ ArticleContents.propTypes = {
   copyPageUrlLink: PropTypes.string,
   locale: PropTypes.string,
   modifier: PropTypes.string,
+  showIngress: PropTypes.bool,
 };
 
 export default injectT(ArticleContents);

--- a/src/containers/MultidisciplinarySubject/components/MultidisciplinaryTopic.jsx
+++ b/src/containers/MultidisciplinarySubject/components/MultidisciplinaryTopic.jsx
@@ -69,6 +69,7 @@ const MultidisciplinaryTopic = ({
           copyPageUrlLink={copyPageUrlLink}
           locale={locale}
           modifier="in-topic"
+          showIngress={false}
         />
       </NavigationTopicAbout>
       {subTopics.length !== 0 && disableNav !== true && (

--- a/src/containers/SubjectPage/components/Topic.jsx
+++ b/src/containers/SubjectPage/components/Topic.jsx
@@ -73,6 +73,7 @@ const Topic = ({
             copyPageUrlLink={copyPageUrlLink}
             locale={locale}
             modifier="in-topic"
+            showIngress={false}
           />
         }
       />


### PR DESCRIPTION
Fixes NDLANO/Issues#2505

Legger til mulighet for å skjule ingress i ArticleContents. Som beskrevet i issuet vises denne to ganger.

Eksempel på hvordan det ser ut i [test](https://test.ndla.no/nb/subject:39/topic:1:189087?filters=urn:filter:4ad7fe49-b14a-4caf-8e19-ad402d1e2ce6). Når man trykket på "Les emnebeskrivelse" kan man se ingress både ovenfor knappen og i innholdet som dukket opp.

Hvordan teste:
1. https://ndla-frontend-pr-659.ndla.sh
2. Åpne et emne, feks https://ndla-frontend-pr-659.ndla.sh/subject:39/topic:1:189087?filters=urn:filter:4ad7fe49-b14a-4caf-8e19-ad402d1e2ce6
2. Trykk på "Les emnebeskrivelse"
3. Ingress skal ikke dukke i innholdet.