### PR TITLE
Using new isOembed param. But not for plain article page.

### DIFF
--- a/src/containers/ArticlePage/articleApi.js
+++ b/src/containers/ArticlePage/articleApi.js
@@ -21,10 +21,10 @@ const converterBaseUrl = (() => {
 
 const baseUrl = apiResourceUrl('/article-api/v2/articles');
 
-export const fetchArticle = (id, locale, removeRelatedContent = false) =>
-  fetch(
-    `${converterBaseUrl}/${locale}/${id}?removeRelatedContent=${removeRelatedContent}`,
-  ).then(resolveJsonOrRejectWithError);
+export const fetchArticle = (id, locale, isOembed = false) =>
+  fetch(`${converterBaseUrl}/${locale}/${id}?isOembed=${isOembed}`).then(
+    resolveJsonOrRejectWithError,
+  );
 
 export const fetchArticles = ids =>
   fetch(`${baseUrl}?ids=${ids.join(',')}`).then(resolveJsonOrRejectWithError);

--- a/src/containers/PlainArticlePage/PlainArticlePage.jsx
+++ b/src/containers/PlainArticlePage/PlainArticlePage.jsx
@@ -40,7 +40,7 @@ const PlainArticlePage = ({
   },
 }) => {
   const { loading, data } = useGraphQuery(plainArticleQuery, {
-    variables: { articleId, removeRelatedContent: 'true' },
+    variables: { articleId, isOembed: 'false' },
   });
 
   useEffect(() => {

--- a/src/gqlSchema.json
+++ b/src/gqlSchema.json
@@ -109,6 +109,18 @@
                 "defaultValue": null,
                 "isDeprecated": false,
                 "deprecationReason": null
+              },
+              {
+                "name": "isOembed",
+                "description": "",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
               }
             ],
             "type": {
@@ -9044,7 +9056,11 @@
         "name": "cacheControl",
         "description": "",
         "isRepeatable": false,
-        "locations": ["FIELD_DEFINITION", "OBJECT", "INTERFACE"],
+        "locations": [
+          "FIELD_DEFINITION",
+          "OBJECT",
+          "INTERFACE"
+        ],
         "args": [
           {
             "name": "maxAge",
@@ -9076,7 +9092,11 @@
         "name": "skip",
         "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
         "isRepeatable": false,
-        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
+        "locations": [
+          "FIELD",
+          "FRAGMENT_SPREAD",
+          "INLINE_FRAGMENT"
+        ],
         "args": [
           {
             "name": "if",
@@ -9100,7 +9120,11 @@
         "name": "include",
         "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
         "isRepeatable": false,
-        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
+        "locations": [
+          "FIELD",
+          "FRAGMENT_SPREAD",
+          "INLINE_FRAGMENT"
+        ],
         "args": [
           {
             "name": "if",
@@ -9124,7 +9148,10 @@
         "name": "deprecated",
         "description": "Marks an element of a GraphQL schema as no longer supported.",
         "isRepeatable": false,
-        "locations": ["FIELD_DEFINITION", "ENUM_VALUE"],
+        "locations": [
+          "FIELD_DEFINITION",
+          "ENUM_VALUE"
+        ],
         "args": [
           {
             "name": "reason",

--- a/src/gqlSchema.json
+++ b/src/gqlSchema.json
@@ -8668,6 +8668,22 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "paths",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -9028,11 +9044,7 @@
         "name": "cacheControl",
         "description": "",
         "isRepeatable": false,
-        "locations": [
-          "FIELD_DEFINITION",
-          "OBJECT",
-          "INTERFACE"
-        ],
+        "locations": ["FIELD_DEFINITION", "OBJECT", "INTERFACE"],
         "args": [
           {
             "name": "maxAge",
@@ -9064,11 +9076,7 @@
         "name": "skip",
         "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
         "isRepeatable": false,
-        "locations": [
-          "FIELD",
-          "FRAGMENT_SPREAD",
-          "INLINE_FRAGMENT"
-        ],
+        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
         "args": [
           {
             "name": "if",
@@ -9092,11 +9100,7 @@
         "name": "include",
         "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
         "isRepeatable": false,
-        "locations": [
-          "FIELD",
-          "FRAGMENT_SPREAD",
-          "INLINE_FRAGMENT"
-        ],
+        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
         "args": [
           {
             "name": "if",
@@ -9120,10 +9124,7 @@
         "name": "deprecated",
         "description": "Marks an element of a GraphQL schema as no longer supported.",
         "isRepeatable": false,
-        "locations": [
-          "FIELD_DEFINITION",
-          "ENUM_VALUE"
-        ],
+        "locations": ["FIELD_DEFINITION", "ENUM_VALUE"],
         "args": [
           {
             "name": "reason",

--- a/src/iframe/IframePage.jsx
+++ b/src/iframe/IframePage.jsx
@@ -42,11 +42,11 @@ export const IframePage = ({
   resourceTypes,
   location,
   articleId,
-  removeRelatedContent,
+  isOembed,
   isTopicArticle,
 }) => {
   const { error, loading, data } = useGraphQuery(plainArticleQuery, {
-    variables: { articleId, removeRelatedContent },
+    variables: { articleId, isOembed },
   });
 
   if (status !== 'success' || error) {
@@ -87,7 +87,7 @@ IframePage.propTypes = {
   location: PropTypes.shape({
     pathname: PropTypes.string,
   }),
-  removeRelatedContent: PropTypes.string,
+  isOembed: PropTypes.string,
   isTopicArticle: PropTypes.bool,
 };
 

--- a/src/iframe/IframePageContainer.jsx
+++ b/src/iframe/IframePageContainer.jsx
@@ -20,7 +20,7 @@ const IframePageContainer = ({
   resourceTypes,
   location,
   articleId,
-  removeRelatedContent,
+  isOembed,
   isTopicArticle,
 }) => (
   <IframePageWrapper basename={basename} locale={locale}>
@@ -30,7 +30,7 @@ const IframePageContainer = ({
       resourceTypes={resourceTypes}
       location={location}
       articleId={articleId}
-      removeRelatedContent={removeRelatedContent}
+      isOembed={isOembed}
       isTopicArticle={isTopicArticle}
     />
   </IframePageWrapper>
@@ -48,7 +48,7 @@ IframePageContainer.propTypes = {
   location: PropTypes.shape({
     pathname: PropTypes.string,
   }),
-  removeRelatedContent: PropTypes.string,
+  isOembed: PropTypes.string,
   isTopicArticle: PropTypes.bool,
 };
 

--- a/src/iframe/__tests__/IframeArticlePage-test.js
+++ b/src/iframe/__tests__/IframeArticlePage-test.js
@@ -93,13 +93,13 @@ test('IframePage with article displays error message on status === error', () =>
 
 test('fetchResourceId fetches correct resource id from path', () => {
   const url =
-    'https://ndla.no/article-iframe/urn:resource:670ac97d-1d4d-4515-9554-07e0870e66aa/24835?removeRelatedContent=true';
+    'https://ndla.no/article-iframe/urn:resource:670ac97d-1d4d-4515-9554-07e0870e66aa/24835';
   expect(fetchResourceId({ location: { pathname: url } })).toMatch(
     'urn:resource:670ac97d-1d4d-4515-9554-07e0870e66aa',
   );
 
   const urlWithLang =
-    'https://ndla.no/article-iframe/nb/urn:resource:670ac97d-1d4d-4515-9554-07e0870e66aa/24835?removeRelatedContent=true';
+    'https://ndla.no/article-iframe/nb/urn:resource:670ac97d-1d4d-4515-9554-07e0870e66aa/24835';
   expect(fetchResourceId({ location: { pathname: urlWithLang } })).toMatch(
     'urn:resource:670ac97d-1d4d-4515-9554-07e0870e66aa',
   );

--- a/src/lti/components/LtiBasicLaunch.jsx
+++ b/src/lti/components/LtiBasicLaunch.jsx
@@ -59,7 +59,7 @@ const getQuery = (ltiData, item) => {
       ? 'http://localhost:3000'
       : config.ndlaFrontendDomain;
   const query = {
-    url: `${baseUrl}/article-iframe/article/${item.id}?removeRelatedContent=true`,
+    url: `${baseUrl}/article-iframe/article/${item.id}`,
     title: item.title,
     return_type: getReturnType(ltiData),
     width: ltiData.launch_presentation_width,

--- a/src/lti/components/LtiDeepLinking.jsx
+++ b/src/lti/components/LtiDeepLinking.jsx
@@ -33,7 +33,7 @@ const getLtiPostData = async (ltiData, item = {}) => {
     config.ndlaEnvironment === 'dev'
       ? 'http://localhost:3000'
       : config.ndlaFrontendDomain;
-  const iframeurl = `${baseUrl}/article-iframe/article/${item.id}?removeRelatedContent=true`;
+  const iframeurl = `${baseUrl}/article-iframe/article/${item.id}`;
   const postData = {
     oauth_callback: ltiData.oauth_callback || '',
     oauth_consumer_key: ltiData.oauth_consumer_key || 'key',

--- a/src/queries.js
+++ b/src/queries.js
@@ -741,8 +741,8 @@ export const movedResourceQuery = gql`
 `;
 
 export const plainArticleQuery = gql`
-  query plainArticleQuery($articleId: String!, $removeRelatedContent: String) {
-    article(id: $articleId, removeRelatedContent: $removeRelatedContent) {
+  query plainArticleQuery($articleId: String!, $isOembed: String) {
+    article(id: $articleId, isOembed: $isOembed) {
       ...ArticleInfo
     }
   }

--- a/src/server/routes/__tests__/__snapshots__/oembedArticleRoute-test.js.snap
+++ b/src/server/routes/__tests__/__snapshots__/oembedArticleRoute-test.js.snap
@@ -11,7 +11,7 @@ exports[`oembedArticleRoute success 1`] = `
 Object {
   "data": Object {
     "height": 800,
-    "html": "<iframe aria-label=\\"Resource title\\" src=\\"https://test.ndla.no/article-iframe/nb/urn:resource:1/123?removeRelatedContent=true\\" frameborder=\\"0\\" allowFullscreen=\\"\\" />",
+    "html": "<iframe aria-label=\\"Resource title\\" src=\\"https://test.ndla.no/article-iframe/nb/urn:resource:1/123\\" frameborder=\\"0\\" allowFullscreen=\\"\\" />",
     "title": "Resource title",
     "type": "rich",
     "version": "1.0",
@@ -24,7 +24,7 @@ exports[`oembedArticleRoute success 2`] = `
 Object {
   "data": Object {
     "height": 800,
-    "html": "<iframe aria-label=\\"Resource title\\" src=\\"https://test.ndla.no/article-iframe/nb/urn:resource:1/123?removeRelatedContent=true\\" frameborder=\\"0\\" allowFullscreen=\\"\\" />",
+    "html": "<iframe aria-label=\\"Resource title\\" src=\\"https://test.ndla.no/article-iframe/nb/urn:resource:1/123\\" frameborder=\\"0\\" allowFullscreen=\\"\\" />",
     "title": "Resource title",
     "type": "rich",
     "version": "1.0",

--- a/src/server/routes/__tests__/iframeArticleRoute-test.js
+++ b/src/server/routes/__tests__/iframeArticleRoute-test.js
@@ -28,7 +28,6 @@ jest.mock('../../../iframe/IframePage', () =>
 test('iframeArticleRoute 200 OK', async () => {
   nock('http://ndla-api')
     .get('/article-converter/json/nb/26050')
-    .query({ removeRelatedContent: true })
     .reply(200, {
       id: 123,
       title: 'unit test',
@@ -44,9 +43,6 @@ test('iframeArticleRoute 200 OK', async () => {
       articleId: '26050',
       taxonomyId: 'urn:resource:123',
     },
-    query: {
-      removeRelatedContent: true,
-    },
     headers: {
       'user-agent': 'Mozilla/5.0 Gecko/20100101 Firefox/58.0',
     },
@@ -58,7 +54,6 @@ test('iframeArticleRoute 200 OK', async () => {
 test('iframeArticleRoute 500 Internal server error', async () => {
   nock('http://ndla-api')
     .get('/article-converter/json/nb/26050')
-    .query({ removeRelatedContent: true })
     .replyWithError('something awful happened');
 
   const response = await iframeArticleRoute({
@@ -66,9 +61,6 @@ test('iframeArticleRoute 500 Internal server error', async () => {
       lang: 'nb',
       articleId: '26050',
       taxonomyId: '123',
-    },
-    query: {
-      removeRelatedContent: true,
     },
     headers: {
       'user-agent': 'Mozilla/5.0 Gecko/20100101 Firefox/58.0',

--- a/src/server/routes/iframeArticleRoute.js
+++ b/src/server/routes/iframeArticleRoute.js
@@ -53,10 +53,6 @@ async function doRenderPage(initialProps) {
 
 export async function iframeArticleRoute(req) {
   const lang = defined(req.params.lang, '');
-  const removeRelatedContent = defined(
-    req.query.removeRelatedContent,
-    false,
-  ).toString();
   const htmlLang = getHtmlLang(lang);
   const locale = getLocaleObject(htmlLang);
   const { articleId, taxonomyId } = req.params;
@@ -67,7 +63,7 @@ export async function iframeArticleRoute(req) {
         basename: lang,
         locale,
         articleId,
-        removeRelatedContent,
+        isOembed: 'true',
         isTopicArticle: true,
         status: 'success',
         location,
@@ -81,7 +77,7 @@ export async function iframeArticleRoute(req) {
     const { html, docProps } = await doRenderPage({
       resourceTypes,
       articleId,
-      removeRelatedContent,
+      isOembed: 'true',
       basename: lang,
       locale,
       status: 'success',

--- a/src/server/routes/oembedArticleRoute.ts
+++ b/src/server/routes/oembedArticleRoute.ts
@@ -54,7 +54,7 @@ const getHTMLandTitle = async (match: RouterMatchType<MatchParams>) => {
     const articleId = getArticleIdFromResource(topic);
     return {
       title: topic.name,
-      html: `<iframe aria-label="${topic.name}" src="${config.ndlaFrontendDomain}/article-iframe/${lang}/${topic.id}/${articleId}?removeRelatedContent=true" frameborder="0" allowFullscreen="" />`,
+      html: `<iframe aria-label="${topic.name}" src="${config.ndlaFrontendDomain}/article-iframe/${lang}/${topic.id}/${articleId}" frameborder="0" allowFullscreen="" />`,
     };
   }
 
@@ -62,7 +62,7 @@ const getHTMLandTitle = async (match: RouterMatchType<MatchParams>) => {
   const articleId = getArticleIdFromResource(resource);
   return {
     title: resource.name,
-    html: `<iframe aria-label="${resource.name}" src="${config.ndlaFrontendDomain}/article-iframe/${lang}/${resource.id}/${articleId}?removeRelatedContent=true" frameborder="0" allowFullscreen="" />`,
+    html: `<iframe aria-label="${resource.name}" src="${config.ndlaFrontendDomain}/article-iframe/${lang}/${resource.id}/${articleId}" frameborder="0" allowFullscreen="" />`,
   };
 };
 
@@ -95,7 +95,7 @@ export async function oembedArticleRoute(req: express.Request) {
       return getOembedObject(
         req,
         article.title,
-        `<iframe aria-label="${article.title}" src="${config.ndlaFrontendDomain}/article-iframe/${lang}/article/${articleId}?removeRelatedContent=true" frameborder="0" allowFullscreen="" />`,
+        `<iframe aria-label="${article.title}" src="${config.ndlaFrontendDomain}/article-iframe/${lang}/article/${articleId}" frameborder="0" allowFullscreen="" />`,
       );
     }
     const { html, title } = await getHTMLandTitle(match);


### PR DESCRIPTION
Fixes NDLANO/Issues#2566
Depends on https://github.com/NDLANO/graphql-api/pull/156

Vil alltid vise oembed-versjon på iframe-urler. Treng ikkje ha med ekstra parameter fordi iframe _er_ oembed,