### PR TITLE
Account for parameters when doing automatic language redirects

### DIFF
--- a/src/I18nWrapper.tsx
+++ b/src/I18nWrapper.tsx
@@ -34,7 +34,9 @@ export const I18nWrapper = ({ locale, initialProps }: Props) => {
       ) {
         setLang(storedLang as LocaleType);
         if (!window.location.pathname.includes('/login/success')) {
-          history.replace(`/${storedLang}${window.location.pathname}`);
+          history.replace(
+            `/${storedLang}${window.location.pathname}${window.location.search}`,
+          );
           apolloClient.setLink(createApolloLinks(storedLang, document.cookie));
           apolloClient.resetStore();
         }


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2983
Kan testes ved å følge instruksjonene i trello-kortet, bare at man erstatter ndla.no med localhost:3000.