### PR TITLE
Fixed apolloState and client-side hydration

### DIFF
--- a/src/server/helpers/render.js
+++ b/src/server/helpers/render.js
@@ -52,13 +52,21 @@ export function renderPage(Page, assets, data = {}, cache) {
   };
 }
 
-export async function renderPageWithData(Page, assets, data = {}, cache) {
+export async function renderPageWithData(
+  Page,
+  assets,
+  data = {},
+  cache,
+  client,
+) {
   resetIdCounter();
   if (cache) {
     const { extractCritical } = createEmotionServer(cache);
     const { html, css, ids } = extractCritical(
       await renderToStringWithData(Page),
     );
+
+    const apolloState = client?.extract();
     const helmet = Helmet.renderStatic();
     return {
       html,
@@ -69,6 +77,7 @@ export async function renderPageWithData(Page, assets, data = {}, cache) {
       // Following is serialized to window.DATA
       data: {
         ...data,
+        apolloState,
         config,
         assets,
       },

--- a/src/server/routes/defaultRoute.js
+++ b/src/server/routes/defaultRoute.js
@@ -101,6 +101,7 @@ async function doRender(req) {
       serverQuery: req.query,
     },
     cache,
+    client,
   );
 
   return {


### PR DESCRIPTION
Hydrering av apollo-state viste seg å være brukket. Vi kalte rett og slett på `client.extract()` for tidlig, så `apolloState` var alltid et tomt objekt. Nå funker det faktisk ordentlig. Konsekvensen av dette er at vi slipper å se at siden blir hydrert, for deretter å gå rett tilbake i en loading-state. Nå slipper vi å gjøre doble graphql-kall!

Merk derimot at dette fortsatt er et problem for iframe-endepunktet. Der er det litt vanskeligere å fikse opp i ting, da apollo-klienten først opprettes lenger ned i treet. Skal se nærmere på det i morgen, men kan godt hende det ender opp i egen PR.