### PR TITLE
Converted NotFoundPage to TypeScript

### DIFF
--- a/src/components/Status.tsx
+++ b/src/components/Status.tsx
@@ -6,24 +6,25 @@
  *
  */
 
-import React from 'react';
-import PropTypes from 'prop-types';
+import React, { ReactNode } from 'react';
 import { Route } from 'react-router-dom';
 
-const Status = ({ code, children }) => (
+interface Props {
+  code: number;
+  children: ReactNode;
+}
+
+const Status = ({ code, children }: Props) => (
   <Route
     render={({ staticContext }) => {
       const context = staticContext;
       if (staticContext) {
+        //@ts-ignore
         context.status = code;
       }
       return children;
     }}
   />
 );
-
-Status.propTypes = {
-  code: PropTypes.number.isRequired,
-};
 
 export default Status;

--- a/src/containers/NotFoundPage/NotFoundPage.tsx
+++ b/src/containers/NotFoundPage/NotFoundPage.tsx
@@ -9,29 +9,32 @@
 import React from 'react';
 import { OneColumn, ErrorMessage } from '@ndla/ui';
 import { HelmetWithTracker } from '@ndla/tracker';
-import { WithTranslation, withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import { Status } from '../../components';
 
-const NotFound = ({ t }: WithTranslation) => (
-  <Status code={404}>
-    <HelmetWithTracker title={t('htmlTitles.notFound')} />
-    <OneColumn cssModifier="clear">
-      <ErrorMessage
-        illustration={{
-          url: '/static/not-exist.gif',
-          altText: t('errorMessage.title'),
-        }}
-        messages={{
-          title: t('notFoundPage.title'),
-          description: t('notFoundPage.errorDescription'),
-          back: t('errorMessage.back'),
-          goToFrontPage: t('errorMessage.goToFrontPage'),
-        }}
-      />
-    </OneColumn>
-  </Status>
-);
+const NotFound = () => {
+  const { t } = useTranslation();
+  return (
+    <Status code={404}>
+      <HelmetWithTracker title={t('htmlTitles.notFound')} />
+      <OneColumn cssModifier="clear">
+        <ErrorMessage
+          illustration={{
+            url: '/static/not-exist.gif',
+            altText: t('errorMessage.title'),
+          }}
+          messages={{
+            title: t('notFoundPage.title'),
+            description: t('notFoundPage.errorDescription'),
+            back: t('errorMessage.back'),
+            goToFrontPage: t('errorMessage.goToFrontPage'),
+          }}
+        />
+      </OneColumn>
+    </Status>
+  );
+};
 
 NotFound.propTypes = {};
 
-export default withTranslation()(NotFound);
+export default NotFound;

--- a/src/containers/NotFoundPage/NotFoundPage.tsx
+++ b/src/containers/NotFoundPage/NotFoundPage.tsx
@@ -9,10 +9,10 @@
 import React from 'react';
 import { OneColumn, ErrorMessage } from '@ndla/ui';
 import { HelmetWithTracker } from '@ndla/tracker';
-import { withTranslation } from 'react-i18next';
+import { WithTranslation, withTranslation } from 'react-i18next';
 import { Status } from '../../components';
 
-const NotFound = ({ t }) => (
+const NotFound = ({ t }: WithTranslation) => (
   <Status code={404}>
     <HelmetWithTracker title={t('htmlTitles.notFound')} />
     <OneColumn cssModifier="clear">


### PR DESCRIPTION
La en `ts-ignore` i Status for å unngå å type StaticContext. Dette kommer til å endre seg når vi oppgraderer til React Router 6. Venter derfor med å ta den jobben til den kommer. 