### PR TITLE
#2888: Scroll to header if hash in `Article` matches header

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@ndla/safelink": "^1.0.5",
     "@ndla/tabs": "^1.0.8",
     "@ndla/tracker": "^0.5.0",
-    "@ndla/ui": "^3.0.15",
+    "@ndla/ui": "^3.1.0",
     "@ndla/util": "^2.0.0",
     "@ndla/zendesk": "^0.2.44",
     "babel-plugin-graphql-tag": "^2.5.0",

--- a/src/components/Article/Article.tsx
+++ b/src/components/Article/Article.tsx
@@ -6,8 +6,9 @@
  *
  */
 
-import React, { ComponentType, ReactNode, useMemo } from 'react';
+import React, { ComponentType, ReactNode, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router';
 import { Remarkable } from 'remarkable';
 // @ts-ignore
 import { Article as UIArticle, ContentTypeBadge } from '@ndla/ui';
@@ -17,6 +18,7 @@ import CompetenceGoals from './CompetenceGoals';
 import { GQLArticle, GQLArticleInfoFragment } from '../../graphqlTypes';
 import { LocaleType } from '../../interfaces';
 import VisualElementWrapper from '../VisualElement/VisualElementWrapper';
+import { MastheadHeightPx } from '../../constants';
 
 function renderCompetenceGoals(
   article: GQLArticle,
@@ -120,6 +122,26 @@ const Article = ({
     md.block.ruler.disable(['list']);
     return md;
   }, []);
+
+  const location = useLocation();
+
+  // Scroll to element with ID passed in as a query-parameter.
+  // We use query-params instead of the regular fragments since
+  // the article doesn't exist on initial page load (At least without SSR).
+  useEffect(() => {
+    if (location.hash && article.content) {
+      const element = document.getElementById(location.hash.slice(1));
+      const elementTop = element?.getBoundingClientRect().top ?? 0;
+      const bodyTop = document.body.getBoundingClientRect().top ?? 0;
+      const absoluteTop = elementTop - bodyTop;
+      const scrollPosition = absoluteTop - MastheadHeightPx;
+
+      window.scrollTo({
+        top: scrollPosition,
+        behavior: 'smooth',
+      });
+    }
+  }, [article.content, location]);
 
   if (!article) {
     return children || null;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -60,3 +60,5 @@ export const TAXONOMY_CUSTOM_FIELD_UNGROUPED_RESOURCE = 'ungrouped';
 export const OLD_SUBJECT_PAGE_REDIRECT_CUSTOM_FIELD = 'old-subject-id';
 
 export const LocaleValues = ['nb', 'nn', 'en'] as const;
+
+export const MastheadHeightPx = 84; // See `misc` in @ndla/core for origin

--- a/src/containers/ResourcePage/ResourcePage.tsx
+++ b/src/containers/ResourcePage/ResourcePage.tsx
@@ -73,9 +73,6 @@ const ResourcePage = (props: Props) => {
     }
   }
 
-  if (typeof window != 'undefined' && window.scrollY) {
-    window.scroll(0, 0);
-  }
   const { subject, resource, topic } = data;
   const relevanceId = resource.relevanceId;
   const relevance =

--- a/yarn.lock
+++ b/yarn.lock
@@ -2762,10 +2762,10 @@
     "@ndla/util" "^2.0.0"
     react-tabs "^3.0.0"
 
-"@ndla/tooltip@^0.2.46":
-  version "0.2.46"
-  resolved "https://registry.yarnpkg.com/@ndla/tooltip/-/tooltip-0.2.46.tgz#ead81211c9bb835d45f7fe67c18667028180038d"
-  integrity sha512-HX4NPKmPL8jJVo99o0BW4s0quG1ZyW/Km6A81HAm5ZmWFEHuVfRZiM/YjgvjjPl/prTfUAtqT9U/GwoLEj04fw==
+"@ndla/tooltip@^0.2.47":
+  version "0.2.47"
+  resolved "https://registry.yarnpkg.com/@ndla/tooltip/-/tooltip-0.2.47.tgz#443d3ad413f59a904be9d220cd79b8ff72f75b64"
+  integrity sha512-UoiEpp8V0JOni3iy6T0mv687CNw4r/aNScYWm/aI8p3OxH8lVc/iLnpxDXomWey7AWpsyzStiKVgrhtpaV3V3A==
   dependencies:
     "@ndla/core" "^0.7.2"
 
@@ -2776,10 +2776,10 @@
   dependencies:
     warning "^4.0.3"
 
-"@ndla/ui@^3.0.15":
-  version "3.0.15"
-  resolved "https://registry.yarnpkg.com/@ndla/ui/-/ui-3.0.15.tgz#b7ae2c0c66156641f259be45d01f152bea93a2f6"
-  integrity sha512-jo5xfID7AnSeXqO/rffZXfhjNXWmWgrEcp0IypXhYagwhqkCAtheEjNfdhOnTIu8Twlzz3+WniTHOkVS0kQMmg==
+"@ndla/ui@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@ndla/ui/-/ui-3.1.0.tgz#a89eaf9b74f81427aef16ed1ff41304e001d0d5c"
+  integrity sha512-xkIsjWOQS/a9ntYuGPq4pXEa1i8zVq20pY58cEHutRo7JU2nRbhKVyfbDqhcGW05YtPeN2gktejlfK7/f+sicA==
   dependencies:
     "@ndla/button" "^1.0.6"
     "@ndla/carousel" "^1.0.6"
@@ -2791,7 +2791,7 @@
     "@ndla/safelink" "^1.0.5"
     "@ndla/switch" "^0.0.32"
     "@ndla/tabs" "^1.0.8"
-    "@ndla/tooltip" "^0.2.46"
+    "@ndla/tooltip" "^0.2.47"
     "@ndla/util" "^2.0.0"
     "@reach/menu-button" "^0.12.1"
     "@reach/slider" "^0.12.1"


### PR DESCRIPTION
Fixes NDLANO/Issues#2888
Depends on https://github.com/NDLANO/frontend-packages/pull/928
Depends on https://github.com/NDLANO/article-converter/pull/290

Denne gjør at vi hydrater `CopyParagraphButton` komponenten, og at vi
scroller til en id om den finnes i url-fragmentet (etter #) i `Article`.

Denne er litt omfattende å teste, men fremgangsmåten blir noe som det her:
- Link `@ndla/ui` inn i article-converter og ndla-frontend (på branchene fra PR'ene over)
- Spinn opp article-converter med `yarn start`
- Spinn opp graphql (master) med `yarn start-with-local-converter`
- Spinn opp ndla-frontend med `yarn start-with-local-graphql-and-article-converter`
    - Test at link ikonet dukker opp når du hovrer over h2 titler i artikler.
    - Test at lenken blir kopiert når du trykker på den
    - Test at lenken blir scrollet til når du limer den inn

En gotcha som vi kanskje vil gjøre noe med er at siden vi bruker `#` så vil nettleseren automatisk scrolle til id'en dersom man limer den inn på samme side som man står. OG siden vi har masthead'en så vil headeren havne under den (Dette skjer kun om man allerede står på siden og paster en url med #, men er fortsatt litt teit). Vi kunne evt løst det med å bruke en query-param istedet (?).