### PR TITLE
Use locale as parameter.

### DIFF
--- a/src/containers/LearningpathPage/LearningpathPage.jsx
+++ b/src/containers/LearningpathPage/LearningpathPage.jsx
@@ -162,14 +162,16 @@ class LearningpathPage extends Component {
 
     const breadcrumbItems =
       subject && topicPath
-        ? toBreadcrumbItems(t('breadcrumb.toFrontpage'), [
-            subject,
-            ...topicPath,
-            { name: learningpath.title, url: '' },
-          ])
-        : toBreadcrumbItems(t('breadcrumb.toFrontpage'), [
-            { name: learningpath.title, url: '' },
-          ]);
+        ? toBreadcrumbItems(
+            t('breadcrumb.toFrontpage'),
+            [subject, ...topicPath, { name: learningpath.title, url: '' }],
+            locale,
+          )
+        : toBreadcrumbItems(
+            t('breadcrumb.toFrontpage'),
+            [{ name: learningpath.title, url: '' }],
+            locale,
+          );
 
     return (
       <div>

--- a/src/containers/Masthead/MastheadContainer.tsx
+++ b/src/containers/Masthead/MastheadContainer.tsx
@@ -152,11 +152,11 @@ const MastheadContainer = ({
   const path = topicPath ?? [];
 
   const breadcrumbBlockItems = (subject?.id
-    ? toBreadcrumbItems(t('breadcrumb.toFrontpage'), [
-        subject,
-        ...path,
-        ...(resource ? [resource] : []),
-      ])
+    ? toBreadcrumbItems(
+        t('breadcrumb.toFrontpage'),
+        [subject, ...path, ...(resource ? [resource] : [])],
+        locale,
+      )
     : []
   ).filter(uri => !!uri.name && !!uri.to);
 

--- a/src/containers/TopicPage/TopicContainer.jsx
+++ b/src/containers/TopicPage/TopicContainer.jsx
@@ -130,10 +130,11 @@ const TopicContainer = ({
             <section>
               {subject ? (
                 <Breadcrumb
-                  items={toBreadcrumbItems(t('breadcrumb.toFrontpage'), [
-                    subject,
-                    ...topicPath,
-                  ])}
+                  items={toBreadcrumbItems(
+                    t('breadcrumb.toFrontpage'),
+                    [subject, ...topicPath],
+                    locale,
+                  )}
                 />
               ) : null}
             </section>


### PR DESCRIPTION
Fixes NDLANO/Issues#2860

Gjør at breadcrumbs har samme språk overalt.

Test:
* Åpne test.ndla.no og klikk deg fram til en artikkel. Bytt språk til nynorsk. Breadcrumb for artikkel er nynorsk. Scroll ned slik at breadcrumb skjules, og breadcrumb i masthead vises. Denne er på bokmål.
* Gjør det samme i denne branchen, og sjekk at breadcrumb i masthead er samme som for artikkel.