### PR TITLE
Bugfix forslag til søkeord

### DIFF
--- a/src/containers/WelcomePage/WelcomePageSearch.jsx
+++ b/src/containers/WelcomePage/WelcomePageSearch.jsx
@@ -95,7 +95,7 @@ const WelcomePageSearch = ({ t, history, locale }) => {
       loading={loading}
       resourceToLinkProps={searchResultToLinkProps}
       history={history}
-      suggestion={suggestion}
+      suggestion={searchResult && delayedSearchQuery.length >= 2 && suggestion}
       suggestionUrl={suggestionUrl}
     />
   );

--- a/src/queries.js
+++ b/src/queries.js
@@ -263,6 +263,7 @@ export const frontpageSearchQuery = gql`
           suggestions {
             options {
               text
+              score
             }
           }
         }
@@ -286,6 +287,7 @@ export const frontpageSearchQuery = gql`
           suggestions {
             options {
               text
+              score
             }
           }
         }

--- a/src/util/searchHelpers.js
+++ b/src/util/searchHelpers.js
@@ -49,16 +49,12 @@ export const frontPageSearchSuggestion = searchResult => {
     frontpageSearch: { learningResources, topicResources },
   } = searchResult;
 
-  const suggestions = learningResources.suggestions.concat(
-    topicResources.suggestions,
-  );
-
-  return suggestions.find(s => {
-    if (s?.suggestions?.[0]?.options?.[0]?.text) {
-      return true;
-    }
-    return false;
-  })?.suggestions?.[0]?.options?.[0]?.text;
+  const suggestions = learningResources.suggestions
+    .concat(topicResources.suggestions)
+    .map(s => s?.suggestions?.[0]?.options?.[0])
+    .filter(s => !!s)
+    .sort((a, b) => b.score - a.score);
+  return suggestions[0]?.text;
 };
 
 export const mapSearchToFrontPageStructure = (data, t, query, locale) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1550,11 +1550,6 @@
   resolved "https://registry.yarnpkg.com/@ndla/icons/-/icons-0.7.2.tgz#956325b49114b4bcf31adaa2d4820a828c6a00a7"
   integrity sha512-5tsJLY5Igx1dlk9SNEGlSyY03nWRoxUVzFNxPuK+1w7ZonQdzcBFlE78uYB8zI/zwq9Hig8MWnDX2jdCFEdbSw==
 
-"@ndla/icons@^0.7.2":
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/@ndla/icons/-/icons-0.7.2.tgz#956325b49114b4bcf31adaa2d4820a828c6a00a7"
-  integrity sha512-5tsJLY5Igx1dlk9SNEGlSyY03nWRoxUVzFNxPuK+1w7ZonQdzcBFlE78uYB8zI/zwq9Hig8MWnDX2jdCFEdbSw==
-
 "@ndla/licenses@^0.6.42":
   version "0.6.42"
   resolved "https://registry.yarnpkg.com/@ndla/licenses/-/licenses-0.6.42.tgz#479073304381d9ec2edcd14c66ee4e4748cf747b"


### PR DESCRIPTION
Fikser bugs relatert til NDLANO/Issues#2499

1. Forslag til søkeord fra tidligere søk hang igjen. Dette gjaldt spesielt dersom man søkte på et ord, lukket søket med escape-knappen og deretter gjorde et nytt søk. Da var det gamle forslaget til søkeord synlig et kort øyeblikk.
2. Forslag til søkeord vil nå alltid være forslaget som har høyest score.

Jeg så på muligheten til å droppe å vise søkeord dersom forslagene har for lav score, men dette fungerte ikke optimalt. Scoren på ordene som foreslås er generelt høy dersom det søkes på et enkeltord, og blir mye lavere dersom det søkes på flere ord. Resultatet blir i så fall at man ender opp med å kutte forslag på mesteparten av søk bestående av to eller flere ord.