### PR TITLE
Fixes sorting of resources by adding topicid as param to graphql

### DIFF
--- a/src/containers/Resources/Resources.jsx
+++ b/src/containers/Resources/Resources.jsx
@@ -120,6 +120,7 @@ class Resources extends Component {
       const resourceTypes = sortResourceTypes(resource.resourceTypes);
       return {
         ...resource,
+        active: resource.id.endsWith(params.resourceId) ? true : false,
         contentTypeName: resourceTypes?.[0]?.name,
         contentType: contentTypeMapping[resourceTypes?.[0]?.id],
       };

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -1126,7 +1126,7 @@ export const mastHeadQuery = gql`
         ...ResourceInfo
       }
     }
-    resource(id: $resourceId, subjectId: $subjectId) @skip(if: $skipResource) {
+    resource(id: $resourceId, subjectId: $subjectId, topicId: $topicId) @skip(if: $skipResource) {
       ...ResourceInfo
       article(subjectId: $subjectId) {
         ...ArticleInfo
@@ -1232,7 +1232,7 @@ export const resourcePageQuery = gql`
         customFields
       }
     }
-    resource(id: $resourceId, subjectId: $subjectId) {
+    resource(id: $resourceId, subjectId: $subjectId, topicId: $topicId) {
       ...ResourceInfo
       article(subjectId: $subjectId) {
         ...ArticleInfo

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -1126,7 +1126,8 @@ export const mastHeadQuery = gql`
         ...ResourceInfo
       }
     }
-    resource(id: $resourceId, subjectId: $subjectId, topicId: $topicId) @skip(if: $skipResource) {
+    resource(id: $resourceId, subjectId: $subjectId, topicId: $topicId)
+      @skip(if: $skipResource) {
       ...ResourceInfo
       article(subjectId: $subjectId) {
         ...ArticleInfo


### PR DESCRIPTION
Fixes NDLANO/Issues#2769
Depends on ~https://github.com/NDLANO/graphql-api/pull/193~

Fikser sortering av ressurser ved å legge til parameter i graphql. Det er fordi uten parameter så hentes ressursen med rank=undefined og då havner ressursen øverst i lista. Legger også til active-flagg i ugrupperte ressurser.

Test: Sjekk følgende artikler at ugrupperte ressurser kjem i korrekt rekkefølge og at Du er her vises.
https://ndla-frontend-pr-788.ndla.sh/subject:20/topic:1:186732/topic:1:187167/resource:1:151951
https://ndla-frontend-pr-788.ndla.sh/subject:1:a3c1b65a-c41f-4879-b650-32a13fe1801b/topic:2:1:187398/topic:4:1:165209/resource:1:116671