### PR TITLE
Fiks visning av emne for tverrfaglig tema.

### DIFF
--- a/src/containers/MultidisciplinarySubject/MultidisciplinarySubjectArticlePage.jsx
+++ b/src/containers/MultidisciplinarySubject/MultidisciplinarySubjectArticlePage.jsx
@@ -19,7 +19,7 @@ const MultidisciplinarySubjectArticlePage = ({ match, locale }) => {
   const { topicId, subjectId } = getUrnIdsFromProps({ match });
 
   const { data, loading } = useGraphQuery(topicQueryWithPathTopics, {
-    variables: { topicId, subjectId },
+    variables: { topicId, subjectId, showVisualElement: 'true' },
   });
 
   if (loading) {

--- a/src/containers/MultidisciplinarySubject/MultidisciplinarySubjectArticlePage.tsx
+++ b/src/containers/MultidisciplinarySubject/MultidisciplinarySubjectArticlePage.tsx
@@ -7,23 +7,40 @@
  */
 
 import React from 'react';
-import PropTypes from 'prop-types';
+import { RouteComponentProps } from 'react-router';
 import Spinner from '@ndla/ui/lib/Spinner';
 import { useGraphQuery } from '../../util/runQueries';
 import { topicQueryWithPathTopics } from '../../queries';
 import { getUrnIdsFromProps } from '../../routeHelpers';
 import MultidisciplinarySubjectArticle from './components/MultidisciplinarySubjectArticle';
 import config from '../../config';
+import { LocaleType } from '../../interfaces';
+import { GQLResourceType, GQLSubject, GQLTopic } from '../../graphqlTypes';
+import DefaultErrorMessage from '../../components/DefaultErrorMessage';
 
-const MultidisciplinarySubjectArticlePage = ({ match, locale }) => {
+interface Props extends RouteComponentProps {
+  locale: LocaleType;
+}
+
+interface Data {
+  subject: GQLSubject & { allTopics: GQLTopic[] };
+  topic: GQLTopic;
+  resourceTypes: GQLResourceType[];
+}
+
+const MultidisciplinarySubjectArticlePage = ({ match, locale }: Props) => {
   const { topicId, subjectId } = getUrnIdsFromProps({ match });
 
-  const { data, loading } = useGraphQuery(topicQueryWithPathTopics, {
+  const { data, loading } = useGraphQuery<Data>(topicQueryWithPathTopics, {
     variables: { topicId, subjectId, showVisualElement: 'true' },
   });
 
   if (loading) {
     return <Spinner />;
+  }
+
+  if (!data) {
+    return <DefaultErrorMessage />;
   }
 
   const { topic, subject, resourceTypes } = data;
@@ -38,17 +55,6 @@ const MultidisciplinarySubjectArticlePage = ({ match, locale }) => {
       locale={locale}
     />
   );
-};
-
-MultidisciplinarySubjectArticlePage.propTypes = {
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      topicId: PropTypes.string.isRequired,
-      subjectId: PropTypes.string.isRequired,
-    }).isRequired,
-    path: PropTypes.string.isRequired,
-  }).isRequired,
-  locale: PropTypes.string,
 };
 
 export default MultidisciplinarySubjectArticlePage;

--- a/src/containers/MultidisciplinarySubject/components/MultidisciplinaryTopicWrapper.tsx
+++ b/src/containers/MultidisciplinarySubject/components/MultidisciplinaryTopicWrapper.tsx
@@ -1,11 +1,27 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import Spinner from '@ndla/ui/lib/Spinner';
 import { topicQuery } from '../../../queries';
 import { useGraphQuery } from '../../../util/runQueries';
-import { GraphQLSubjectShape } from '../../../graphqlShapes';
 import MultidisciplinaryTopic from './MultidisciplinaryTopic';
+import { GQLResourceType, GQLSubject, GQLTopic } from '../../../graphqlTypes';
+import DefaultErrorMessage from '../../../components/DefaultErrorMessage';
+import { LocaleType } from '../../../interfaces';
+
+interface Props {
+  topicId: string;
+  subjectId: string;
+  subTopicId?: string;
+  locale: LocaleType;
+  subject: GQLSubject & { allTopics: GQLTopic[] };
+  ndlaFilm?: boolean;
+  disableNav?: boolean;
+}
+
+interface Data {
+  topic: GQLTopic;
+  resourceTypes: Array<GQLResourceType>;
+}
 
 const MultidisciplinaryTopicWrapper = ({
   topicId,
@@ -13,16 +29,19 @@ const MultidisciplinaryTopicWrapper = ({
   locale,
   subTopicId,
   ndlaFilm,
-  index,
   subject,
   disableNav,
-}) => {
-  const { data, loading } = useGraphQuery(topicQuery, {
+}: Props) => {
+  const { data, loading } = useGraphQuery<Data>(topicQuery, {
     variables: { topicId, subjectId },
   });
 
   if (loading) {
     return <Spinner />;
+  }
+
+  if (!data) {
+    return <DefaultErrorMessage />;
   }
 
   return (
@@ -37,18 +56,6 @@ const MultidisciplinaryTopicWrapper = ({
       disableNav={disableNav}
     />
   );
-};
-
-MultidisciplinaryTopicWrapper.propTypes = {
-  topicId: PropTypes.string.isRequired,
-  subjectId: PropTypes.string,
-  setSelectedTopic: PropTypes.func,
-  subTopicId: PropTypes.string,
-  locale: PropTypes.string,
-  ndlaFilm: PropTypes.bool,
-  index: PropTypes.number,
-  subject: GraphQLSubjectShape,
-  disableNav: PropTypes.bool,
 };
 
 export default MultidisciplinaryTopicWrapper;

--- a/src/gqlSchema.json
+++ b/src/gqlSchema.json
@@ -858,6 +858,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "availability",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -1786,6 +1798,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "availability",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -1998,6 +2022,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "availability",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "isDeprecated": false,
@@ -2228,6 +2264,18 @@
                 "defaultValue": null,
                 "isDeprecated": false,
                 "deprecationReason": null
+              },
+              {
+                "name": "showVisualElement",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
               }
             ],
             "type": {
@@ -2265,6 +2313,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "availability",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "isDeprecated": false,
@@ -4043,6 +4103,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "availability",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -4288,6 +4360,18 @@
                   "ofType": null
                 }
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "competenceAimSetId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -6922,7 +7006,7 @@
             "args": [],
             "type": {
               "kind": "SCALAR",
-              "name": "Int",
+              "name": "Float",
               "ofType": null
             },
             "isDeprecated": false,
@@ -6934,7 +7018,7 @@
             "args": [],
             "type": {
               "kind": "SCALAR",
-              "name": "Int",
+              "name": "Float",
               "ofType": null
             },
             "isDeprecated": false,
@@ -6946,7 +7030,7 @@
             "args": [],
             "type": {
               "kind": "SCALAR",
-              "name": "Int",
+              "name": "Float",
               "ofType": null
             },
             "isDeprecated": false,
@@ -6958,7 +7042,7 @@
             "args": [],
             "type": {
               "kind": "SCALAR",
-              "name": "Int",
+              "name": "Float",
               "ofType": null
             },
             "isDeprecated": false,
@@ -6970,7 +7054,7 @@
             "args": [],
             "type": {
               "kind": "SCALAR",
-              "name": "Int",
+              "name": "Float",
               "ofType": null
             },
             "isDeprecated": false,
@@ -6982,7 +7066,7 @@
             "args": [],
             "type": {
               "kind": "SCALAR",
-              "name": "Int",
+              "name": "Float",
               "ofType": null
             },
             "isDeprecated": false,
@@ -7047,6 +7131,17 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Float",
+        "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
+        "specifiedByUrl": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -7999,17 +8094,6 @@
         "possibleTypes": null
       },
       {
-        "kind": "SCALAR",
-        "name": "Float",
-        "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
-        "specifiedByUrl": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
         "kind": "OBJECT",
         "name": "GroupSearchResult",
         "description": null,
@@ -8378,6 +8462,18 @@
                 "defaultValue": null,
                 "isDeprecated": false,
                 "deprecationReason": null
+              },
+              {
+                "name": "topicId",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
               }
             ],
             "type": {
@@ -8446,6 +8542,18 @@
               },
               {
                 "name": "path",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "showVisualElement",
                 "description": null,
                 "type": {
                   "kind": "SCALAR",

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -897,7 +897,11 @@ export const iframeArticleQuery = gql`
 `;
 
 export const topicQueryWithPathTopics = gql`
-  query topicQuery($topicId: String!, $subjectId: String!, $showVisualElement: String) {
+  query topicQuery(
+    $topicId: String!
+    $subjectId: String!
+    $showVisualElement: String
+  ) {
     subject(id: $subjectId) {
       id
       name

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -897,7 +897,7 @@ export const iframeArticleQuery = gql`
 `;
 
 export const topicQueryWithPathTopics = gql`
-  query topicQuery($topicId: String!, $subjectId: String!) {
+  query topicQuery($topicId: String!, $subjectId: String!, $showVisualElement: String) {
     subject(id: $subjectId) {
       id
       name
@@ -930,7 +930,7 @@ export const topicQueryWithPathTopics = gql`
         id
         name
       }
-      article {
+      article(showVisualElement: $showVisualElement) {
         ...ArticleInfo
         crossSubjectTopics(subjectId: $subjectId) {
           code


### PR DESCRIPTION
Akuttsak fra ndla.no. Emner for tverrfaglige tema vises ikkje lenger som dei skal. Har kopiert kode fra Topic.tsx inntil videre, men sida bør omskrives til typescript.

Avhenger av https://github.com/NDLANO/graphql-api/pull/190 og https://github.com/NDLANO/article-converter/pull/274

Test:
Klikk deg inn på pr-installasjon og velg tverffaglige tema. Visuelt element skal vises når du klikker deg inn på et kort.

