### PR TITLE
Do not reset subtypes on reset content type filter in search

### DIFF
--- a/src/containers/SearchPage/SearchInnerPage.jsx
+++ b/src/containers/SearchPage/SearchInnerPage.jsx
@@ -145,7 +145,6 @@ const SearchInnerPage = ({
 
   const handleFilterReset = () => {
     resetSelected();
-    setTypeFilter(getTypeFilter(resourceTypes));
   };
 
   const handleFilterToggle = type => {


### PR DESCRIPTION
Fixes NDLANO/Issues#2837

Den andre feilen der henting av flere søkeresultater ikke fungerer ser det ut som er fikset allerede?

Hvordan teste:
* Åpne test.ndla.no
* Gå til søkesida.
* Klikk på filter Simulering under fagstoff, og du får 34 treff
* Klikk på knapp Fagstoff øverst, og du går inn i gruppa med simulering valgt og 34 treff.
* Klikk på Fjern filter. Fagstoff skal fortsatt ha 34 resultater og Simulering skal fortsatt være markert. (I master blir markeringen av simulering fjernet)