### PR TITLE
Temporary fix to show ungrouped resources

### DIFF
--- a/src/containers/Masthead/components/MastheadTopics.tsx
+++ b/src/containers/Masthead/components/MastheadTopics.tsx
@@ -69,6 +69,28 @@ const MastheadTopics = ({
     expandedSubtopicsId,
   );
 
+  const topicsWithUngroupedResources = topicsWithContentTypes.map(topic => ({
+    ...topic,
+    subtopics: topic.subtopics.map(subtopic => {
+      const isUngrouped =
+        subtopic.metadata?.customFields?.['topic-resources'] === 'ungrouped';
+
+      return isUngrouped
+        ? {
+            ...subtopic,
+            contentTypeResults: subtopic.contentTypeResults
+              ?.flatMap(result =>
+                result.resources?.map(resource => ({
+                  ...result,
+                  resources: [{ ...resource }],
+                })),
+              )
+              .sort((a, b) => a?.resources[0]?.rank! - b?.resources[0]?.rank!),
+          }
+        : subtopic;
+    }),
+  }));
+
   const localResourceToLinkProps = (resource: GQLResource) => {
     const subjectTopicPath = [subject.id, ...expandedTopicIds]
       .map(removeUrn)
@@ -83,7 +105,7 @@ const MastheadTopics = ({
       close={onClose}
       toFrontpage={() => '/'}
       searchFieldComponent={searchFieldComponent}
-      topics={topicsWithContentTypes}
+      topics={topicsWithUngroupedResources}
       toTopic={toTopicWithBoundParams(subject.id, expandedTopicIds)}
       toSubject={() => toSubject(subject.id)}
       defaultCount={12}

--- a/src/containers/Masthead/mastheadHelpers.ts
+++ b/src/containers/Masthead/mastheadHelpers.ts
@@ -32,12 +32,7 @@ function getContentTypeResults(
   }));
 }
 
-export function mapTopicResourcesToTopic(
-  topics: GQLTopic[],
-  selectedTopicId: string,
-  topicResourcesByType: GQLResourceType[],
-  expandedSubTopics: string[] = [],
-): (GQLTopic & {
+type TransformedTopic = Omit<GQLTopic, 'subtopics'> & {
   contentTypeResults:
     | {
         contentType: string | undefined;
@@ -45,8 +40,15 @@ export function mapTopicResourcesToTopic(
         title: string;
       }[]
     | undefined;
-  subtopics: GQLTopic[];
-})[] {
+  subtopics: TransformedTopic[];
+};
+
+export function mapTopicResourcesToTopic(
+  topics: GQLTopic[],
+  selectedTopicId: string,
+  topicResourcesByType: GQLResourceType[],
+  expandedSubTopics: string[] = [],
+): TransformedTopic[] {
   return topics.map(topic => {
     const subtopics =
       topic.subtopics && topic.subtopics.length > 0

--- a/src/graphqlTypes.ts
+++ b/src/graphqlTypes.ts
@@ -54,7 +54,7 @@ export interface GQLTaxonomyMetadata {
   customFields?: GQLJSON;
 }
 
-export type GQLJSON = JSON;
+export type GQLJSON = { [key: string]: string };
 
 export interface GQLMetaImage {
   url?: string;


### PR DESCRIPTION
Ref https://github.com/NDLANO/frontend-packages/pull/853.

Har lagt inn en midlertidig fiks som gjør at visning av ugrupperte ressurser vises korrekt. Dette burde reverseres så fort PRen over er ute i prod.



Oppdaterte samtidig et par interfaces som ikke så ut til å stemme.