### PR TITLE
Do not use crop on previewing topic visual element in full size

### DIFF
--- a/src/containers/SubjectPage/components/Topic.tsx
+++ b/src/containers/SubjectPage/components/Topic.tsx
@@ -18,7 +18,11 @@ import Resources from '../../Resources/Resources';
 import { toTopic } from '../../../routeHelpers';
 import { getAllDimensions } from '../../../util/trackingUtil';
 import { htmlTitle } from '../../../util/titleHelper';
-import { getCrop, getFocalPoint } from '../../../util/imageHelpers';
+import {
+  getCrop,
+  getFocalPoint,
+  getImageWithoutCrop,
+} from '../../../util/imageHelpers';
 import { getSubjectLongName } from '../../../data/subjects';
 import {
   GQLResourceTypeDefinition,
@@ -107,7 +111,10 @@ const Topic = ({
             type: getResourceType(article.visualElement.resource),
             element: (
               <VisualElementWrapper
-                visualElement={article.visualElement}
+                visualElement={{
+                  ...article.visualElement,
+                  image: getImageWithoutCrop(article.visualElement.image),
+                }}
                 locale={locale}
               />
             ),

--- a/src/util/imageHelpers.ts
+++ b/src/util/imageHelpers.ts
@@ -31,3 +31,19 @@ export const getFocalPoint = (visualElement: GQLImageElement) => {
   }
   return undefined;
 };
+
+export const getImageWithoutCrop = (
+  image?: GQLImageElement,
+): GQLImageElement | undefined => {
+  return (
+    image && {
+      ...image,
+      focalX: undefined,
+      focalY: undefined,
+      upperLeftX: undefined,
+      upperLeftY: undefined,
+      lowerRightX: undefined,
+      lowerRightY: undefined,
+    }
+  );
+};


### PR DESCRIPTION
Fixes NDLANO/Issues#2977

Fjerner crop-informasjon fra visuelt element som sendes inn til `Topic`-komponenten. Sirkelformet bildet som er croppet skal da vises i full størrelse ved ekspandering.

Hvordan teste: Sammenlign disse to. I test skal ekspandert bilde være croppet. Det skal det ikke være i PR-instans.
https://test.ndla.no/en/subject:1:1f1865fc-e4cc-48a0-918f-3530485ec424/topic:1:ae0e6304-d30e-4d3f-8e94-306d1a884e10
og
https://ndla-frontend-pr-877.ndla.sh/en/subject:1:1f1865fc-e4cc-48a0-918f-3530485ec424/topic:1:ae0e6304-d30e-4d3f-8e94-306d1a884e10