### PR TITLE
Add htmlTitle helper. Use helper to generate titles.

### DIFF
--- a/src/containers/ArticlePage/ArticlePage.jsx
+++ b/src/containers/ArticlePage/ArticlePage.jsx
@@ -179,7 +179,7 @@ class ArticlePage extends Component {
           </script>
         </Helmet>
         <SocialMediaMetadata
-          title={`${article.title}${subject?.name ? ' - ' + subject.name : ''}`}
+          title={htmlTitle(article.title, [subject?.name])}
           trackableContent={article}
           description={article.metaDescription}
           locale={locale}

--- a/src/containers/ArticlePage/ArticlePage.jsx
+++ b/src/containers/ArticlePage/ArticlePage.jsx
@@ -26,6 +26,7 @@ import ArticleErrorMessage from './components/ArticleErrorMessage';
 import { getContentType } from '../../util/getContentType';
 import { getArticleScripts } from '../../util/getArticleScripts';
 import getStructuredDataFromArticle from '../../util/getStructuredDataFromArticle';
+import { htmlTitle } from '../../util/titleHelper';
 import { getArticleProps } from '../../util/getArticleProps';
 import { getAllDimensions } from '../../util/trackingUtil';
 import { transformArticle } from '../../util/transformArticle';
@@ -77,8 +78,10 @@ class ArticlePage extends Component {
   }
 
   static getDocumentTitle({ t, data }) {
-    return `${data.subject?.name || ''} - ${data.resource?.article?.title ||
-      ''}${t('htmlTitles.titleTemplate')}`;
+    return htmlTitle(data.resource?.article?.title, [
+      data.subject?.name,
+      t('htmlTitles.titleTemplate'),
+    ]);
   }
 
   componentDidMount() {
@@ -176,7 +179,7 @@ class ArticlePage extends Component {
           </script>
         </Helmet>
         <SocialMediaMetadata
-          title={`${subject?.name ? subject.name + ' - ' : ''}${article.title}`}
+          title={`${article.title}${subject?.name ? ' - ' + subject.name : ''}`}
           trackableContent={article}
           description={article.metaDescription}
           locale={locale}

--- a/src/containers/FilmFrontpage/FilmFrontpage.jsx
+++ b/src/containers/FilmFrontpage/FilmFrontpage.jsx
@@ -26,6 +26,7 @@ import {
   GraphQLSubjectShape,
 } from '../../graphqlShapes';
 import { SUPPORTED_LANGUAGES } from '../../constants';
+import { htmlTitle } from '../../util/titleHelper';
 
 const ARIA_FILMCATEGORY_ID = 'movieCategoriesId';
 
@@ -43,7 +44,7 @@ class FilmFrontpage extends Component {
   }
 
   static getDocumentTitle({ t, subject }) {
-    return `${subject ? subject.name : ''}${t('htmlTitles.titleTemplate')}`;
+    return htmlTitle(subject?.name, [t('htmlTitles.titleTemplate')]);
   }
 
   onChangeResourceType(resourceTypeSelected) {

--- a/src/containers/LearningpathPage/LearningpathPage.jsx
+++ b/src/containers/LearningpathPage/LearningpathPage.jsx
@@ -14,6 +14,7 @@ import { injectT } from '@ndla/i18n';
 import { withTracker } from '@ndla/tracker';
 import { getArticleProps } from '../../util/getArticleProps';
 import { getAllDimensions } from '../../util/trackingUtil';
+import { htmlTitle } from '../../util/titleHelper';
 import SocialMediaMetadata from '../../components/SocialMediaMetadata';
 import Learningpath from '../../components/Learningpath';
 import { DefaultErrorMessage } from '../../components/DefaultErrorMessage';
@@ -77,14 +78,21 @@ class LearningpathPage extends Component {
     );
   }
 
+  static getTitle(subject, learningpath, learningpathStep) {
+    return htmlTitle(learningpath?.title, [
+      learningpathStep?.title,
+      subject?.name,
+    ]);
+  }
+
   static getDocumentTitle({ t, data }) {
     const {
       subject,
       resource: { learningpath },
     } = data;
-    return `${subject?.name || ''} - ${learningpath?.title || ''}${t(
-      'htmlTitles.titleTemplate',
-    )}`;
+    return htmlTitle(this.getTitle(subject, learningpath), [
+      t('htmlTitles.titleTemplate'),
+    ]);
   }
 
   onKeyUpEvent = evt => {
@@ -169,9 +177,10 @@ class LearningpathPage extends Component {
           <title>{`${this.constructor.getDocumentTitle(this.props)}`}</title>
         </Helmet>
         <SocialMediaMetadata
-          title={`${subject && subject.name ? subject.name + ' - ' : ''}${
-            learningpath.title
-          } - ${learningpathStep.title}`}
+          title={htmlTitle(
+            this.constructor.getTitle(subject, learningpath, learningpathStep),
+            [t('htmlTitles.titleTemplate')],
+          )}
           trackableContent={learningpath}
           description={learningpath.description}
           locale={locale}

--- a/src/containers/MultidisciplinarySubject/components/MultidisciplinarySubjectArticle.jsx
+++ b/src/containers/MultidisciplinarySubject/components/MultidisciplinarySubjectArticle.jsx
@@ -19,6 +19,7 @@ import { withTracker } from '@ndla/tracker';
 import { ArticleShape, SubjectShape } from '@ndla/ui/lib/shapes';
 
 import { getAllDimensions } from '../../../util/trackingUtil';
+import { htmlTitle } from '../../../util/titleHelper';
 import { getSubjectLongName } from '../../../data/subjects';
 import Article from '../../../components/Article';
 import SocialMediaMetadata from '../../../components/SocialMediaMetadata';
@@ -68,9 +69,7 @@ const MultidisciplinarySubjectArticle = ({
         subjectsLinks={subjectLinks}
       />
       <SocialMediaMetadata
-        title={`${subject?.name ? subject.name + ' - ' : ''}${
-          topic.article.title
-        }`}
+        title={htmlTitle(topic.article.title, [subject?.name])}
         trackableContent={topic.article}
         description={topic.article.metaDescription}
         locale={locale}
@@ -102,7 +101,7 @@ MultidisciplinarySubjectArticle.propTypes = {
 };
 
 MultidisciplinarySubjectArticle.getDocumentTitle = ({ t, topic }) => {
-  return `${topic.name || ''}${t('htmlTitles.titleTemplate')}`;
+  return htmlTitle(topic.name || '', [t('htmlTitles.titleTemplate')]);
 };
 
 MultidisciplinarySubjectArticle.willTrackPageView = (

--- a/src/containers/MultidisciplinarySubject/components/MultidisciplinaryTopic.jsx
+++ b/src/containers/MultidisciplinarySubject/components/MultidisciplinaryTopic.jsx
@@ -15,6 +15,7 @@ import config from '../../../config';
 import ArticleContents from '../../../components/Article/ArticleContents';
 import { toTopic } from '../../../routeHelpers';
 import { getAllDimensions } from '../../../util/trackingUtil';
+import { htmlTitle } from '../../../util/titleHelper';
 import { getSubjectLongName } from '../../../data/subjects';
 import {
   GraphQLResourceTypeShape,
@@ -23,7 +24,7 @@ import {
 } from '../../../graphqlShapes';
 
 const getDocumentTitle = ({ t, data }) => {
-  return `${data?.topic?.name || ''}${t('htmlTitles.titleTemplate')}`;
+  return htmlTitle(data?.topic?.name, [t('htmlTitles.titleTemplate')]);
 };
 
 const MultidisciplinaryTopic = ({

--- a/src/containers/PlainArticlePage/PlainArticlePage.jsx
+++ b/src/containers/PlainArticlePage/PlainArticlePage.jsx
@@ -18,6 +18,7 @@ import NotFoundPage from '../NotFoundPage/NotFoundPage';
 import { transformArticle } from '../../util/transformArticle';
 import Article from '../../components/Article';
 import { getArticleScripts } from '../../util/getArticleScripts';
+import { htmlTitle } from '../../util/titleHelper';
 import getStructuredDataFromArticle from '../../util/getStructuredDataFromArticle';
 import { getArticleProps } from '../../util/getArticleProps';
 import { getAllDimensions } from '../../util/trackingUtil';
@@ -28,7 +29,7 @@ import { useGraphQuery } from '../../util/runQueries';
 const getTitle = article => article?.title || '';
 
 const getDocumentTitle = ({ t, article }) => {
-  return `${getTitle(article)}${t('htmlTitles.titleTemplate')}`;
+  return htmlTitle(getTitle(article), [t('htmlTitles.titleTemplate')]);
 };
 
 const PlainArticlePage = ({

--- a/src/containers/PlainLearningpathPage/PlainLearningpathPage.jsx
+++ b/src/containers/PlainLearningpathPage/PlainLearningpathPage.jsx
@@ -18,13 +18,16 @@ import { learningPathStepQuery } from '../../queries';
 import { DefaultErrorMessage } from '../../components/DefaultErrorMessage';
 import SocialMediaMetadata from '../../components/SocialMediaMetadata';
 import { useGraphQuery } from '../../util/runQueries';
+import { htmlTitle } from '../../util/titleHelper';
 import { toLearningPath } from '../../routeHelpers';
 
 const getTitle = learningpath => (learningpath ? learningpath.title : '');
 
 const getDocumentTitle = ({ t, data }) => {
   const { learningpath } = data;
-  return `${getTitle(learningpath)}${t('htmlTitles.titleTemplate')}`;
+  return `${htmlTitle(getTitle(learningpath), [
+    t('htmlTitles.titleTemplate'),
+  ])}`;
 };
 
 const PlainLearningpathPage = props => {
@@ -95,7 +98,9 @@ const PlainLearningpathPage = props => {
         <title>{`${getDocumentTitle({ t, data })}`}</title>
       </Helmet>
       <SocialMediaMetadata
-        title={`${learningpath.title} - ${learningpathStep.title}`}
+        title={htmlTitle(getTitle(learningpath), [
+          t('htmlTitles.titleTemplate'),
+        ])}
         trackableContent={learningpath}
         description={learningpath.description}
         locale={locale}

--- a/src/containers/ProgrammePage/ProgrammePage.jsx
+++ b/src/containers/ProgrammePage/ProgrammePage.jsx
@@ -19,6 +19,7 @@ import { getAllDimensions } from '../../util/trackingUtil';
 import { getProgrammeBySlug } from '../../data/programmes';
 import { getSubjectById } from '../../data/subjects';
 import { createSubjectUrl } from '../../util/programmesSubjectsHelper';
+import { htmlTitle } from '../../util/titleHelper';
 
 const mapGradesData = (grades, locale, programmeSlug) => {
   return grades.map(grade => {
@@ -63,7 +64,7 @@ const getProgrammeName = (match, locale) => {
 
 const getDocumentTitle = ({ match, locale, t }) => {
   const name = getProgrammeName(match, locale);
-  return name ? `${name}${t('htmlTitles.titleTemplate')}` : '';
+  return htmlTitle(name, [t('htmlTitles.titleTemplate')]);
 };
 
 const ProgrammePage = ({ match, locale, t }) => {

--- a/src/containers/SubjectPage/SubjectContainer.jsx
+++ b/src/containers/SubjectPage/SubjectContainer.jsx
@@ -30,9 +30,10 @@ import { getSubjectBySubjectId, getSubjectLongName } from '../../data/subjects';
 import { GraphQLSubjectShape } from '../../graphqlShapes';
 import { parseAndMatchUrl } from '../../util/urlHelper';
 import { getAllDimensions } from '../../util/trackingUtil';
+import { htmlTitle } from '../../util/titleHelper';
 
 const getDocumentTitle = ({ t, data }) => {
-  return `${data?.subject?.name || ''}${t('htmlTitles.titleTemplate')}`;
+  return htmlTitle(data?.subject?.name, [t('htmlTitles.titleTemplate')]);
 };
 
 const SubjectContainer = ({
@@ -168,9 +169,9 @@ const SubjectContainer = ({
   return (
     <>
       <Helmet>
-        <title>{`${subjectNames?.name || ''}${t(
-          'htmlTitles.titleTemplate',
-        )}`}</title>
+        <title>
+          {htmlTitle(subjectNames?.name, [t('htmlTitles.titleTemplate')])}
+        </title>
         {metaDescription && (
           <meta name="description" content={metaDescription} />
         )}

--- a/src/containers/SubjectPage/components/Topic.jsx
+++ b/src/containers/SubjectPage/components/Topic.jsx
@@ -16,6 +16,7 @@ import ArticleContents from '../../../components/Article/ArticleContents';
 import Resources from '../../Resources/Resources';
 import { toTopic } from '../../../routeHelpers';
 import { getAllDimensions } from '../../../util/trackingUtil';
+import { htmlTitle } from '../../../util/titleHelper';
 import { getSubjectLongName } from '../../../data/subjects';
 import {
   GraphQLResourceTypeShape,
@@ -24,7 +25,7 @@ import {
 } from '../../../graphqlShapes';
 
 const getDocumentTitle = ({ t, data }) => {
-  return `${data?.topic?.name || ''}${t('htmlTitles.titleTemplate')}`;
+  return htmlTitle(data?.topic?.name, [t('htmlTitles.titleTemplate')]);
 };
 
 const Topic = ({

--- a/src/containers/TopicPage/TopicContainer.jsx
+++ b/src/containers/TopicPage/TopicContainer.jsx
@@ -39,6 +39,7 @@ import { getAllDimensions } from '../../util/trackingUtil';
 import { getSubjectLongName } from '../../data/subjects';
 import Resources from '../Resources/Resources';
 import { getTopicPath } from '../../util/getTopicPath';
+import { htmlTitle } from '../../util/titleHelper';
 import { transformArticle } from '../../util/transformArticle';
 import SocialMediaMetadata from '../../components/SocialMediaMetadata';
 
@@ -73,9 +74,10 @@ const TopicContainer = ({
   const { subject, topicPath, resourceTypes, topic } = result;
 
   const getDocumentTitle = () => {
-    return `${subject?.name || ''} - ${getTitle(topic.article, topic.title)}${t(
-      'htmlTitles.titleTemplate',
-    )}`;
+    return htmlTitle(getTitle(topic.article, topic.title), [
+      subject?.name,
+      t('htmlTitles.titleTemplate'),
+    ]);
   };
 
   const hasArticleError =
@@ -91,7 +93,7 @@ const TopicContainer = ({
   return (
     <>
       <Helmet>
-        <title>{`${getDocumentTitle()}`}</title>
+        <title>{getDocumentTitle()}</title>
         {article && article.metaDescription && (
           <meta name="description" content={article.metaDescription} />
         )}
@@ -112,7 +114,7 @@ const TopicContainer = ({
         <SocialMediaMetadata
           description={article.metaDescription}
           image={article.metaImage}
-          title={`${subject?.name ? subject.name + ' - ' : ''}${article.title}`}
+          title={htmlTitle(article.title, [subject?.name])}
           trackableContent={article}
           locale={locale}
         />
@@ -176,9 +178,10 @@ TopicContainer.willTrackPageView = (trackPageView, props) => {
 };
 
 TopicContainer.getDocumentTitle = ({ t, data: { topic, subject } }) => {
-  return `${subject ? subject.name : ''} - ${getTitle(topic.article, topic)}${t(
-    'htmlTitles.titleTemplate',
-  )}`;
+  return htmlTitle(getTitle(topic.article, topic), [
+    subject?.name,
+    t('htmlTitles.titleTemplate'),
+  ]);
 };
 
 TopicContainer.getDimensions = props => {

--- a/src/iframe/IframeArticlePage.js
+++ b/src/iframe/IframeArticlePage.js
@@ -16,7 +16,7 @@ import { withTracker } from '@ndla/tracker';
 import { transformArticle } from '../util/transformArticle';
 import Article from '../components/Article';
 import { getArticleScripts } from '../util/getArticleScripts';
-import { ResourceShape, ArticleShape } from '../shapes';
+import { ResourceShape, ArticleShape, LocationShape } from '../shapes';
 import { getArticleProps } from '../util/getArticleProps';
 import { getAllDimensions } from '../util/trackingUtil';
 import PostResizeMessage from './PostResizeMessage';
@@ -120,9 +120,7 @@ IframeArticlePage.propTypes = {
   locale: PropTypes.string.isRequired,
   resource: ResourceShape,
   article: ArticleShape,
-  location: PropTypes.shape({
-    pathname: PropTypes.string,
-  }),
+  location: LocationShape,
 };
 
 export default injectT(withTracker(IframeArticlePage));

--- a/src/iframe/IframeTopicPage.jsx
+++ b/src/iframe/IframeTopicPage.jsx
@@ -65,9 +65,7 @@ const Success = ({ resource, locale, location }) => {
 Success.propTypes = {
   locale: PropTypes.string.isRequired,
   resource: ResourceShape,
-  location: PropTypes.shape({
-    pathname: PropTypes.string,
-  }),
+  location: LocationShape,
 };
 
 export class IframeTopicPage extends Component {

--- a/src/messages/messagesEN.ts
+++ b/src/messages/messagesEN.ts
@@ -6,17 +6,18 @@
  *
  */
 
-const titleTemplate = ' - NDLA';
+const titleTemplate = 'NDLA';
 
 const messages = {
   htmlTitles: {
     titleTemplate,
-    welcomePage: `Frontpage${titleTemplate}`,
+    welcomePage: `Frontpage - ${titleTemplate}`,
     topicPage: 'Topic',
-    subjectsPage: `Choose subjects${titleTemplate}`,
-    searchPage: `Search${titleTemplate}`,
-    notFound: `Page not found${titleTemplate}`,
+    subjectsPage: `Choose subjects - ${titleTemplate}`,
+    searchPage: `Search - ${titleTemplate}`,
+    notFound: `Page not found - ${titleTemplate}`,
     subject: 'Subject',
+    lti: `LTI - ${titleTemplate}`,
   },
 };
 

--- a/src/messages/messagesNB.ts
+++ b/src/messages/messagesNB.ts
@@ -6,18 +6,18 @@
  *
  */
 
-const titleTemplate = ' - NDLA';
+const titleTemplate = 'NDLA';
 
 const messages = {
   htmlTitles: {
     titleTemplate,
-    welcomePage: `Forsiden${titleTemplate}`,
+    welcomePage: `Forsiden - ${titleTemplate}`,
     topicPage: 'Emne',
-    subjectsPage: `Velg fag${titleTemplate}`,
-    searchPage: `Søk${titleTemplate}`,
-    notFound: `Siden finnes ikke${titleTemplate}`,
+    subjectsPage: `Velg fag - ${titleTemplate}`,
+    searchPage: `Søk - ${titleTemplate}`,
+    notFound: `Siden finnes ikke - ${titleTemplate}`,
     subject: 'Fag',
-    lti: `LTI${titleTemplate}`,
+    lti: `LTI - ${titleTemplate}`,
   },
 };
 

--- a/src/messages/messagesNN.ts
+++ b/src/messages/messagesNN.ts
@@ -6,17 +6,18 @@
  *
  */
 
-const titleTemplate = ' - NDLA';
+const titleTemplate = 'NDLA';
 
 const messages = {
   htmlTitles: {
     titleTemplate,
-    welcomePage: `Framsida${titleTemplate}`,
+    welcomePage: `Framsida - ${titleTemplate}`,
     topicPage: 'Emne',
-    subjectsPage: `Velg fag${titleTemplate}`,
-    searchPage: `Søk${titleTemplate}`,
-    notFound: `Sida finst ikkje${titleTemplate}`,
+    subjectsPage: `Velg fag - ${titleTemplate}`,
+    searchPage: `Søk - ${titleTemplate}`,
+    notFound: `Sida finst ikkje - ${titleTemplate}`,
     subject: 'Fag',
+    lti: `LTI - ${titleTemplate}`,
   },
 };
 

--- a/src/util/__tests__/titleHelper-test.ts
+++ b/src/util/__tests__/titleHelper-test.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { htmlTitle } from '../titleHelper';
+
+test('title with elements gets formatted correctly', () => {
+  expect(htmlTitle('Page', ['With', 'Many', 'Elements', 'Together'])).toBe(
+    'Page - With - Many - Elements - Together',
+  );
+  expect(htmlTitle('Page', ['Subject', 'NDLA'])).toBe('Page - Subject - NDLA');
+  expect(htmlTitle('Page', [undefined, 'NDLA'])).toBe('Page - NDLA');
+  expect(htmlTitle(undefined, [undefined, 'NDLA'])).toBe(' - NDLA');
+  expect(htmlTitle('Standalone', [])).toBe('Standalone');
+  expect(htmlTitle('Standalone', [undefined])).toBe('Standalone');
+  expect(htmlTitle('Without elements')).toBe('Without elements');
+  expect(htmlTitle(undefined)).toBe('');
+});

--- a/src/util/titleHelper.ts
+++ b/src/util/titleHelper.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+export const htmlTitle = (
+  main: string | undefined,
+  elements?: Array<string | undefined>,
+) => {
+  const subs = elements?.filter(e => e).map(e => ' - ' + e) || [];
+  return `${main || ''}${subs.join('')}`;
+};


### PR DESCRIPTION
Ny helper som lager tittel-element på formatet 'Artikkel - Fag - NDLA'.

Alle titler på sider skal være på samme format som tidligerer, men med artikkelnavnet først og ikkje som nest siste ledd.

Test:
Sammenlign titler på sider fra pr og test.ndla.no.