### PR TITLE
Added a static width to resultsWithContentTypeBagdeAndImage

### DIFF
--- a/src/containers/SearchPage/searchHelpers.js
+++ b/src/containers/SearchPage/searchHelpers.js
@@ -236,7 +236,9 @@ export const resultsWithContentTypeBadgeAndImage = (
         <LtiEmbed ltiData={ltiData} item={result} />
       ),
       contentTypeLabel: contentType ? t(`contentTypes.${contentType}`) : '',
-      image: metaImage && <Image src={metaImage.url} alt={metaImage.alt} />,
+      image: metaImage && (
+        <Image src={metaImage.url} alt={metaImage.alt} width={'80px'} />
+      ),
     };
   });
 


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2784

La på en statisk bredde. Funksjonaliteten brukes kun for å vise flyttede topics og ressurser. Feilen kommer av at et `Image` nå wrappes i en `StyledImageWrapper`, som gjør at `SearchResultItem`-scss'en overstyres. 