### PR TITLE
Add helmet links to other language versions when on page with base language

### DIFF
--- a/src/components/SocialMediaMetadata.jsx
+++ b/src/components/SocialMediaMetadata.jsx
@@ -10,7 +10,6 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
-import { BasenameContext } from '../App';
 import config from '../config';
 import {
   LocationShape,
@@ -18,7 +17,7 @@ import {
   ArticleShape,
   LearningpathShape,
 } from '../shapes';
-import { getHtmlLang, appLocales, isValidLocale } from '../i18n';
+import { appLocales, isValidLocale } from '../i18n';
 
 export const getCanonicalUrl = location => {
   if (!location.pathname.includes('article-iframe')) {
@@ -43,17 +42,11 @@ export const getAlternateUrl = (location, alternateLanguage) => {
   return `${config.ndlaFrontendDomain}${paths.join('/')}`;
 };
 
-export const getAlternateLanguages = (basename, locale, trackableContent) => {
-  const defaultLocale = getHtmlLang();
-  const isBasenamePage = locale === defaultLocale && basename === '';
-  if (!trackableContent && isBasenamePage) {
+export const getAlternateLanguages = trackableContent => {
+  if (!trackableContent) {
     return appLocales.map(appLocale => appLocale.abbreviation);
   }
-  if (
-    (!trackableContent && !isBasenamePage) ||
-    !isBasenamePage ||
-    trackableContent?.supportedLanguages?.length === 0
-  ) {
+  if (trackableContent?.supportedLanguages?.length === 0) {
     return [];
   }
   return trackableContent.supportedLanguages.filter(
@@ -70,70 +63,60 @@ export const SocialMediaMetadata = ({
   location,
   children,
 }) => (
-  <BasenameContext.Consumer>
-    {basename => (
-      <Helmet>
-        <link rel="canonical" href={getCanonicalUrl(location)} />
-        {getAlternateLanguages(basename, locale, trackableContent).map(
-          alternateLanguage => (
-            <link
-              key={alternateLanguage}
-              rel="alternate"
-              hrefLang={alternateLanguage}
-              href={getAlternateUrl(location, alternateLanguage)}
-            />
-          ),
-        )}
-        {children}
-        {trackableContent?.tags && (
-          <meta property="keywords" content={`${trackableContent?.tags}`} />
-        )}
-        <meta property="og:type" content="article" />
-        <meta name="twitter:card" content="summary" />
-        <meta name="twitter:site" content="@ndla_no" />
-        <meta name="twitter:creator" content="@ndla_no" />
-        <meta
-          property="og:url"
-          content={`${config.ndlaFrontendDomain}${location.pathname}`}
-        />
-        {title && <meta property="og:title" content={`${title} - NDLA`} />}
-        {title && <meta name="twitter:title" content={`${title} - NDLA`} />}
-        {description && (
-          <meta property="og:description" content={description} />
-        )}
-        {description && (
-          <meta name="twitter:description" content={description} />
-        )}
-        {image?.url && <meta property="og:image" content={image.url} />}
-        {image?.url && <meta name="twitter:image:src" content={image.url} />}
-        {!image || !image.url ? (
-          <meta
-            name="twitter:image:src"
-            content={`${config.ndlaFrontendDomain}/static/metalogo.jpg`}
-          />
-        ) : (
-          ''
-        )}
-        {!image || !image.url ? (
-          <meta
-            property="og:image"
-            content={`${config.ndlaFrontendDomain}/static/metalogo.jpg`}
-          />
-        ) : (
-          ''
-        )}
-        <meta property="og:site_name" content="ndla.no" />
-        <meta
-          property="article:publisher"
-          content="https://www.facebook.com/ndla.no"
-        />
-        <meta
-          property="article:author"
-          content="https://www.facebook.com/ndla.no"
-        />
-      </Helmet>
+  <Helmet>
+    <link rel="canonical" href={getCanonicalUrl(location)} />
+    {getAlternateLanguages(trackableContent).map(alternateLanguage => (
+      <link
+        key={alternateLanguage}
+        rel="alternate"
+        hrefLang={alternateLanguage}
+        href={getAlternateUrl(location, alternateLanguage)}
+      />
+    ))}
+    {children}
+    {trackableContent?.tags && (
+      <meta property="keywords" content={`${trackableContent?.tags}`} />
     )}
-  </BasenameContext.Consumer>
+    <meta property="og:type" content="article" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:site" content="@ndla_no" />
+    <meta name="twitter:creator" content="@ndla_no" />
+    <meta
+      property="og:url"
+      content={`${config.ndlaFrontendDomain}${location.pathname}`}
+    />
+    {title && <meta property="og:title" content={`${title} - NDLA`} />}
+    {title && <meta name="twitter:title" content={`${title} - NDLA`} />}
+    {description && <meta property="og:description" content={description} />}
+    {description && <meta name="twitter:description" content={description} />}
+    {image?.url && <meta property="og:image" content={image.url} />}
+    {image?.url && <meta name="twitter:image:src" content={image.url} />}
+    {!image || !image.url ? (
+      <meta
+        name="twitter:image:src"
+        content={`${config.ndlaFrontendDomain}/static/metalogo.jpg`}
+      />
+    ) : (
+      ''
+    )}
+    {!image || !image.url ? (
+      <meta
+        property="og:image"
+        content={`${config.ndlaFrontendDomain}/static/metalogo.jpg`}
+      />
+    ) : (
+      ''
+    )}
+    <meta property="og:site_name" content="ndla.no" />
+    <meta
+      property="article:publisher"
+      content="https://www.facebook.com/ndla.no"
+    />
+    <meta
+      property="article:author"
+      content="https://www.facebook.com/ndla.no"
+    />
+  </Helmet>
 );
 
 SocialMediaMetadata.propTypes = {

--- a/src/components/__tests__/SocialMediaMetadata-test.js
+++ b/src/components/__tests__/SocialMediaMetadata-test.js
@@ -10,27 +10,15 @@ import {
   getCanonicalUrl,
 } from '../SocialMediaMetadata';
 
-test('getAlternateLanguages with article and basename is empty', () => {
-  const alternateLanguages = getAlternateLanguages('', 'nb', {
+test('getAlternateLanguages with article', () => {
+  const alternateLanguages = getAlternateLanguages({
     supportedLanguages: ['nb', 'nn', 'en'],
   });
   expect(alternateLanguages).toMatchSnapshot();
 });
 
-test('getAlternateLanguages with article and basename is en', () => {
-  const alternateLanguages = getAlternateLanguages('en', 'en', {
-    supportedLanguages: ['nb', 'nn', 'en'],
-  });
-  expect(alternateLanguages).toMatchSnapshot();
-});
-
-test('getAlternateLanguages without article and basename is empty', () => {
-  const alternateLanguages = getAlternateLanguages('', 'nb');
-  expect(alternateLanguages).toMatchSnapshot();
-});
-
-test('getAlternateLanguages without article and basename is nn', () => {
-  const alternateLanguages = getAlternateLanguages('nn', 'nn');
+test('getAlternateLanguages without article', () => {
+  const alternateLanguages = getAlternateLanguages();
   expect(alternateLanguages).toMatchSnapshot();
 });
 

--- a/src/components/__tests__/__snapshots__/SocialMediaMetadata-test.js.snap
+++ b/src/components/__tests__/__snapshots__/SocialMediaMetadata-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getAlternateLanguages with article and basename is empty 1`] = `
+exports[`getAlternateLanguages with article 1`] = `
 Array [
   "nb",
   "nn",
@@ -8,14 +8,10 @@ Array [
 ]
 `;
 
-exports[`getAlternateLanguages with article and basename is en 1`] = `Array []`;
-
-exports[`getAlternateLanguages without article and basename is empty 1`] = `
+exports[`getAlternateLanguages without article 1`] = `
 Array [
   "nb",
   "nn",
   "en",
 ]
 `;
-
-exports[`getAlternateLanguages without article and basename is nn 1`] = `Array []`;


### PR DESCRIPTION
Fixes NDLANO/Issues#2735

Har endret `getAlternateLanguages`. Den returnerer nå også alternative språkversjoner om url-en har språk i starten (feks ndla.no/en/...). Dette burde føre til at link til alternative språkversjoner alltid legges til

