### PR TITLE
Change Article id to skipToContentId

### DIFF
--- a/src/containers/ArticlePage/ArticlePage.tsx
+++ b/src/containers/ArticlePage/ArticlePage.tsx
@@ -52,6 +52,7 @@ interface Props extends WithTranslation {
   ndlaFilm: boolean;
   loading?: boolean;
   user?: FeideUserWithGroups;
+  skipToContentId?: string;
 }
 
 const ArticlePage = ({
@@ -64,6 +65,7 @@ const ArticlePage = ({
   ndlaFilm,
   i18n,
   t,
+  skipToContentId,
 }: Props) => {
   const [scripts, setScripts] = useState<Scripts[]>([]);
   const locale = i18n.language as LocaleType;
@@ -164,6 +166,7 @@ const ArticlePage = ({
       />
       <OneColumn>
         <Article
+          id={skipToContentId}
           article={article}
           locale={locale}
           resourceType={contentType}

--- a/src/containers/MultidisciplinarySubject/MultidisciplinarySubjectArticlePage.tsx
+++ b/src/containers/MultidisciplinarySubject/MultidisciplinarySubjectArticlePage.tsx
@@ -28,7 +28,11 @@ import { AuthContext } from '../../components/AuthenticationContext';
 
 interface Props extends RootComponentProps, RouteComponentProps {}
 
-const MultidisciplinarySubjectArticlePage = ({ match, locale }: Props) => {
+const MultidisciplinarySubjectArticlePage = ({
+  match,
+  locale,
+  skipToContentId,
+}: Props) => {
   const { t } = useTranslation();
   const { user } = useContext(AuthContext);
   const { topicId, subjectId } = getUrnIdsFromProps({ match });
@@ -89,6 +93,7 @@ const MultidisciplinarySubjectArticlePage = ({ match, locale }: Props) => {
         }}
       />
       <MultidisciplinarySubjectArticle
+        skipToContentId={skipToContentId}
         topic={topic}
         subject={subject}
         resourceTypes={resourceTypes}

--- a/src/containers/MultidisciplinarySubject/components/MultidisciplinarySubjectArticle.tsx
+++ b/src/containers/MultidisciplinarySubject/components/MultidisciplinarySubjectArticle.tsx
@@ -43,6 +43,7 @@ interface Props extends WithTranslation {
   locale: LocaleType;
   resourceTypes?: GQLResourceTypeDefinition[];
   user?: FeideUserWithGroups;
+  skipToContentId?: string;
 }
 
 const MultidisciplinarySubjectArticle = ({
@@ -51,6 +52,7 @@ const MultidisciplinarySubjectArticle = ({
   subject,
   locale,
   resourceTypes,
+  skipToContentId,
 }: Props) => {
   const resourcesRef = useRef(null);
   const onLinkToResourcesClick = (e: React.MouseEvent) => {
@@ -87,6 +89,7 @@ const MultidisciplinarySubjectArticle = ({
       />
       <OneColumn>
         <Article
+          id={skipToContentId}
           article={topic.article}
           label=""
           locale={locale}

--- a/src/containers/ResourcePage/ResourcePage.tsx
+++ b/src/containers/ResourcePage/ResourcePage.tsx
@@ -101,6 +101,7 @@ const ResourcePage = (props: Props) => {
   }
   return (
     <ArticlePage
+      skipToContentId={props.skipToContentId}
       resource={data.resource}
       topic={data.topic}
       topicPath={topicPath}


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2970

Hopping til innhold er avhengige av at innholdet skal ha id'en som passeres ned i `skipToContentId`. Dette så ut til å ha blitt erstattet med den faktiske artikkelen sin ID. 

Valgte å ikke legge det inn på Iframe-endepunktene, da de ikke støtter hopping til innhold uansett.