### PR TITLE
#2874: Handle boolean fallbacks in config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,10 @@ export function getEnvironmentVariabel(
 ): string | boolean | undefined {
   const env = 'env';
   const variableValue = process[env][key]; // Hack to prevent DefinePlugin replacing process.env
+  if (typeof fallback === 'boolean') {
+    return variableValue ? variableValue.toLowerCase() === 'true' : fallback;
+  }
+
   return variableValue || fallback;
 }
 


### PR DESCRIPTION
This makes boolean environment variables false if they are not set to
`true` when converted to lowercase. This makes FEIDE_ENABLED act as
expected.

Kan testes ved å sjekke at FEIDE ikonet ikke dukker opp dersom `FEIDE_ENABLED` er satt til `false` feks istedet for å mangle.