### PR TITLE
Hide download button in ImageLicenseList if source is copyrighted

### DIFF
--- a/src/components/license/ImageLicenseList.jsx
+++ b/src/components/license/ImageLicenseList.jsx
@@ -74,12 +74,14 @@ const ImageLicenseInfo = ({ image, locale, t }) => {
               copyTitle={t('copyTitle')}
               hasCopiedTitle={t('hasCopiedTitle')}
             />
-            <AnchorButton
-              href={downloadUrl(image.src)}
-              appearance="outline"
-              download>
-              {t('download')}
-            </AnchorButton>
+            {image.copyright.license.license !== 'COPYRIGHTED' && (
+              <AnchorButton
+                href={downloadUrl(image.src)}
+                appearance="outline"
+                download>
+                {t('download')}
+              </AnchorButton>
+            )}
           </div>
         </MediaListItemActions>
       </MediaListItemBody>


### PR DESCRIPTION
Fixes NDLANO/Issues#2687

Knapp for nedlasting skal ikke vises dersom bildet er kopibeskyttet. Dette er allerede fikset for artikler. Implementeres nå i "regler for bruk". 

Løst etter samme mal som article-converter: https://github.com/NDLANO/article-converter/blob/f10f9ffef3308a4b9663845fffed3018d3c13e8f/src/plugins/imagePlugin.js#L171

Hvordan teste:
- Åpne PR-instans
- Åpne en artikkel med bilde. Feks /subject:1:f9eb2b20-1c83-4292-8ad2-0fa8522da7cd/topic:1:96845fc3-978d-4819-b2ed-7e210a38384b/resource:1:101618
- Trykk på regler for bruk i bunnen av artikkelen og bekreft at "last ned"-knapp er skjult for kopibeskyttede bilder.
- Sammenlikn design/funksjon med lisens på hvert enkelt bilde i artikkelen også