### PR TITLE
2567 utvide visning av oembed artikler i læringssteg

### DIFF
--- a/src/components/Learningpath/Learningpath.jsx
+++ b/src/components/Learningpath/Learningpath.jsx
@@ -31,6 +31,7 @@ import {
   BreadCrumbShape,
   LearningpathShape,
   LearningpathStepShape,
+  LocationShape,
   ResourceShape,
   ResourceTypeShape,
   SubjectShape,
@@ -230,7 +231,7 @@ Learningpath.propTypes = {
   resource: ResourceShape,
   skipToContentId: PropTypes.string,
   locale: PropTypes.string.isRequired,
-  location: PropTypes.string,
+  location: LocationShape,
   ndlaFilm: PropTypes.bool.isRequired,
   history: PropTypes.shape({
     push: PropTypes.func.isRequired,

--- a/src/components/Learningpath/LearningpathEmbed.jsx
+++ b/src/components/Learningpath/LearningpathEmbed.jsx
@@ -104,6 +104,6 @@ LearningpathEmbed.propTypes = {
   topic: TopicShape,
   skipToContentId: PropTypes.string,
   locale: PropTypes.string.isRequired,
-  breadcrumbItems: BreadCrumbShape,
+  breadcrumbItems: PropTypes.arrayOf(BreadCrumbShape),
 };
 export default LearningpathEmbed;

--- a/src/components/Learningpath/LearningpathEmbed.jsx
+++ b/src/components/Learningpath/LearningpathEmbed.jsx
@@ -9,7 +9,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
-import parse from 'html-react-parser';
 import { spacing } from '@ndla/core';
 import styled from '@emotion/styled';
 import Article from '../Article';
@@ -19,6 +18,7 @@ import { getArticleScripts } from '../../util/getArticleScripts';
 import getStructuredDataFromArticle from '../../util/getStructuredDataFromArticle';
 import { getArticleProps } from '../../util/getArticleProps';
 import { BreadCrumbShape, TopicShape } from '../../shapes';
+import LearningpathIframe from './LearningpathIframe';
 
 const StyledIframeContainer = styled.div`
   margin-bottom: ${spacing.normal};
@@ -57,7 +57,7 @@ const LearningpathEmbed = ({
       <StyledIframeContainer
         oembedWidth={oembed.width}
         oembedHeight={oembed.height}>
-        {parse(oembed.html)}
+        <LearningpathIframe html={oembed.html} url={embedUrl.url} />
       </StyledIframeContainer>
     );
   }

--- a/src/components/Learningpath/LearningpathIframe.tsx
+++ b/src/components/Learningpath/LearningpathIframe.tsx
@@ -38,7 +38,7 @@ const LearningpathIframe = ({ html, url }: Props) => {
 
   useEffect(() => {
     handleIframeResizing(url);
-  }, [url, iframeRef]);
+  });
 
   const getIframeDOM = () => {
     return iframeRef.current?.children[0] as HTMLIFrameElement;

--- a/src/components/Learningpath/LearningpathIframe.tsx
+++ b/src/components/Learningpath/LearningpathIframe.tsx
@@ -8,6 +8,7 @@
 
 import React from 'react';
 import get from 'lodash/get';
+import parse from 'html-react-parser';
 
 export const urlIsNDLAApiUrl = (url: string) =>
   /^(http|https):\/\/(ndla-frontend|www).([a-zA-Z]+.)?api.ndla.no/.test(url);
@@ -135,11 +136,11 @@ export default class LearningpathIframe extends React.Component<Props, State> {
 
     return (
       <div
-        dangerouslySetInnerHTML={{ __html: html }}
         ref={iframeDiv => {
           this._iframeDiv = iframeDiv;
-        }}
-      />
+        }}>
+        {parse(html)}
+      </div>
     );
   }
 }

--- a/src/components/Learningpath/LearningpathIframe.tsx
+++ b/src/components/Learningpath/LearningpathIframe.tsx
@@ -1,12 +1,12 @@
 /**
- * Copyright (c) 2016-present, NDLA.
+ * Copyright (c) 2021-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.
  *
  */
 
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import get from 'lodash/get';
 import parse from 'html-react-parser';
 
@@ -24,64 +24,38 @@ interface Props {
   url: string;
 }
 
-interface State {
-  listeningToMessages: boolean;
-}
+const LearningpathIframe = ({ html, url }: Props) => {
+  const iframeRef = useRef() as React.MutableRefObject<HTMLInputElement>;
+  const [listeningToMessages, setListeningToMessages] = useState(true);
 
-export default class LearningpathIframe extends React.Component<Props, State> {
-  private _iframeDiv: HTMLDivElement | null = null;
-
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      listeningToMessages: false,
-    };
-
-    this.handleIframeMessages = this.handleIframeMessages.bind(this);
-    this.handleResize = this.handleResize.bind(this);
-    this.handleScrollTo = this.handleScrollTo.bind(this);
-  }
-
-  componentDidMount() {
-    this.handleIframeResizing(this.props.url);
-  }
-
-  componentDidUpdate(prevProps: Props) {
-    if (this.props.url !== prevProps.url) {
-      this.handleIframeResizing(this.props.url);
-    }
-  }
-
-  componentWillUnmount() {
-    this.disableIframeMessageListener();
-  }
-
-  getIframeDOM(): HTMLIFrameElement {
-    return this._iframeDiv?.children[0] as HTMLIFrameElement;
-  }
-
-  handleIframeResizing(url: string) {
+  const handleIframeResizing = (url: string) => {
     if (urlIsNDLAUrl(url)) {
-      this.setState(this.enableIframeMessageListener);
+      enableIframeMessageListener();
     } else {
-      this.setState(this.disableIframeMessageListener);
+      disableIframeMessageListener();
     }
-  }
+  };
 
-  enableIframeMessageListener() {
-    if (!this.state.listeningToMessages) {
-      window.addEventListener('message', this.handleIframeMessages);
-      this.setState({ listeningToMessages: true });
-    }
-  }
+  useEffect(() => {
+    handleIframeResizing(url);
+  }, [url, iframeRef]);
 
-  disableIframeMessageListener() {
-    window.removeEventListener('message', this.handleIframeMessages);
-    this.setState({ listeningToMessages: false });
-  }
+  const getIframeDOM = () => {
+    return iframeRef.current?.children[0] as HTMLIFrameElement;
+  };
 
-  handleScrollTo(evt: MessageEvent) {
-    const iframe = this.getIframeDOM();
+  const enableIframeMessageListener = () => {
+    window.addEventListener('message', handleIframeMessages);
+    setListeningToMessages(true);
+  };
+
+  const disableIframeMessageListener = () => {
+    window.removeEventListener('message', handleIframeMessages);
+    setListeningToMessages(false);
+  };
+
+  const handleScrollTo = (evt: MessageEvent) => {
+    const iframe = getIframeDOM();
     if (iframe) {
       const rect = iframe.getBoundingClientRect();
       const scrollTop =
@@ -90,57 +64,43 @@ export default class LearningpathIframe extends React.Component<Props, State> {
       const top = evt.data.top + rect.top + scrollTop;
       window.scroll({ top });
     }
-  }
+  };
 
-  handleResize(evt: MessageEvent) {
+  const handleResize = (evt: MessageEvent) => {
     if (!evt.data.height) {
       return;
     }
-    const iframe = this.getIframeDOM();
+    const iframe = getIframeDOM();
     if (iframe) {
       const newHeight = parseInt(get(evt, 'data.height', 0), 10);
       iframe.style.height = `${newHeight}px`; // eslint-disable-line no-param-reassign
     }
-  }
+  };
 
-  handleIframeMessages(event: MessageEvent) {
-    const iframe = this.getIframeDOM();
+  const handleIframeMessages = (event: MessageEvent) => {
+    const iframe = getIframeDOM();
     /* Needed to enforce content to stay within iframe on Safari iOS */
     if (iframe) {
       iframe.setAttribute('scrolling', 'no');
     }
 
-    if (
-      !this.state.listeningToMessages ||
-      !event ||
-      !event.data ||
-      iframe?.contentWindow !== event.source
-    ) {
+    if (!listeningToMessages || !event || !event.data) {
       return;
     }
 
     switch (event.data.event) {
       case 'resize':
-        this.handleResize(event);
+        handleResize(event);
         break;
       case 'scrollTo':
-        this.handleScrollTo(event);
+        handleScrollTo(event);
         break;
       default:
         break;
     }
-  }
+  };
 
-  render() {
-    const { html } = this.props;
+  return <div ref={iframeRef}>{parse(html)}</div>;
+};
 
-    return (
-      <div
-        ref={iframeDiv => {
-          this._iframeDiv = iframeDiv;
-        }}>
-        {parse(html)}
-      </div>
-    );
-  }
-}
+export default LearningpathIframe;

--- a/src/components/Learningpath/LearningpathIframe.tsx
+++ b/src/components/Learningpath/LearningpathIframe.tsx
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2016-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import React from 'react';
+import get from 'lodash/get';
+
+export const urlIsNDLAApiUrl = (url: string) =>
+  /^(http|https):\/\/(ndla-frontend|www).([a-zA-Z]+.)?api.ndla.no/.test(url);
+export const urlIsNDLAEnvUrl = (url: string) =>
+  /^(http|https):\/\/(www.)?([a-zA-Z]+.)?ndla.no/.test(url);
+export const urlIsLocalNdla = (url: string) =>
+  /^http:\/\/(proxy.ndla-local|localhost):30017/.test(url);
+export const urlIsNDLAUrl = (url: string) =>
+  urlIsNDLAApiUrl(url) || urlIsNDLAEnvUrl(url) || urlIsLocalNdla(url);
+
+interface Props {
+  html: string;
+  url: string;
+}
+
+interface State {
+  listeningToMessages: boolean;
+}
+
+export default class LearningpathIframe extends React.Component<Props, State> {
+  private _iframeDiv: HTMLDivElement | null = null;
+
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      listeningToMessages: false,
+    };
+
+    this.handleIframeMessages = this.handleIframeMessages.bind(this);
+    this.handleResize = this.handleResize.bind(this);
+    this.handleScrollTo = this.handleScrollTo.bind(this);
+  }
+
+  componentDidMount() {
+    this.handleIframeResizing(this.props.url);
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (this.props.url !== prevProps.url) {
+      this.handleIframeResizing(this.props.url);
+    }
+  }
+
+  componentWillUnmount() {
+    this.disableIframeMessageListener();
+  }
+
+  getIframeDOM(): HTMLIFrameElement {
+    return this._iframeDiv?.children[0] as HTMLIFrameElement;
+  }
+
+  handleIframeResizing(url: string) {
+    if (urlIsNDLAUrl(url)) {
+      this.setState(this.enableIframeMessageListener);
+    } else {
+      this.setState(this.disableIframeMessageListener);
+    }
+  }
+
+  enableIframeMessageListener() {
+    if (!this.state.listeningToMessages) {
+      window.addEventListener('message', this.handleIframeMessages);
+      this.setState({ listeningToMessages: true });
+    }
+  }
+
+  disableIframeMessageListener() {
+    window.removeEventListener('message', this.handleIframeMessages);
+    this.setState({ listeningToMessages: false });
+  }
+
+  handleScrollTo(evt: MessageEvent) {
+    const iframe = this.getIframeDOM();
+    if (iframe) {
+      const rect = iframe.getBoundingClientRect();
+      const scrollTop =
+        window.pageYOffset || document.documentElement.scrollTop;
+
+      const top = evt.data.top + rect.top + scrollTop;
+      window.scroll({ top });
+    }
+  }
+
+  handleResize(evt: MessageEvent) {
+    if (!evt.data.height) {
+      return;
+    }
+    const iframe = this.getIframeDOM();
+    if (iframe) {
+      const newHeight = parseInt(get(evt, 'data.height', 0), 10);
+      iframe.style.height = `${newHeight}px`; // eslint-disable-line no-param-reassign
+    }
+  }
+
+  handleIframeMessages(event: MessageEvent) {
+    const iframe = this.getIframeDOM();
+    /* Needed to enforce content to stay within iframe on Safari iOS */
+    if (iframe) {
+      iframe.setAttribute('scrolling', 'no');
+    }
+
+    if (
+      !this.state.listeningToMessages ||
+      !event ||
+      !event.data ||
+      iframe?.contentWindow !== event.source
+    ) {
+      return;
+    }
+
+    switch (event.data.event) {
+      case 'resize':
+        this.handleResize(event);
+        break;
+      case 'scrollTo':
+        this.handleScrollTo(event);
+        break;
+      default:
+        break;
+    }
+  }
+
+  render() {
+    const { html } = this.props;
+
+    return (
+      <div
+        dangerouslySetInnerHTML={{ __html: html }}
+        ref={iframeDiv => {
+          this._iframeDiv = iframeDiv;
+        }}
+      />
+    );
+  }
+}


### PR DESCRIPTION
Fixes NDLANO/Issue#2567

Har lagt til nesten samme komponenten som viser oembeds i learningpath-frontend i ndla-frontend for å ha en listener som følger med på når iframer for ndla-artikler lastes inn i læringssteg, så de vises i sin fulle størrelse i stedet for i en liten iframe som må scrolles i.

F.eks. i artikler som dette: https://ndla-frontend-pr-685.ndla.sh/subject:42/topic:1:198227/topic:1:198361/resource:1:170189/7501?filters=urn:filter:22dee9ab-5b1a-4c23-8c97-c68107b881bb vil det nå heller vises i en fullsize iframe. 

Andre iframes som er en del av artiklene som vanlig blir ikke påvirket av dette, f.eks: https://ndla-frontend-pr-685.ndla.sh/subject:6/topic:1:182849/topic:1:175043/resource:1:176514/22?filters=urn:filter:01c27030-e8f8-4a7c-a5b3-489fdb8fea30