### PR TITLE
fixed site title for moved resource page

### DIFF
--- a/src/containers/MovedResourcePage/MovedResourcePage.jsx
+++ b/src/containers/MovedResourcePage/MovedResourcePage.jsx
@@ -10,6 +10,7 @@ import React from 'react';
 import { SearchResultList, OneColumn } from '@ndla/ui';
 
 import { useTranslation } from 'react-i18next';
+import { HelmetWithTracker } from '@ndla/tracker';
 import { movedResourceQuery } from '../../queries';
 import { useGraphQuery } from '../../util/runQueries';
 import handleError from '../../util/handleError';
@@ -77,12 +78,15 @@ const MovedResourcePage = ({ resource }) => {
   );
 
   return (
-    <OneColumn>
-      <h1>{t('movedResourcePage.title')}</h1>
-      <div className="c-search-result">
-        <SearchResultList results={results} />
-      </div>
-    </OneColumn>
+    <>
+      <HelmetWithTracker title={t('htmlTitles.movedResourcePage')} />
+      <OneColumn>
+        <h1>{t('movedResourcePage.title')}</h1>
+        <div className="c-search-result">
+          <SearchResultList results={results} />
+        </div>
+      </OneColumn>
+    </>
   );
 };
 

--- a/src/messages/messagesEN.ts
+++ b/src/messages/messagesEN.ts
@@ -18,6 +18,7 @@ const messages = {
     notFound: `Page not found - ${titleTemplate}`,
     subject: 'Subject',
     lti: `LTI - ${titleTemplate}`,
+    movedResourcePage: `The page has been moved - ${titleTemplate}`,
     toolbox: {
       visualElement: 'About subject video',
       introduction:

--- a/src/messages/messagesNB.ts
+++ b/src/messages/messagesNB.ts
@@ -18,6 +18,7 @@ const messages = {
     notFound: `Siden finnes ikke - ${titleTemplate}`,
     subject: 'Fag',
     lti: `LTI - ${titleTemplate}`,
+    movedResourcePage: `Siden har flyttet - ${titleTemplate}`,
     toolbox: {
       visualElement: 'Om emne video',
       introduction:

--- a/src/messages/messagesNN.ts
+++ b/src/messages/messagesNN.ts
@@ -18,6 +18,7 @@ const messages = {
     notFound: `Sida finst ikkje - ${titleTemplate}`,
     subject: 'Fag',
     lti: `LTI - ${titleTemplate}`,
+    movedResourcePage: `Sida har flytta - ${titleTemplate}`,
     toolbox: {
       visualElement: 'Om emne video',
       introduction:


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2771

Setter ny sidetittel for "sider som har flyttet". 
Hvordan teste:
* besøk /subject:80063181-61d8-4c52-9bbc-4313376175a2/topic:b34684b3-3e91-44ee-88b4-1c3e588586dc/topic:1cc14972-df1f-4294-b19b-1c2472f5489a/topic:a00fc42f-30b9-44f4-94ad-76adcaee3079/resource:1:193411
* sjekk at sidetittel er `Siden har flyttet - NDLA` istedenfor `NDLA`