### PR TITLE
Justerer matte styling.

### DIFF
--- a/src/style/index.css
+++ b/src/style/index.css
@@ -20,7 +20,7 @@ mjx-container.MathJax[jax='CHTML'][display='true'] {
   display: inline-flex !important;
   overflow-x: auto;
   overflow-y: hidden;
-  padding: 0;
+  padding: 1px 0;
   margin: 5px 0;
   max-width: -webkit-stretch;
 }


### PR DESCRIPTION
Legger på en px padding for å gjøre matte litt penere.

Uten padding: 
![image](https://user-images.githubusercontent.com/8956884/143878706-8f8fae10-ee78-4ab5-a121-6a615e39277a.png)

Med padding:
![image](https://user-images.githubusercontent.com/8956884/143878900-fc9a6d13-386d-47a2-858d-848afb7a6a82.png)

Det er en liten forskjell men den er synlig, spesiellt på B. Sjekk også /article/31308 i pr-installasjon.