### PR TITLE
Remove temporary sorting of ungrouped resoures

### DIFF
--- a/src/containers/Masthead/components/MastheadTopics.tsx
+++ b/src/containers/Masthead/components/MastheadTopics.tsx
@@ -69,28 +69,6 @@ const MastheadTopics = ({
     expandedSubtopicsId,
   );
 
-  const topicsWithUngroupedResources = topicsWithContentTypes.map(topic => ({
-    ...topic,
-    subtopics: topic.subtopics.map(subtopic => {
-      const isUngrouped =
-        subtopic.metadata?.customFields?.['topic-resources'] === 'ungrouped';
-
-      return isUngrouped
-        ? {
-            ...subtopic,
-            contentTypeResults: subtopic.contentTypeResults
-              ?.flatMap(result =>
-                result.resources?.map(resource => ({
-                  ...result,
-                  resources: [{ ...resource }],
-                })),
-              )
-              .sort((a, b) => a?.resources[0]?.rank! - b?.resources[0]?.rank!),
-          }
-        : subtopic;
-    }),
-  }));
-
   const localResourceToLinkProps = (resource: GQLResource) => {
     const subjectTopicPath = [subject.id, ...expandedTopicIds]
       .map(removeUrn)
@@ -105,7 +83,7 @@ const MastheadTopics = ({
       close={onClose}
       toFrontpage={() => '/'}
       searchFieldComponent={searchFieldComponent}
-      topics={topicsWithUngroupedResources}
+      topics={topicsWithContentTypes}
       toTopic={toTopicWithBoundParams(subject.id, expandedTopicIds)}
       toSubject={() => toSubject(subject.id)}
       defaultCount={12}


### PR DESCRIPTION
Tilknyttet NDLANO/Issues#2718
Oppgaven er ferdig, men det ble gjort en midlertidig sortering i ndla-frontend fram til ny versjon av pakker ble tatt i bruk. Fjerner nå denne sorteringen siden ny pakker brukes.

Hvordan teste:
- Åpne PR-instans
- Gå til feks: /subject:1:a3c1b65a-c41f-4879-b650-32a13fe1801b/topic:2:1:187398/topic:4:1:165209/
- Listen på denne siden skal være ugruppert. Dersom du åpner masthead skal det vises en liste med de samme ressursene som også er ugruppert og likt sortert.