### PR TITLE
2778 bugfix language graphql query

### DIFF
--- a/src/I18nWrapper.tsx
+++ b/src/I18nWrapper.tsx
@@ -33,7 +33,6 @@ export const I18nWrapper = ({ locale, children }: Props) => {
       ) {
         setLang(storedLang as LocaleType);
         if (!window.location.pathname.includes('/login/success')) {
-          console.log('her');
           history.replace(`/${storedLang}${window.location.pathname}`);
           apolloClient.setLink(createApolloLinks(storedLang));
           apolloClient.resetStore();

--- a/src/I18nWrapper.tsx
+++ b/src/I18nWrapper.tsx
@@ -1,3 +1,4 @@
+import { useApolloClient } from '@apollo/client';
 import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router';
@@ -6,6 +7,7 @@ import { getDefaultLocale } from './config';
 import { STORED_LANGUAGE_KEY } from './constants';
 import { appLocales, isValidLocale } from './i18n';
 import { LocaleType } from './interfaces';
+import { createApolloLinks } from './util/apiHelpers';
 
 interface Props {
   locale?: LocaleType;
@@ -17,6 +19,7 @@ export const I18nWrapper = ({ locale, children }: Props) => {
   const history = useHistory();
   const [lang, setLang] = useState(locale);
   const firstRender = useRef(true);
+  const apolloClient = useApolloClient();
 
   useEffect(() => {
     if (firstRender.current) {
@@ -31,6 +34,7 @@ export const I18nWrapper = ({ locale, children }: Props) => {
         setLang(storedLang as LocaleType);
         if (!window.location.pathname.includes('/login/success')) {
           history.replace(`/${storedLang}${window.location.pathname}`);
+          apolloClient.setLink(createApolloLinks(storedLang));
         }
       } else if (locale && !isValidLocale(locale)) {
         const l =

--- a/src/I18nWrapper.tsx
+++ b/src/I18nWrapper.tsx
@@ -33,8 +33,10 @@ export const I18nWrapper = ({ locale, children }: Props) => {
       ) {
         setLang(storedLang as LocaleType);
         if (!window.location.pathname.includes('/login/success')) {
+          console.log('her');
           history.replace(`/${storedLang}${window.location.pathname}`);
           apolloClient.setLink(createApolloLinks(storedLang));
+          apolloClient.resetStore();
         }
       } else if (locale && !isValidLocale(locale)) {
         const l =

--- a/src/components/Article/CompetenceGoals.jsx
+++ b/src/components/Article/CompetenceGoals.jsx
@@ -6,7 +6,6 @@
  */
 
 import React from 'react';
-import { useQuery } from '@apollo/client';
 import PropTypes from 'prop-types';
 import { CompetenceGoalTab } from '@ndla/ui';
 import { isValidElementType } from 'react-is';
@@ -16,6 +15,7 @@ import { useTranslation } from 'react-i18next';
 import { competenceGoalsQuery } from '../../queries';
 import handleError from '../../util/handleError';
 import { ArticleShape, SubjectShape } from '../../shapes';
+import { useGraphQuery } from '../../util/runQueries';
 
 export function groupByCurriculums(competenceGoals, addUrl = false) {
   const searchUrl = '/search?grepCodes=';
@@ -62,7 +62,7 @@ const CompetenceGoals = ({
     article.supportedLanguages.find(l => l === language) ||
     article.supportedLanguages[0];
   const { t } = useTranslation();
-  const { error, data, loading } = useQuery(competenceGoalsQuery, {
+  const { error, data, loading } = useGraphQuery(competenceGoalsQuery, {
     variables: { codes, nodeId, language: lang },
   });
 

--- a/src/containers/FilmFrontpage/NdlaFilmFrontpage.jsx
+++ b/src/containers/FilmFrontpage/NdlaFilmFrontpage.jsx
@@ -24,7 +24,7 @@ import { useGraphQuery } from '../../util/runQueries';
 const ALL_MOVIES_ID = 'ALL_MOVIES_ID';
 
 const NdlaFilm = ({ locale, skipToContentId }) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [state, setState] = useState({
     moviesByType: [],
     showingAll: false,
@@ -35,7 +35,9 @@ const NdlaFilm = ({ locale, skipToContentId }) => {
   const { data: { subject } = {} } = useGraphQuery(subjectPageQuery, {
     variables: { subjectId: 'urn:subject:20' },
   });
-  const [searchAllMovies, { data: allMovies }] = useLazyQuery(searchFilmQuery);
+  const [searchAllMovies, { data: allMovies }] = useLazyQuery(searchFilmQuery, {
+    variables: { language: i18n.language, fallback: 'true' },
+  });
 
   useEffect(() => {
     // if we receive new movies we map them into state

--- a/src/containers/FilmFrontpage/NdlaFilmFrontpage.jsx
+++ b/src/containers/FilmFrontpage/NdlaFilmFrontpage.jsx
@@ -8,9 +8,9 @@
 
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { useLazyQuery, useQuery } from '@apollo/client';
+import { useLazyQuery } from '@apollo/client';
 
-import { useTranslation } from 'react-i18next';
+import { useTranslation, withTranslation } from 'react-i18next';
 import FilmFrontpage from './FilmFrontpage';
 import {
   subjectPageQuery,
@@ -19,6 +19,7 @@ import {
 } from '../../queries';
 import { movieResourceTypes } from './resourceTypes';
 import MoreAboutNdlaFilm from './MoreAboutNdlaFilm';
+import { useGraphQuery } from '../../util/runQueries';
 
 const ALL_MOVIES_ID = 'ALL_MOVIES_ID';
 
@@ -30,8 +31,8 @@ const NdlaFilm = ({ locale, skipToContentId }) => {
     fetchingMoviesByType: false,
   });
 
-  const { data: { filmfrontpage } = {} } = useQuery(filmFrontPageQuery);
-  const { data: { subject } = {} } = useQuery(subjectPageQuery, {
+  const { data: { filmfrontpage } = {} } = useGraphQuery(filmFrontPageQuery);
+  const { data: { subject } = {} } = useGraphQuery(subjectPageQuery, {
     variables: { subjectId: 'urn:subject:20' },
   });
   const [searchAllMovies, { data: allMovies }] = useLazyQuery(searchFilmQuery);
@@ -127,4 +128,4 @@ NdlaFilm.propTypes = {
   skipToContentId: PropTypes.string,
 };
 
-export default NdlaFilm;
+export default withTranslation()(NdlaFilm);

--- a/src/containers/FilmFrontpage/NdlaFilmFrontpage.jsx
+++ b/src/containers/FilmFrontpage/NdlaFilmFrontpage.jsx
@@ -10,7 +10,7 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useLazyQuery } from '@apollo/client';
 
-import { useTranslation, withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import FilmFrontpage from './FilmFrontpage';
 import {
   subjectPageQuery,
@@ -128,4 +128,4 @@ NdlaFilm.propTypes = {
   skipToContentId: PropTypes.string,
 };
 
-export default withTranslation()(NdlaFilm);
+export default NdlaFilm;

--- a/src/containers/ResourcePage/ResourcePage.jsx
+++ b/src/containers/ResourcePage/ResourcePage.jsx
@@ -9,7 +9,7 @@
 import React from 'react';
 import { Redirect } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import { useTranslation, withTranslation } from 'react-i18next';
+import { withTranslation } from 'react-i18next';
 
 import DefaultErrorMessage from '../../components/DefaultErrorMessage';
 import { getUrnIdsFromProps } from '../../routeHelpers';
@@ -29,9 +29,6 @@ const urlInPaths = (location, resource) => {
 };
 
 const ResourcePage = props => {
-  const {
-    i18n: { language },
-  } = useTranslation();
   const { subjectId, resourceId, topicId } = getUrnIdsFromProps(props);
   const { error, loading, data } = useGraphQuery(resourcePageQuery, {
     variables: {
@@ -39,7 +36,6 @@ const ResourcePage = props => {
       topicId,
       resourceId,
     },
-    'accept-language': language,
   });
 
   if (loading) {

--- a/src/containers/ResourcePage/ResourcePage.jsx
+++ b/src/containers/ResourcePage/ResourcePage.jsx
@@ -9,7 +9,7 @@
 import React from 'react';
 import { Redirect } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import { withTranslation } from 'react-i18next';
+import { useTranslation, withTranslation } from 'react-i18next';
 
 import DefaultErrorMessage from '../../components/DefaultErrorMessage';
 import { getUrnIdsFromProps } from '../../routeHelpers';
@@ -29,9 +29,17 @@ const urlInPaths = (location, resource) => {
 };
 
 const ResourcePage = props => {
+  const {
+    i18n: { language },
+  } = useTranslation();
   const { subjectId, resourceId, topicId } = getUrnIdsFromProps(props);
   const { error, loading, data } = useGraphQuery(resourcePageQuery, {
-    variables: { subjectId, topicId, resourceId },
+    variables: {
+      subjectId,
+      topicId,
+      resourceId,
+    },
+    'accept-language': language,
   });
 
   if (loading) {

--- a/src/util/runQueries.ts
+++ b/src/util/runQueries.ts
@@ -22,6 +22,7 @@ export function useGraphQuery<TData = any, TVariables = OperationVariables>(
   const {
     i18n: { language },
   } = useTranslation();
+
   const result = useQuery(query, {
     errorPolicy: 'all',
     ...(language ? { 'accept-language': language } : {}),

--- a/src/util/runQueries.ts
+++ b/src/util/runQueries.ts
@@ -13,13 +13,18 @@ import {
   TypedDocumentNode,
   useQuery,
 } from '@apollo/client';
+import { useTranslation } from 'react-i18next';
 
 export function useGraphQuery<TData = any, TVariables = OperationVariables>(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
   options?: QueryHookOptions<TData, TVariables>,
 ): QueryResult<TData, TVariables> {
+  const {
+    i18n: { language },
+  } = useTranslation();
   const result = useQuery(query, {
     errorPolicy: 'all',
+    ...(language ? { 'accept-language': language } : {}),
     ...options,
   });
 

--- a/src/util/runQueries.ts
+++ b/src/util/runQueries.ts
@@ -13,19 +13,13 @@ import {
   TypedDocumentNode,
   useQuery,
 } from '@apollo/client';
-import { useTranslation } from 'react-i18next';
 
 export function useGraphQuery<TData = any, TVariables = OperationVariables>(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
   options?: QueryHookOptions<TData, TVariables>,
 ): QueryResult<TData, TVariables> {
-  const {
-    i18n: { language },
-  } = useTranslation();
-
   const result = useQuery(query, {
     errorPolicy: 'all',
-    ...(language ? { 'accept-language': language } : {}),
     ...options,
   });
 


### PR DESCRIPTION
Under arbeid

Fixes NDLANO/Issues#2778

Fikser en feil der feil språkversjon blir hentet. Legger på `accept-language`-parameter manuelt basert på i18n.

Problemet ser ut til å oppstå i de fleste sider i ndla frontend

Hvordan teste:
1. Sørg for at du allerede har besøk PR-instansen og at språket er satt til nn.
2. Lukk deretter siden og åpne /subject:1:78e538a3-78bf-4db2-af00-2ca7d721cb25/topic:2:198170/topic:2:198460/, uten language prefix.
3. Teksten som vises skal være på nynorsk. Gjør du det samme i test får du bokmål.