### PR TITLE
Fix emotion cache for iframe endpoints

### DIFF
--- a/src/iframe/index.tsx
+++ b/src/iframe/index.tsx
@@ -10,9 +10,12 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { configureTracker } from '@ndla/tracker';
 import ErrorReporter from '@ndla/error-reporter';
+import { CacheProvider } from '@emotion/core';
+import createCache from '@emotion/cache';
 import { Router } from 'react-router';
 import IframePageContainer from './IframePageContainer';
 import { createHistory } from '../history';
+import { EmotionCacheKey } from '../constants';
 
 const { config, initialProps } = window.DATA;
 
@@ -38,13 +41,19 @@ configureTracker({
 });
 
 const browserHistory = createHistory();
+const cache = createCache({ key: EmotionCacheKey });
 
 const renderOrHydrate = disableSSR ? ReactDOM.render : ReactDOM.hydrate;
 renderOrHydrate(
-  <Router history={browserHistory}>
-    <IframePageContainer {...initialProps} />
-  </Router>,
+  <CacheProvider value={cache}>
+    <Router history={browserHistory}>
+      <IframePageContainer {...initialProps} />
+    </Router>
+  </CacheProvider>,
   document.getElementById('root'),
+  () => {
+    window.hasHydrated = true;
+  },
 );
 
 if (module.hot) {

--- a/src/server/routes/iframeArticleRoute.js
+++ b/src/server/routes/iframeArticleRoute.js
@@ -11,11 +11,14 @@ import url from 'url';
 import { Helmet } from 'react-helmet';
 import { INTERNAL_SERVER_ERROR, OK } from 'http-status';
 import { StaticRouter } from 'react-router';
+import { CacheProvider } from '@emotion/core';
+import createCache from '@emotion/cache';
 import { getHtmlLang } from '../../i18n';
 import IframePageContainer from '../../iframe/IframePageContainer';
 import config from '../../config';
 import handleError from '../../util/handleError';
 import { renderPageWithData, renderHtml } from '../helpers/render';
+import { EmotionCacheKey } from '../../constants';
 
 const assets =
   process.env.NODE_ENV !== 'unittest'
@@ -48,15 +51,19 @@ const disableSSR = req => {
 
 async function doRenderPage(req, initialProps) {
   const context = {};
+
+  const cache = createCache({ key: EmotionCacheKey });
   const Page = disableSSR(req) ? (
     ''
   ) : (
-    <StaticRouter
-      basename={initialProps.basename}
-      location={req.url}
-      context={context}>
-      <IframePageContainer {...initialProps} />
-    </StaticRouter>
+    <CacheProvider value={cache}>
+      <StaticRouter
+        basename={initialProps.basename}
+        location={req.url}
+        context={context}>
+        <IframePageContainer {...initialProps} />
+      </StaticRouter>
+    </CacheProvider>
   );
   const assets = getAssets();
   const { html, ...docProps } = await renderPageWithData(Page, assets, {


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2956

Ser ut som at `window.hasHydrated = true` gjorde susen. Tror absolutt at SSR-prosessen kan forenkles litt, men det får skje en annen gang. 