### PR TITLE
Show active resource anyways

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@ndla/safelink": "^1.0.5",
     "@ndla/tabs": "^1.0.8",
     "@ndla/tracker": "^0.5.0",
-    "@ndla/ui": "^3.0.14-alpha.0",
+    "@ndla/ui": "^3.0.14",
     "@ndla/util": "^2.0.0",
     "@ndla/zendesk": "^0.2.44",
     "babel-plugin-graphql-tag": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@ndla/safelink": "^1.0.5",
     "@ndla/tabs": "^1.0.8",
     "@ndla/tracker": "^0.5.0",
-    "@ndla/ui": "^3.0.13",
+    "@ndla/ui": "^3.0.14-alpha.0",
     "@ndla/util": "^2.0.0",
     "@ndla/zendesk": "^0.2.44",
     "babel-plugin-graphql-tag": "^2.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2776,10 +2776,10 @@
   dependencies:
     warning "^4.0.3"
 
-"@ndla/ui@^3.0.13":
-  version "3.0.13"
-  resolved "https://registry.yarnpkg.com/@ndla/ui/-/ui-3.0.13.tgz#c2bb7ad3909fba196117ec74f80ebacf16b37bc4"
-  integrity sha512-9LKLf+63WMg0PolVfUZLoV0f2aZy6x7I8oPrUQaTh/1nMUQqPnige2UNwFqzOAa/zhrOa2SeviKDHM6fTZw5bQ==
+"@ndla/ui@^3.0.14-alpha.0":
+  version "3.0.14-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ndla/ui/-/ui-3.0.14-alpha.0.tgz#ac45af5449b09bb9459b48425cdd8328799c2c64"
+  integrity sha512-BA1JtiUeB9lQKHkddpfU5ZDcp2GHxTX6SD63iveCDWsJ/k1MDqdZqjqcRv9CzqLvhloTNb/JY0lP+kMkY8p0Dg==
   dependencies:
     "@ndla/button" "^1.0.6"
     "@ndla/carousel" "^1.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2776,10 +2776,10 @@
   dependencies:
     warning "^4.0.3"
 
-"@ndla/ui@^3.0.14-alpha.0":
-  version "3.0.14-alpha.0"
-  resolved "https://registry.yarnpkg.com/@ndla/ui/-/ui-3.0.14-alpha.0.tgz#ac45af5449b09bb9459b48425cdd8328799c2c64"
-  integrity sha512-BA1JtiUeB9lQKHkddpfU5ZDcp2GHxTX6SD63iveCDWsJ/k1MDqdZqjqcRv9CzqLvhloTNb/JY0lP+kMkY8p0Dg==
+"@ndla/ui@^3.0.14":
+  version "3.0.14"
+  resolved "https://registry.yarnpkg.com/@ndla/ui/-/ui-3.0.14.tgz#7d4e84e289cd85c1a6b76f8309a9aae1ac131fbd"
+  integrity sha512-aQvu6Wjq2fPM0b4oQAGiuUyoOwkyKf8jGEZd48mNToyRwYW/WmvQtl5ECIqZwfQU3Zlh2/15o12nJ65L02sXZg==
   dependencies:
     "@ndla/button" "^1.0.6"
     "@ndla/carousel" "^1.0.6"


### PR DESCRIPTION
Bumper for å få alpha-versjon av pakke.

Test
* Søk opp artikkel som er tilleggstoff, og klikk deg inn på den. Artikkelen skal vises i launchpad sjølv om tilleggstoff er skjult.
* Om du navigerer deg fra ressursen forsvinner den.