### PR TITLE
Fix subject page link by returning something from handleSubjectClick

### DIFF
--- a/src/containers/Masthead/components/MastheadTopics.tsx
+++ b/src/containers/Masthead/components/MastheadTopics.tsx
@@ -85,10 +85,8 @@ const MastheadTopics = ({
 
   const subjectTitle = getSubjectLongName(subject?.id, locale) || subject?.name;
 
-  const handleSubjectClick = () => {
-    if (subject) {
-      toSubject(subject.id);
-    }
+  const handleSubjectClick = (): string | undefined => {
+    return subject ? toSubject(subject.id) : undefined;
   };
 
   return (


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2925

Funksjonen som ble passert inn i `toSubject` returnerte ikke en verdi, men kalte bare på en funksjon som returnerte en verdi.
Feilen kan testes ved å gå n antall nivåer dypt i et fag, for deretter å trykke på "gå til fagforside" i Masthead. Dette skal ta deg til ndla.no/subject:$URN.