### PR TITLE
Initial attempt at fixing MathJax error

### DIFF
--- a/src/containers/ArticlePage/ArticlePage.jsx
+++ b/src/containers/ArticlePage/ArticlePage.jsx
@@ -94,8 +94,8 @@ class ArticlePage extends Component {
   }
 
   componentDidUpdate() {
-    if (window.MathJax) {
-      window.MathJax.typeset();
+    if (window.MathJax && typeof window.MathJax.typeset === 'function') {
+      window?.MathJax?.typeset();
     }
   }
 

--- a/src/util/getArticleScripts.ts
+++ b/src/util/getArticleScripts.ts
@@ -22,25 +22,21 @@ export function getArticleScripts(article: GQLArticle) {
       src: lib.url,
       type: lib.mediaType,
     })) || [];
-
   if (article && article.content.indexOf('<math') > -1) {
-    scripts.push(...MathjaxScripts);
+    scripts.push({
+      src: '/static/mathjax-config.js',
+      type: 'text/javascript',
+      async: false,
+      defer: true,
+    });
+
+    scripts.push({
+      src: 'https://cdn.jsdelivr.net/npm/mathjax@3.1.2/es5/mml-chtml.js',
+      type: 'text/javascript',
+      async: false,
+      defer: true,
+    });
   }
 
   return scripts;
 }
-
-const MathjaxScripts = [
-  {
-    src: '/static/mathjax-config.js',
-    type: 'text/javascript',
-    async: false,
-    defer: true,
-  },
-  {
-    src: 'https://cdn.jsdelivr.net/npm/mathjax@3.1.2/es5/mml-chtml.js',
-    type: 'text/javascript',
-    async: false,
-    defer: true,
-  },
-];


### PR DESCRIPTION
https://github.com/NDLANO/Issues/issues/2702

Jeg klarer ikke å gjenskape feilen lenger. Virker som at dette kan oppstå når MathJax ikke er null, men ikke har initialisert seg ferdig. Problemet løste seg først når jeg la inn en typeof-check. Risikoen vil eventuelt være at typeset ikke blir kjørt hvis man virkelig beveger seg fort. 

Dette er en vanskelig fiks å teste. Her er hvordan man enklest kan fremkalle den.

1.  Gå til en artikkel på ndla.no, f.eks https://ndla.no/subject:1:ca607ca1-4dd0-4bbd-954f-67461f4b96fc/topic:1:89f902cb-98f4-4acc-be79-d3e2f40a8bf1/topic:1:5bd0cbfd-14fe-4201-b1c7-baa4e1504b48/resource:46831ee6-48ab-4525-a483-21961291267f
2. Hard refresh siden. 
3. Før siden har lastet ferdig, klikk på "utholdenhet"-breadcrumben. 
4. Naviger deg tilbake til artikkelen.