### PR TITLE
Upgrade mathjax and adjust styling to fix rendering.

### DIFF
--- a/public/static/mathjax-config.js
+++ b/public/static/mathjax-config.js
@@ -8,7 +8,7 @@
 
 window.MathJax = {
     chtml:{
-        mathmlSpacing:false
+        mathmlSpacing: true,
     },
     options:{
         renderActions:{

--- a/public/static/mathjax-config.js
+++ b/public/static/mathjax-config.js
@@ -7,9 +7,6 @@
  */
 
 window.MathJax = {
-    loader: {
-        load: ['ui/lazy']
-    },
     chtml:{
         mathmlSpacing: false
     },

--- a/public/static/mathjax-config.js
+++ b/public/static/mathjax-config.js
@@ -7,8 +7,11 @@
  */
 
 window.MathJax = {
+    loader: {
+        load: ['ui/lazy']
+    },
     chtml:{
-        mathmlSpacing: true,
+        mathmlSpacing: false
     },
     options:{
         renderActions:{

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -18,9 +18,9 @@
 
 mjx-container.MathJax[jax='CHTML'][display='true'] {
   display: inline-flex !important;
-  overflow-x: auto;
+  overflow-x: hidden;
   overflow-y: hidden;
-  padding: 1px 0;
+  padding: 1px 4px;
   margin: 5px 0;
   max-width: -webkit-stretch;
 }

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -21,6 +21,6 @@ mjx-container.MathJax[jax='CHTML'][display='true'] {
   overflow-x: hidden;
   overflow-y: hidden;
   padding: 1px 4px;
-  margin: 5px 0;
+  margin: 0;
   max-width: -webkit-stretch;
 }

--- a/src/util/getArticleScripts.ts
+++ b/src/util/getArticleScripts.ts
@@ -31,7 +31,7 @@ export function getArticleScripts(article: GQLArticle) {
     });
 
     scripts.push({
-      src: 'https://cdn.jsdelivr.net/npm/mathjax@3.1.2/es5/mml-chtml.js',
+      src: 'https://cdn.jsdelivr.net/npm/mathjax@3.2.0/es5/mml-chtml.js',
       type: 'text/javascript',
       async: false,
       defer: true,


### PR DESCRIPTION
Setter nyeste mathjax. Måtte endre litt på stylinga for at ikkje formler skulle kuttes, pga endring i bredde på feks vektorer.

Gammel mathjax:
![image](https://user-images.githubusercontent.com/8956884/144051532-8b0e4390-2d4e-418c-b2ea-44d7db88e58c.png)

Ny mathjax:
![image](https://user-images.githubusercontent.com/8956884/144051643-a9cbe5c6-8d25-4fa2-991a-b28bcf377b37.png)

Vektorpiler er penere opptegna. Avstand mellom formler er litt større på grunn av padding, men det måtte til for ikkje å kutte noen av vektorene:
![image](https://user-images.githubusercontent.com/8956884/144052245-a45b8192-3313-4677-b962-5a6632afde36.png)
![image](https://user-images.githubusercontent.com/8956884/144052324-3ceb140e-c1e1-407f-910b-17c4d5c5ede7.png)
