### PR TITLE
Fix GQL errors

### DIFF
--- a/src/containers/FilmFrontpage/NdlaFilmFrontpage.tsx
+++ b/src/containers/FilmFrontpage/NdlaFilmFrontpage.tsx
@@ -19,8 +19,9 @@ import {
 import { movieResourceTypes } from './resourceTypes';
 import { useGraphQuery } from '../../util/runQueries';
 import {
-  GQLArticleSearchResult,
   GQLFilmFrontPageQuery,
+  GQLSearchFilmArticleSearchResultFragment,
+  GQLSearchFilmLearningpathSearchResultFragment,
   GQLSearchWithoutPaginationQuery,
   GQLSubjectPageQuery,
 } from '../../graphqlTypes';
@@ -31,7 +32,9 @@ interface Props {
   skipToContentId?: string;
 }
 
-export type MoviesByType = Omit<GQLArticleSearchResult, '__typename'>;
+export type MoviesByType =
+  | GQLSearchFilmArticleSearchResultFragment
+  | GQLSearchFilmLearningpathSearchResultFragment;
 
 const NdlaFilm = ({ skipToContentId }: Props) => {
   const [moviesByType, setMoviesByType] = useState<MoviesByType[]>([]);
@@ -56,13 +59,13 @@ const NdlaFilm = ({ skipToContentId }: Props) => {
     // if we receive new movies we map them into state
     if (allMovies) {
       const byType = allMovies.searchWithoutPagination?.results?.map(movie => {
-        const contexts = movie?.contexts?.filter(
+        const contexts = movie.contexts.filter(
           ctx => ctx.learningResourceType === 'standard',
         );
         return {
           ...movie,
-          path: contexts?.[0]?.path,
-          resourceTypes: contexts?.flatMap(ctx => ctx.resourceTypes),
+          path: contexts[0]?.path,
+          resourceTypes: contexts.flatMap(ctx => ctx.resourceTypes),
         };
       });
 

--- a/src/containers/SubjectPage/components/MovedTopicPage.tsx
+++ b/src/containers/SubjectPage/components/MovedTopicPage.tsx
@@ -13,7 +13,11 @@ import { useTranslation } from 'react-i18next';
 import { resultsWithContentTypeBadgeAndImage } from '../../SearchPage/searchHelpers';
 import { GQLSearchResult, GQLTopic } from '../../../graphqlTypes';
 
-interface GQLSearchResultExtended extends Omit<GQLSearchResult, 'id'> {
+interface GQLSearchResultExtended
+  extends Omit<
+    GQLSearchResult,
+    'id' | 'contexts' | 'metaDescription' | 'supportedLanguages' | 'traits'
+  > {
   subjects?: {
     url?: string;
     title: string;
@@ -21,13 +25,14 @@ interface GQLSearchResultExtended extends Omit<GQLSearchResult, 'id'> {
   }[];
   ingress?: string;
   id: string;
+  contentType: string;
 }
 
 const convertTopicToResult = (topic: GQLTopic): GQLSearchResultExtended => {
   return {
     metaImage: topic.meta?.metaImage,
     title: topic.name,
-    url: topic.path,
+    url: topic.path || '',
     id: topic.id,
     ingress: topic.meta?.metaDescription,
     subjects: topic.breadcrumbs?.map(crumb => ({

--- a/src/gqlSchema.json
+++ b/src/gqlSchema.json
@@ -8054,6 +8054,46 @@
             "deprecationReason": null
           },
           {
+            "name": "subjectIds",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "subjectNames",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "metaImage",
             "description": null,
             "args": [],
@@ -8065,6 +8105,18 @@
                 "name": "MetaImage",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "visualElement",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "VisualElement",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -10355,7 +10407,7 @@
                 "deprecationReason": null
               },
               {
-                "name": "exactTitleMatch",
+                "name": "exactMatch",
                 "description": null,
                 "type": {
                   "kind": "SCALAR",

--- a/src/gqlSchema.json
+++ b/src/gqlSchema.json
@@ -162,6 +162,50 @@
       },
       {
         "kind": "OBJECT",
+        "name": "Description",
+        "description": null,
+        "specifiedByUrl": null,
+        "fields": [
+          {
+            "name": "description",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "language",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "Tags",
         "description": null,
         "specifiedByUrl": null,
@@ -171,15 +215,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -275,22 +323,6 @@
         "specifiedByUrl": null,
         "fields": [
           {
-            "name": "header",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "introduction",
             "description": null,
             "args": [],
@@ -322,6 +354,34 @@
             "isDeprecated": false,
             "deprecationReason": null
           },
+          {
+            "name": "language",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Manuscript",
+        "description": null,
+        "specifiedByUrl": null,
+        "fields": [
           {
             "name": "manuscript",
             "description": null,
@@ -375,7 +435,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "Int",
                 "ofType": null
               }
             },
@@ -451,9 +511,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "OBJECT",
-              "name": "Tags",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Tags",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -463,15 +527,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -505,6 +573,350 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "series",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "PodcastSeries",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "manuscript",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Manuscript",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "PodcastSeries",
+        "description": null,
+        "specifiedByUrl": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Title",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Description",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "supportedLanguages",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "episodes",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Audio",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "coverPhoto",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CoverPhoto",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AudioSummary",
+        "description": null,
+        "specifiedByUrl": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Title",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "audioType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "license",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "supportedLanguages",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "manuscript",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Manuscript",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "podcastMeta",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "PodcastMeta",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "series",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "PodcastSeries",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastUpdated",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -523,9 +935,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -547,15 +963,203 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "totalCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "results",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Audio",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "PodcastSeriesSummary",
+        "description": null,
+        "specifiedByUrl": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Title",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Description",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "supportedLanguages",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "episodes",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AudioSummary",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "coverPhoto",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CoverPhoto",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "PodcastSeriesSearch",
+        "description": null,
+        "specifiedByUrl": null,
+        "fields": [
+          {
+            "name": "pageSize",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "page",
             "description": null,
             "args": [],
             "type": {
@@ -567,19 +1171,55 @@
             "deprecationReason": null
           },
           {
+            "name": "language",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "results",
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Audio",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "PodcastSeriesSummary",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -2564,9 +3204,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "OBJECT",
-              "name": "License",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "License",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -2576,15 +3220,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Contributor",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Contributor",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -2596,15 +3244,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Contributor",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Contributor",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -2616,15 +3268,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Contributor",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Contributor",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -5696,9 +6352,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -5708,15 +6368,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -5728,9 +6392,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -5740,9 +6408,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -5760,31 +6432,23 @@
             "deprecationReason": null
           },
           {
-            "name": "contentType",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "traits",
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -5796,15 +6460,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "SearchContext",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "SearchContext",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -5855,9 +6523,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -5867,15 +6539,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -5887,9 +6563,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -5899,9 +6579,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -5919,31 +6603,23 @@
             "deprecationReason": null
           },
           {
-            "name": "contentType",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "traits",
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -5955,15 +6631,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "SearchContext",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "SearchContext",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -6009,9 +6689,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -6021,15 +6705,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -6041,9 +6729,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -6053,9 +6745,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -6073,31 +6769,23 @@
             "deprecationReason": null
           },
           {
-            "name": "contentType",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "traits",
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -6109,15 +6797,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "SearchContext",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "SearchContext",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -6163,9 +6855,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -6175,15 +6871,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "SearchContextResourceTypes",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "SearchContextResourceTypes",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -6195,9 +6895,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -6207,9 +6911,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -6219,15 +6927,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "SearchContextFilter",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "SearchContextFilter",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -6251,15 +6963,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -6271,9 +6987,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -6283,15 +7003,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "SearchContextResourceTypes",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "SearchContextResourceTypes",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -6303,9 +7027,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -6315,9 +7043,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -6327,9 +7059,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -6339,9 +7075,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -6351,9 +7091,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -6363,9 +7107,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -6375,15 +7123,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "SearchContextFilter",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "SearchContextFilter",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -6407,9 +7159,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -6419,9 +7175,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -6431,9 +7191,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -6455,9 +7219,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -6467,9 +7235,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -6479,9 +7251,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -7114,9 +7890,57 @@
             "description": null,
             "args": [],
             "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "page",
+            "description": null,
+            "args": [],
+            "type": {
               "kind": "SCALAR",
               "name": "Int",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageSize",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "language",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -7126,15 +7950,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Concept",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Concept",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -7158,9 +7986,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -7170,9 +8002,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -7182,9 +8018,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -7194,15 +8034,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -7214,9 +8058,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "OBJECT",
-              "name": "MetaImage",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "MetaImage",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -7442,9 +8290,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -7466,9 +8318,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -7478,9 +8334,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -7490,15 +8350,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "INTERFACE",
-                  "name": "SearchResult",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INTERFACE",
+                    "name": "SearchResult",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -7510,15 +8374,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "SuggestionResult",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "SuggestionResult",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -7530,15 +8398,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "AggregationResult",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AggregationResult",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -7565,6 +8437,42 @@
       },
       {
         "kind": "OBJECT",
+        "name": "SearchWithoutPagination",
+        "description": null,
+        "specifiedByUrl": null,
+        "fields": [
+          {
+            "name": "results",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INTERFACE",
+                    "name": "SearchResult",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "SuggestionResult",
         "description": null,
         "specifiedByUrl": null,
@@ -7574,9 +8482,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -7586,15 +8498,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "SearchSuggestion",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "SearchSuggestion",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -7618,9 +8534,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -7630,9 +8550,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -7642,9 +8566,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -7654,15 +8582,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "BucketResult",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "BucketResult",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -7686,9 +8618,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -7698,9 +8634,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -7722,9 +8662,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -7734,9 +8678,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -7746,9 +8694,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -7758,15 +8710,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "SuggestOption",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "SuggestOption",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -7790,9 +8746,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -7802,9 +8762,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -7874,9 +8838,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -7886,15 +8854,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -7906,15 +8878,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "SearchContext",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "SearchContext",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -7929,6 +8905,22 @@
               "kind": "OBJECT",
               "name": "MetaImage",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -7950,9 +8942,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -8002,15 +8998,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "SuggestionResult",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "SuggestionResult",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -8022,15 +9022,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "AggregationResult",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AggregationResult",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -8039,6 +9043,34 @@
           },
           {
             "name": "totalCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "page",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageSize",
             "description": null,
             "args": [],
             "type": {
@@ -8070,15 +9102,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "FrontpageSearchResult",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "FrontpageSearchResult",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -8090,9 +9126,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -8102,15 +9142,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "SuggestionResult",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "SuggestionResult",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -8134,9 +9178,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "OBJECT",
-              "name": "FrontPageResources",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "FrontPageResources",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -8146,9 +9194,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "OBJECT",
-              "name": "FrontPageResources",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "FrontPageResources",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -8940,9 +9992,13 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
                   }
                 },
                 "defaultValue": null,
@@ -9109,9 +10165,13 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
                   }
                 },
                 "defaultValue": null,
@@ -9138,7 +10198,20 @@
           {
             "name": "listingPage",
             "description": null,
-            "args": [],
+            "args": [
+              {
+                "name": "subjects",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
             "type": {
               "kind": "OBJECT",
               "name": "ListingPage",
@@ -9155,15 +10228,19 @@
                 "name": "ids",
                 "description": null,
                 "type": {
-                  "kind": "LIST",
+                  "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
+                    "kind": "LIST",
                     "name": null,
                     "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
                     }
                   }
                 },
@@ -9278,7 +10355,7 @@
                 "deprecationReason": null
               },
               {
-                "name": "exactMatch",
+                "name": "exactTitleMatch",
                 "description": null,
                 "type": {
                   "kind": "SCALAR",
@@ -9498,7 +10575,7 @@
             ],
             "type": {
               "kind": "OBJECT",
-              "name": "Search",
+              "name": "SearchWithoutPagination",
               "ofType": null
             },
             "isDeprecated": false,
@@ -9512,9 +10589,13 @@
                 "name": "id",
                 "description": null,
                 "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
                 },
                 "defaultValue": null,
                 "isDeprecated": false,
@@ -9538,7 +10619,7 @@
                 "description": null,
                 "type": {
                   "kind": "SCALAR",
-                  "name": "String",
+                  "name": "Int",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -9550,7 +10631,7 @@
                 "description": null,
                 "type": {
                   "kind": "SCALAR",
-                  "name": "String",
+                  "name": "Int",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -9561,6 +10642,72 @@
             "type": {
               "kind": "OBJECT",
               "name": "AudioSearch",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "podcastSeries",
+            "description": null,
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "PodcastSeries",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "podcastSeriesSearch",
+            "description": null,
+            "args": [
+              {
+                "name": "page",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "pageSize",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "PodcastSeriesSearch",
               "ofType": null
             },
             "isDeprecated": false,

--- a/src/graphqlTypes.ts
+++ b/src/graphqlTypes.ts
@@ -217,8 +217,11 @@ export type GQLConcept = {
   content: Scalars['String'];
   id: Scalars['Int'];
   metaImage: GQLMetaImage;
+  subjectIds?: Maybe<Array<Scalars['String']>>;
+  subjectNames?: Maybe<Array<Scalars['String']>>;
   tags: Array<Scalars['String']>;
   title: Scalars['String'];
+  visualElement?: Maybe<GQLVisualElement>;
 };
 
 export type GQLConceptLicense = {
@@ -671,7 +674,7 @@ export type GQLQueryCompetenceGoalsArgs = {
 };
 
 export type GQLQueryConceptSearchArgs = {
-  exactTitleMatch?: Maybe<Scalars['Boolean']>;
+  exactMatch?: Maybe<Scalars['Boolean']>;
   fallback?: Maybe<Scalars['Boolean']>;
   language?: Maybe<Scalars['String']>;
   page?: Maybe<Scalars['String']>;
@@ -1400,7 +1403,7 @@ export type GQLGroupSearchQuery = {
 export type GQLConceptSearchQueryVariables = Exact<{
   query?: Maybe<Scalars['String']>;
   subjects?: Maybe<Scalars['String']>;
-  exactTitleMatch?: Maybe<Scalars['Boolean']>;
+  exactMatch?: Maybe<Scalars['Boolean']>;
   language?: Maybe<Scalars['String']>;
   fallback?: Maybe<Scalars['Boolean']>;
 }>;

--- a/src/graphqlTypes.ts
+++ b/src/graphqlTypes.ts
@@ -1,11 +1,7 @@
 export type Maybe<T> = T;
-export type Exact<T extends { [key: string]: unknown }> = {
-  [K in keyof T]: T[K];
-};
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> &
-  { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> &
-  { [SubKey in K]: Maybe<T[SubKey]> };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -19,10 +15,10 @@ export type Scalars = {
 
 export type GQLAggregationResult = {
   __typename?: 'AggregationResult';
-  docCountErrorUpperBound?: Maybe<Scalars['Int']>;
-  field?: Maybe<Scalars['String']>;
-  sumOtherDocCount?: Maybe<Scalars['Int']>;
-  values?: Maybe<Array<GQLBucketResult>>;
+  docCountErrorUpperBound: Scalars['Int'];
+  field: Scalars['String'];
+  sumOtherDocCount: Scalars['Int'];
+  values: Array<GQLBucketResult>;
 };
 
 export type GQLArticle = {
@@ -56,6 +52,7 @@ export type GQLArticle = {
   visualElement?: Maybe<GQLVisualElement>;
 };
 
+
 export type GQLArticleCrossSubjectTopicsArgs = {
   subjectId?: Maybe<Scalars['String']>;
 };
@@ -80,15 +77,14 @@ export type GQLArticleRequiredLibrary = {
 
 export type GQLArticleSearchResult = GQLSearchResult & {
   __typename?: 'ArticleSearchResult';
-  contentType?: Maybe<Scalars['String']>;
-  contexts?: Maybe<Array<GQLSearchContext>>;
+  contexts: Array<GQLSearchContext>;
   id: Scalars['Int'];
-  metaDescription?: Maybe<Scalars['String']>;
+  metaDescription: Scalars['String'];
   metaImage?: Maybe<GQLMetaImage>;
-  supportedLanguages?: Maybe<Array<Scalars['String']>>;
-  title?: Maybe<Scalars['String']>;
-  traits?: Maybe<Array<Scalars['String']>>;
-  url?: Maybe<Scalars['String']>;
+  supportedLanguages: Array<Scalars['String']>;
+  title: Scalars['String'];
+  traits: Array<Scalars['String']>;
+  url: Scalars['String'];
 };
 
 export type GQLAudio = {
@@ -96,12 +92,16 @@ export type GQLAudio = {
   audioFile: GQLAudioFile;
   audioType: Scalars['String'];
   copyright: GQLCopyright;
-  id: Scalars['String'];
+  created: Scalars['String'];
+  id: Scalars['Int'];
+  manuscript?: Maybe<GQLManuscript>;
   podcastMeta?: Maybe<GQLPodcastMeta>;
   revision: Scalars['Int'];
-  supportedLanguages?: Maybe<Array<Scalars['String']>>;
-  tags?: Maybe<GQLTags>;
+  series?: Maybe<GQLPodcastSeries>;
+  supportedLanguages: Array<Scalars['String']>;
+  tags: GQLTags;
   title: GQLTitle;
+  updated: Scalars['String'];
 };
 
 export type GQLAudioFile = {
@@ -122,11 +122,25 @@ export type GQLAudioLicense = {
 
 export type GQLAudioSearch = {
   __typename?: 'AudioSearch';
-  language?: Maybe<Scalars['String']>;
+  language: Scalars['String'];
   page?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
-  results?: Maybe<Array<GQLAudio>>;
-  totalCount?: Maybe<Scalars['Int']>;
+  pageSize: Scalars['Int'];
+  results: Array<GQLAudio>;
+  totalCount: Scalars['Int'];
+};
+
+export type GQLAudioSummary = {
+  __typename?: 'AudioSummary';
+  audioType: Scalars['String'];
+  id: Scalars['Int'];
+  lastUpdated: Scalars['String'];
+  license: Scalars['String'];
+  manuscript?: Maybe<GQLManuscript>;
+  podcastMeta?: Maybe<GQLPodcastMeta>;
+  series?: Maybe<GQLPodcastSeries>;
+  supportedLanguages: Array<Scalars['String']>;
+  title: GQLTitle;
+  url: Scalars['String'];
 };
 
 export type GQLBrightcoveElement = {
@@ -166,8 +180,8 @@ export type GQLBrightcoveLicense = {
 
 export type GQLBucketResult = {
   __typename?: 'BucketResult';
-  count?: Maybe<Scalars['Int']>;
-  value?: Maybe<Scalars['String']>;
+  count: Scalars['Int'];
+  value: Scalars['String'];
 };
 
 export type GQLCategory = {
@@ -197,11 +211,11 @@ export type GQLCompetenceGoal = {
 
 export type GQLConcept = {
   __typename?: 'Concept';
-  content?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  metaImage?: Maybe<GQLMetaImage>;
-  tags?: Maybe<Array<Scalars['String']>>;
-  title?: Maybe<Scalars['String']>;
+  content: Scalars['String'];
+  id: Scalars['Int'];
+  metaImage: GQLMetaImage;
+  tags: Array<Scalars['String']>;
+  title: Scalars['String'];
 };
 
 export type GQLConceptLicense = {
@@ -214,8 +228,11 @@ export type GQLConceptLicense = {
 
 export type GQLConceptResult = {
   __typename?: 'ConceptResult';
-  concepts?: Maybe<Array<GQLConcept>>;
-  totalCount?: Maybe<Scalars['Int']>;
+  concepts: Array<GQLConcept>;
+  language: Scalars['String'];
+  page?: Maybe<Scalars['Int']>;
+  pageSize: Scalars['Int'];
+  totalCount: Scalars['Int'];
 };
 
 export type GQLContributor = {
@@ -226,11 +243,11 @@ export type GQLContributor = {
 
 export type GQLCopyright = {
   __typename?: 'Copyright';
-  creators?: Maybe<Array<GQLContributor>>;
-  license?: Maybe<GQLLicense>;
+  creators: Array<GQLContributor>;
+  license: GQLLicense;
   origin?: Maybe<Scalars['String']>;
-  processors?: Maybe<Array<GQLContributor>>;
-  rightsholders?: Maybe<Array<GQLContributor>>;
+  processors: Array<GQLContributor>;
+  rightsholders: Array<GQLContributor>;
 };
 
 export type GQLCoreElement = {
@@ -255,6 +272,12 @@ export type GQLCrossSubjectElement = {
   code?: Maybe<Scalars['String']>;
   path?: Maybe<Scalars['String']>;
   title: Scalars['String'];
+};
+
+export type GQLDescription = {
+  __typename?: 'Description';
+  description: Scalars['String'];
+  language: Scalars['String'];
 };
 
 export type GQLDetailedConcept = {
@@ -308,9 +331,9 @@ export type GQLFootNote = {
 
 export type GQLFrontPageResources = {
   __typename?: 'FrontPageResources';
-  results?: Maybe<Array<GQLFrontpageSearchResult>>;
-  suggestions?: Maybe<Array<GQLSuggestionResult>>;
-  totalCount?: Maybe<Scalars['Int']>;
+  results: Array<GQLFrontpageSearchResult>;
+  suggestions: Array<GQLSuggestionResult>;
+  totalCount: Scalars['Int'];
 };
 
 export type GQLFrontpage = {
@@ -321,39 +344,42 @@ export type GQLFrontpage = {
 
 export type GQLFrontpageSearch = {
   __typename?: 'FrontpageSearch';
-  learningResources?: Maybe<GQLFrontPageResources>;
-  topicResources?: Maybe<GQLFrontPageResources>;
+  learningResources: GQLFrontPageResources;
+  topicResources: GQLFrontPageResources;
 };
 
 export type GQLFrontpageSearchResult = {
   __typename?: 'FrontpageSearchResult';
-  filters?: Maybe<Array<GQLSearchContextFilter>>;
+  filters: Array<GQLSearchContextFilter>;
   id: Scalars['String'];
-  name?: Maybe<Scalars['String']>;
-  path?: Maybe<Scalars['String']>;
-  resourceTypes?: Maybe<Array<GQLSearchContextResourceTypes>>;
-  subject?: Maybe<Scalars['String']>;
+  name: Scalars['String'];
+  path: Scalars['String'];
+  resourceTypes: Array<GQLSearchContextResourceTypes>;
+  subject: Scalars['String'];
 };
 
 export type GQLGroupSearch = {
   __typename?: 'GroupSearch';
-  aggregations?: Maybe<Array<GQLAggregationResult>>;
-  language?: Maybe<Scalars['String']>;
+  aggregations: Array<GQLAggregationResult>;
+  language: Scalars['String'];
+  page?: Maybe<Scalars['Int']>;
+  pageSize: Scalars['Int'];
   resourceType: Scalars['String'];
   resources: Array<GQLGroupSearchResult>;
-  suggestions?: Maybe<Array<GQLSuggestionResult>>;
+  suggestions: Array<GQLSuggestionResult>;
   totalCount: Scalars['Int'];
 };
 
 export type GQLGroupSearchResult = {
   __typename?: 'GroupSearchResult';
-  contexts?: Maybe<Array<GQLSearchContext>>;
+  contexts: Array<GQLSearchContext>;
   id: Scalars['Int'];
-  ingress?: Maybe<Scalars['String']>;
+  ingress: Scalars['String'];
   metaImage?: Maybe<GQLMetaImage>;
   name: Scalars['String'];
   path: Scalars['String'];
-  traits?: Maybe<Array<Scalars['String']>>;
+  traits: Array<Scalars['String']>;
+  url: Scalars['String'];
 };
 
 export type GQLH5pElement = {
@@ -434,15 +460,14 @@ export type GQLLearningpathCoverphoto = {
 
 export type GQLLearningpathSearchResult = GQLSearchResult & {
   __typename?: 'LearningpathSearchResult';
-  contentType?: Maybe<Scalars['String']>;
-  contexts?: Maybe<Array<GQLSearchContext>>;
+  contexts: Array<GQLSearchContext>;
   id: Scalars['Int'];
-  metaDescription?: Maybe<Scalars['String']>;
+  metaDescription: Scalars['String'];
   metaImage?: Maybe<GQLMetaImage>;
-  supportedLanguages?: Maybe<Array<Scalars['String']>>;
-  title?: Maybe<Scalars['String']>;
-  traits?: Maybe<Array<Scalars['String']>>;
-  url?: Maybe<Scalars['String']>;
+  supportedLanguages: Array<Scalars['String']>;
+  title: Scalars['String'];
+  traits: Array<Scalars['String']>;
+  url: Scalars['String'];
 };
 
 export type GQLLearningpathStep = {
@@ -490,6 +515,12 @@ export type GQLListingPage = {
   __typename?: 'ListingPage';
   subjects?: Maybe<Array<GQLSubject>>;
   tags?: Maybe<Array<Scalars['String']>>;
+};
+
+export type GQLManuscript = {
+  __typename?: 'Manuscript';
+  language: Scalars['String'];
+  manuscript: Scalars['String'];
 };
 
 export type GQLMeta = {
@@ -552,10 +583,37 @@ export type GQLName = {
 export type GQLPodcastMeta = {
   __typename?: 'PodcastMeta';
   coverPhoto: GQLCoverPhoto;
-  header: Scalars['String'];
   introduction: Scalars['String'];
   language: Scalars['String'];
-  manuscript: Scalars['String'];
+};
+
+export type GQLPodcastSeries = {
+  __typename?: 'PodcastSeries';
+  coverPhoto: GQLCoverPhoto;
+  description: GQLDescription;
+  episodes?: Maybe<Array<GQLAudio>>;
+  id: Scalars['Int'];
+  supportedLanguages: Array<Scalars['String']>;
+  title: GQLTitle;
+};
+
+export type GQLPodcastSeriesSearch = {
+  __typename?: 'PodcastSeriesSearch';
+  language: Scalars['String'];
+  page?: Maybe<Scalars['Int']>;
+  pageSize: Scalars['Int'];
+  results: Array<GQLPodcastSeriesSummary>;
+  totalCount: Scalars['Int'];
+};
+
+export type GQLPodcastSeriesSummary = {
+  __typename?: 'PodcastSeriesSummary';
+  coverPhoto: GQLCoverPhoto;
+  description: GQLDescription;
+  episodes?: Maybe<Array<GQLAudioSummary>>;
+  id: Scalars['Int'];
+  supportedLanguages?: Maybe<Array<Scalars['String']>>;
+  title: GQLTitle;
 };
 
 export type GQLQuery = {
@@ -577,16 +635,19 @@ export type GQLQuery = {
   listingPage?: Maybe<GQLListingPage>;
   podcast?: Maybe<GQLAudio>;
   podcastSearch?: Maybe<GQLAudioSearch>;
+  podcastSeries?: Maybe<GQLPodcastSeries>;
+  podcastSeriesSearch?: Maybe<GQLPodcastSeriesSearch>;
   resource?: Maybe<GQLResource>;
   resourceTypes?: Maybe<Array<GQLResourceTypeDefinition>>;
   search?: Maybe<GQLSearch>;
-  searchWithoutPagination?: Maybe<GQLSearch>;
+  searchWithoutPagination?: Maybe<GQLSearchWithoutPagination>;
   subject?: Maybe<GQLSubject>;
   subjectpage?: Maybe<GQLSubjectPage>;
   subjects?: Maybe<Array<GQLSubject>>;
   topic?: Maybe<GQLTopic>;
   topics?: Maybe<Array<GQLTopic>>;
 };
+
 
 export type GQLQueryArticleArgs = {
   id: Scalars['String'];
@@ -596,10 +657,12 @@ export type GQLQueryArticleArgs = {
   subjectId?: Maybe<Scalars['String']>;
 };
 
+
 export type GQLQueryCompetenceGoalArgs = {
   code: Scalars['String'];
   language?: Maybe<Scalars['String']>;
 };
+
 
 export type GQLQueryCompetenceGoalsArgs = {
   codes?: Maybe<Array<Maybe<Scalars['String']>>>;
@@ -607,8 +670,9 @@ export type GQLQueryCompetenceGoalsArgs = {
   nodeId?: Maybe<Scalars['String']>;
 };
 
+
 export type GQLQueryConceptSearchArgs = {
-  exactMatch?: Maybe<Scalars['Boolean']>;
+  exactTitleMatch?: Maybe<Scalars['Boolean']>;
   fallback?: Maybe<Scalars['Boolean']>;
   language?: Maybe<Scalars['String']>;
   page?: Maybe<Scalars['String']>;
@@ -618,30 +682,36 @@ export type GQLQueryConceptSearchArgs = {
   tags?: Maybe<Scalars['String']>;
 };
 
+
 export type GQLQueryConceptsArgs = {
-  ids?: Maybe<Array<Scalars['String']>>;
+  ids: Array<Scalars['String']>;
 };
+
 
 export type GQLQueryCoreElementArgs = {
   code: Scalars['String'];
   language?: Maybe<Scalars['String']>;
 };
 
+
 export type GQLQueryCoreElementsArgs = {
   codes?: Maybe<Array<Maybe<Scalars['String']>>>;
   language?: Maybe<Scalars['String']>;
 };
 
+
 export type GQLQueryDetailedConceptArgs = {
   id?: Maybe<Scalars['String']>;
 };
+
 
 export type GQLQueryFrontpageSearchArgs = {
   query?: Maybe<Scalars['String']>;
 };
 
+
 export type GQLQueryGroupSearchArgs = {
-  aggregatePaths?: Maybe<Array<Maybe<Scalars['String']>>>;
+  aggregatePaths?: Maybe<Array<Scalars['String']>>;
   contextTypes?: Maybe<Scalars['String']>;
   fallback?: Maybe<Scalars['String']>;
   grepCodes?: Maybe<Scalars['String']>;
@@ -654,23 +724,44 @@ export type GQLQueryGroupSearchArgs = {
   subjects?: Maybe<Scalars['String']>;
 };
 
+
 export type GQLQueryLearningpathArgs = {
   pathId: Scalars['String'];
 };
+
 
 export type GQLQueryLearningpathStepArgs = {
   pathId: Scalars['String'];
   stepId: Scalars['String'];
 };
 
-export type GQLQueryPodcastArgs = {
-  id?: Maybe<Scalars['String']>;
+
+export type GQLQueryListingPageArgs = {
+  subjects?: Maybe<Scalars['String']>;
 };
 
-export type GQLQueryPodcastSearchArgs = {
-  page?: Maybe<Scalars['String']>;
-  pageSize?: Maybe<Scalars['String']>;
+
+export type GQLQueryPodcastArgs = {
+  id: Scalars['Int'];
 };
+
+
+export type GQLQueryPodcastSearchArgs = {
+  page?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
+};
+
+
+export type GQLQueryPodcastSeriesArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type GQLQueryPodcastSeriesSearchArgs = {
+  page?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
+};
+
 
 export type GQLQueryResourceArgs = {
   id: Scalars['String'];
@@ -678,8 +769,9 @@ export type GQLQueryResourceArgs = {
   topicId?: Maybe<Scalars['String']>;
 };
 
+
 export type GQLQuerySearchArgs = {
-  aggregatePaths?: Maybe<Array<Maybe<Scalars['String']>>>;
+  aggregatePaths?: Maybe<Array<Scalars['String']>>;
   contextFilters?: Maybe<Scalars['String']>;
   contextTypes?: Maybe<Scalars['String']>;
   fallback?: Maybe<Scalars['String']>;
@@ -696,6 +788,7 @@ export type GQLQuerySearchArgs = {
   sort?: Maybe<Scalars['String']>;
   subjects?: Maybe<Scalars['String']>;
 };
+
 
 export type GQLQuerySearchWithoutPaginationArgs = {
   contextFilters?: Maybe<Scalars['String']>;
@@ -712,18 +805,22 @@ export type GQLQuerySearchWithoutPaginationArgs = {
   subjects?: Maybe<Scalars['String']>;
 };
 
+
 export type GQLQuerySubjectArgs = {
   id: Scalars['String'];
 };
+
 
 export type GQLQuerySubjectpageArgs = {
   id: Scalars['String'];
 };
 
+
 export type GQLQueryTopicArgs = {
   id: Scalars['String'];
   subjectId?: Maybe<Scalars['String']>;
 };
+
 
 export type GQLQueryTopicsArgs = {
   contentUri?: Maybe<Scalars['String']>;
@@ -743,25 +840,25 @@ export type GQLRelatedContent = {
   url: Scalars['String'];
 };
 
-export type GQLResource = GQLTaxonomyEntity &
-  GQLWithArticle & {
-    __typename?: 'Resource';
-    article?: Maybe<GQLArticle>;
-    availability?: Maybe<Scalars['String']>;
-    breadcrumbs?: Maybe<Array<Array<Scalars['String']>>>;
-    contentUri?: Maybe<Scalars['String']>;
-    id: Scalars['String'];
-    learningpath?: Maybe<GQLLearningpath>;
-    meta?: Maybe<GQLMeta>;
-    metadata?: Maybe<GQLTaxonomyMetadata>;
-    name: Scalars['String'];
-    parentTopics?: Maybe<Array<GQLTopic>>;
-    path?: Maybe<Scalars['String']>;
-    paths?: Maybe<Array<Scalars['String']>>;
-    rank?: Maybe<Scalars['Int']>;
-    relevanceId?: Maybe<Scalars['String']>;
-    resourceTypes?: Maybe<Array<GQLResourceType>>;
-  };
+export type GQLResource = GQLTaxonomyEntity & GQLWithArticle & {
+  __typename?: 'Resource';
+  article?: Maybe<GQLArticle>;
+  availability?: Maybe<Scalars['String']>;
+  breadcrumbs?: Maybe<Array<Array<Scalars['String']>>>;
+  contentUri?: Maybe<Scalars['String']>;
+  id: Scalars['String'];
+  learningpath?: Maybe<GQLLearningpath>;
+  meta?: Maybe<GQLMeta>;
+  metadata?: Maybe<GQLTaxonomyMetadata>;
+  name: Scalars['String'];
+  parentTopics?: Maybe<Array<GQLTopic>>;
+  path?: Maybe<Scalars['String']>;
+  paths?: Maybe<Array<Scalars['String']>>;
+  rank?: Maybe<Scalars['Int']>;
+  relevanceId?: Maybe<Scalars['String']>;
+  resourceTypes?: Maybe<Array<GQLResourceType>>;
+};
+
 
 export type GQLResourceArticleArgs = {
   isOembed?: Maybe<Scalars['String']>;
@@ -774,6 +871,7 @@ export type GQLResourceType = {
   name: Scalars['String'];
   resources?: Maybe<Array<GQLResource>>;
 };
+
 
 export type GQLResourceTypeResourcesArgs = {
   topicId: Scalars['String'];
@@ -788,62 +886,66 @@ export type GQLResourceTypeDefinition = {
 
 export type GQLSearch = {
   __typename?: 'Search';
-  aggregations?: Maybe<Array<GQLAggregationResult>>;
+  aggregations: Array<GQLAggregationResult>;
   concepts?: Maybe<GQLConceptResult>;
-  language?: Maybe<Scalars['String']>;
+  language: Scalars['String'];
   page?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
-  results?: Maybe<Array<GQLSearchResult>>;
-  suggestions?: Maybe<Array<GQLSuggestionResult>>;
-  totalCount?: Maybe<Scalars['Int']>;
+  pageSize: Scalars['Int'];
+  results: Array<GQLSearchResult>;
+  suggestions: Array<GQLSuggestionResult>;
+  totalCount: Scalars['Int'];
 };
 
 export type GQLSearchContext = {
   __typename?: 'SearchContext';
-  breadcrumbs?: Maybe<Array<Scalars['String']>>;
-  filters?: Maybe<Array<GQLSearchContextFilter>>;
-  id?: Maybe<Scalars['String']>;
-  language?: Maybe<Scalars['String']>;
-  learningResourceType?: Maybe<Scalars['String']>;
-  path?: Maybe<Scalars['String']>;
-  relevance?: Maybe<Scalars['String']>;
-  resourceTypes?: Maybe<Array<GQLSearchContextResourceTypes>>;
-  subject?: Maybe<Scalars['String']>;
-  subjectId?: Maybe<Scalars['String']>;
+  breadcrumbs: Array<Scalars['String']>;
+  filters: Array<GQLSearchContextFilter>;
+  id: Scalars['String'];
+  language: Scalars['String'];
+  learningResourceType: Scalars['String'];
+  path: Scalars['String'];
+  relevance: Scalars['String'];
+  resourceTypes: Array<GQLSearchContextResourceTypes>;
+  subject: Scalars['String'];
+  subjectId: Scalars['String'];
 };
 
 export type GQLSearchContextFilter = {
   __typename?: 'SearchContextFilter';
-  id?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
-  relevance?: Maybe<Scalars['String']>;
+  id: Scalars['String'];
+  name: Scalars['String'];
+  relevance: Scalars['String'];
 };
 
 export type GQLSearchContextResourceTypes = {
   __typename?: 'SearchContextResourceTypes';
-  id?: Maybe<Scalars['String']>;
-  language?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
+  id: Scalars['String'];
+  language: Scalars['String'];
+  name: Scalars['String'];
 };
 
 export type GQLSearchResult = {
-  contentType?: Maybe<Scalars['String']>;
-  contexts?: Maybe<Array<GQLSearchContext>>;
+  contexts: Array<GQLSearchContext>;
   id: Scalars['Int'];
-  metaDescription?: Maybe<Scalars['String']>;
+  metaDescription: Scalars['String'];
   metaImage?: Maybe<GQLMetaImage>;
-  supportedLanguages?: Maybe<Array<Scalars['String']>>;
-  title?: Maybe<Scalars['String']>;
-  traits?: Maybe<Array<Scalars['String']>>;
-  url?: Maybe<Scalars['String']>;
+  supportedLanguages: Array<Scalars['String']>;
+  title: Scalars['String'];
+  traits: Array<Scalars['String']>;
+  url: Scalars['String'];
 };
 
 export type GQLSearchSuggestion = {
   __typename?: 'SearchSuggestion';
-  length?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  options?: Maybe<Array<GQLSuggestOption>>;
-  text?: Maybe<Scalars['String']>;
+  length: Scalars['Int'];
+  offset: Scalars['Int'];
+  options: Array<GQLSuggestOption>;
+  text: Scalars['String'];
+};
+
+export type GQLSearchWithoutPagination = {
+  __typename?: 'SearchWithoutPagination';
+  results: Array<GQLSearchResult>;
 };
 
 export type GQLSubject = GQLTaxonomyEntity & {
@@ -861,6 +963,7 @@ export type GQLSubject = GQLTaxonomyEntity & {
   subjectpage?: Maybe<GQLSubjectPage>;
   topics?: Maybe<Array<GQLTopic>>;
 };
+
 
 export type GQLSubjectTopicsArgs = {
   all?: Maybe<Scalars['Boolean']>;
@@ -883,17 +986,21 @@ export type GQLSubjectPage = {
   twitter?: Maybe<Scalars['String']>;
 };
 
+
 export type GQLSubjectPageEditorsChoicesArgs = {
   subjectId?: Maybe<Scalars['String']>;
 };
+
 
 export type GQLSubjectPageLatestContentArgs = {
   subjectId?: Maybe<Scalars['String']>;
 };
 
+
 export type GQLSubjectPageMostReadArgs = {
   subjectId?: Maybe<Scalars['String']>;
 };
+
 
 export type GQLSubjectPageTopicalArgs = {
   subjectId?: Maybe<Scalars['String']>;
@@ -923,20 +1030,20 @@ export type GQLSubjectPageVisualElement = {
 
 export type GQLSuggestOption = {
   __typename?: 'SuggestOption';
-  score?: Maybe<Scalars['Float']>;
-  text?: Maybe<Scalars['String']>;
+  score: Scalars['Float'];
+  text: Scalars['String'];
 };
 
 export type GQLSuggestionResult = {
   __typename?: 'SuggestionResult';
-  name?: Maybe<Scalars['String']>;
-  suggestions?: Maybe<Array<GQLSearchSuggestion>>;
+  name: Scalars['String'];
+  suggestions: Array<GQLSearchSuggestion>;
 };
 
 export type GQLTags = {
   __typename?: 'Tags';
   language: Scalars['String'];
-  tags?: Maybe<Array<Scalars['String']>>;
+  tags: Array<Scalars['String']>;
 };
 
 export type GQLTaxonomyEntity = {
@@ -963,38 +1070,40 @@ export type GQLTitle = {
   title: Scalars['String'];
 };
 
-export type GQLTopic = GQLTaxonomyEntity &
-  GQLWithArticle & {
-    __typename?: 'Topic';
-    alternateTopics?: Maybe<Array<GQLTopic>>;
-    article?: Maybe<GQLArticle>;
-    availability?: Maybe<Scalars['String']>;
-    breadcrumbs?: Maybe<Array<Array<Scalars['String']>>>;
-    contentUri?: Maybe<Scalars['String']>;
-    coreResources?: Maybe<Array<GQLResource>>;
-    id: Scalars['String'];
-    isPrimary?: Maybe<Scalars['Boolean']>;
-    meta?: Maybe<GQLMeta>;
-    metadata?: Maybe<GQLTaxonomyMetadata>;
-    name: Scalars['String'];
-    parent?: Maybe<Scalars['String']>;
-    path?: Maybe<Scalars['String']>;
-    pathTopics?: Maybe<Array<Array<GQLTopic>>>;
-    paths?: Maybe<Array<Scalars['String']>>;
-    rank?: Maybe<Scalars['Int']>;
-    relevanceId?: Maybe<Scalars['String']>;
-    subtopics?: Maybe<Array<GQLTopic>>;
-    supplementaryResources?: Maybe<Array<GQLResource>>;
-  };
+export type GQLTopic = GQLTaxonomyEntity & GQLWithArticle & {
+  __typename?: 'Topic';
+  alternateTopics?: Maybe<Array<GQLTopic>>;
+  article?: Maybe<GQLArticle>;
+  availability?: Maybe<Scalars['String']>;
+  breadcrumbs?: Maybe<Array<Array<Scalars['String']>>>;
+  contentUri?: Maybe<Scalars['String']>;
+  coreResources?: Maybe<Array<GQLResource>>;
+  id: Scalars['String'];
+  isPrimary?: Maybe<Scalars['Boolean']>;
+  meta?: Maybe<GQLMeta>;
+  metadata?: Maybe<GQLTaxonomyMetadata>;
+  name: Scalars['String'];
+  parent?: Maybe<Scalars['String']>;
+  path?: Maybe<Scalars['String']>;
+  pathTopics?: Maybe<Array<Array<GQLTopic>>>;
+  paths?: Maybe<Array<Scalars['String']>>;
+  rank?: Maybe<Scalars['Int']>;
+  relevanceId?: Maybe<Scalars['String']>;
+  subtopics?: Maybe<Array<GQLTopic>>;
+  supplementaryResources?: Maybe<Array<GQLResource>>;
+};
+
 
 export type GQLTopicArticleArgs = {
   showVisualElement?: Maybe<Scalars['String']>;
   subjectId?: Maybe<Scalars['String']>;
 };
 
+
 export type GQLTopicCoreResourcesArgs = {
   subjectId?: Maybe<Scalars['String']>;
 };
+
 
 export type GQLTopicSupplementaryResourcesArgs = {
   subjectId?: Maybe<Scalars['String']>;
@@ -1031,11 +1140,7 @@ export type GQLEmbedVisualelement = {
   visualElement?: Maybe<GQLVisualElement>;
 };
 
-export type GQLContributorInfoFragment = {
-  __typename?: 'Contributor';
-  name: string;
-  type: string;
-};
+export type GQLContributorInfoFragment = { __typename?: 'Contributor', name: string, type: string };
 
 export type GQLSearchQueryVariables = Exact<{
   query?: Maybe<Scalars['String']>;
@@ -1054,111 +1159,12 @@ export type GQLSearchQueryVariables = Exact<{
   grepCodes?: Maybe<Scalars['String']>;
 }>;
 
-export type GQLSearchQuery = {
-  __typename?: 'Query';
-  search?: Maybe<{
-    __typename?: 'Search';
-    language?: Maybe<string>;
-    page?: Maybe<number>;
-    pageSize?: Maybe<number>;
-    totalCount?: Maybe<number>;
-    results?: Maybe<
-      Array<
-        | {
-            __typename?: 'ArticleSearchResult';
-            id: number;
-            url?: Maybe<string>;
-            metaDescription?: Maybe<string>;
-            title?: Maybe<string>;
-            supportedLanguages?: Maybe<Array<string>>;
-            traits?: Maybe<Array<string>>;
-            metaImage?: Maybe<{
-              __typename?: 'MetaImage';
-              url?: Maybe<string>;
-              alt?: Maybe<string>;
-            }>;
-            contexts?: Maybe<
-              Array<{
-                __typename?: 'SearchContext';
-                id?: Maybe<string>;
-                breadcrumbs?: Maybe<Array<string>>;
-                relevance?: Maybe<string>;
-                language?: Maybe<string>;
-                learningResourceType?: Maybe<string>;
-                path?: Maybe<string>;
-                subject?: Maybe<string>;
-                subjectId?: Maybe<string>;
-                resourceTypes?: Maybe<
-                  Array<{
-                    __typename?: 'SearchContextResourceTypes';
-                    id?: Maybe<string>;
-                    name?: Maybe<string>;
-                    language?: Maybe<string>;
-                  }>
-                >;
-              }>
-            >;
-          }
-        | {
-            __typename?: 'LearningpathSearchResult';
-            id: number;
-            url?: Maybe<string>;
-            metaDescription?: Maybe<string>;
-            title?: Maybe<string>;
-            supportedLanguages?: Maybe<Array<string>>;
-            traits?: Maybe<Array<string>>;
-            metaImage?: Maybe<{
-              __typename?: 'MetaImage';
-              url?: Maybe<string>;
-              alt?: Maybe<string>;
-            }>;
-            contexts?: Maybe<
-              Array<{
-                __typename?: 'SearchContext';
-                id?: Maybe<string>;
-                breadcrumbs?: Maybe<Array<string>>;
-                relevance?: Maybe<string>;
-                language?: Maybe<string>;
-                learningResourceType?: Maybe<string>;
-                path?: Maybe<string>;
-                subject?: Maybe<string>;
-                subjectId?: Maybe<string>;
-                resourceTypes?: Maybe<
-                  Array<{
-                    __typename?: 'SearchContextResourceTypes';
-                    id?: Maybe<string>;
-                    name?: Maybe<string>;
-                    language?: Maybe<string>;
-                  }>
-                >;
-              }>
-            >;
-          }
-      >
-    >;
-    suggestions?: Maybe<
-      Array<{
-        __typename?: 'SuggestionResult';
-        name?: Maybe<string>;
-        suggestions?: Maybe<
-          Array<{
-            __typename?: 'SearchSuggestion';
-            text?: Maybe<string>;
-            offset?: Maybe<number>;
-            length?: Maybe<number>;
-            options?: Maybe<
-              Array<{
-                __typename?: 'SuggestOption';
-                text?: Maybe<string>;
-                score?: Maybe<number>;
-              }>
-            >;
-          }>
-        >;
-      }>
-    >;
-  }>;
-};
+
+export type GQLSearchQuery = { __typename?: 'Query', search?: Maybe<{ __typename?: 'Search', language: string, page?: Maybe<number>, pageSize: number, totalCount: number, results: Array<{ __typename?: 'ArticleSearchResult', id: number, url: string, metaDescription: string, title: string, supportedLanguages: Array<string>, traits: Array<string>, metaImage?: Maybe<{ __typename?: 'MetaImage', url?: Maybe<string>, alt?: Maybe<string> }>, contexts: Array<{ __typename?: 'SearchContext', id: string, breadcrumbs: Array<string>, relevance: string, language: string, learningResourceType: string, path: string, subject: string, subjectId: string, resourceTypes: Array<{ __typename?: 'SearchContextResourceTypes', id: string, name: string, language: string }> }> } | { __typename?: 'LearningpathSearchResult', id: number, url: string, metaDescription: string, title: string, supportedLanguages: Array<string>, traits: Array<string>, metaImage?: Maybe<{ __typename?: 'MetaImage', url?: Maybe<string>, alt?: Maybe<string> }>, contexts: Array<{ __typename?: 'SearchContext', id: string, breadcrumbs: Array<string>, relevance: string, language: string, learningResourceType: string, path: string, subject: string, subjectId: string, resourceTypes: Array<{ __typename?: 'SearchContextResourceTypes', id: string, name: string, language: string }> }> }>, suggestions: Array<{ __typename?: 'SuggestionResult', name: string, suggestions: Array<{ __typename?: 'SearchSuggestion', text: string, offset: number, length: number, options: Array<{ __typename?: 'SuggestOption', text: string, score: number }> }> }> }> };
+
+export type GQLSearchFilmArticleSearchResultFragment = { __typename?: 'ArticleSearchResult', id: number, url: string, metaDescription: string, title: string, supportedLanguages: Array<string>, traits: Array<string>, metaImage?: Maybe<{ __typename?: 'MetaImage', url?: Maybe<string>, alt?: Maybe<string> }>, contexts: Array<{ __typename?: 'SearchContext', breadcrumbs: Array<string>, relevance: string, language: string, learningResourceType: string, path: string, subject: string, resourceTypes: Array<{ __typename?: 'SearchContextResourceTypes', id: string, name: string, language: string }> }> };
+
+export type GQLSearchFilmLearningpathSearchResultFragment = { __typename?: 'LearningpathSearchResult', id: number, url: string, metaDescription: string, title: string, supportedLanguages: Array<string>, traits: Array<string>, metaImage?: Maybe<{ __typename?: 'MetaImage', url?: Maybe<string>, alt?: Maybe<string> }>, contexts: Array<{ __typename?: 'SearchContext', breadcrumbs: Array<string>, relevance: string, language: string, learningResourceType: string, path: string, subject: string, resourceTypes: Array<{ __typename?: 'SearchContextResourceTypes', id: string, name: string, language: string }> }> };
 
 export type GQLSearchWithoutPaginationQueryVariables = Exact<{
   query?: Maybe<Scalars['String']>;
@@ -1174,86 +1180,14 @@ export type GQLSearchWithoutPaginationQueryVariables = Exact<{
   relevance?: Maybe<Scalars['String']>;
 }>;
 
-export type GQLSearchWithoutPaginationQuery = {
-  __typename?: 'Query';
-  searchWithoutPagination?: Maybe<{
-    __typename?: 'Search';
-    language?: Maybe<string>;
-    page?: Maybe<number>;
-    pageSize?: Maybe<number>;
-    totalCount?: Maybe<number>;
-    results?: Maybe<
-      Array<
-        | {
-            __typename?: 'ArticleSearchResult';
-            id: number;
-            url?: Maybe<string>;
-            metaDescription?: Maybe<string>;
-            title?: Maybe<string>;
-            supportedLanguages?: Maybe<Array<string>>;
-            traits?: Maybe<Array<string>>;
-            metaImage?: Maybe<{
-              __typename?: 'MetaImage';
-              url?: Maybe<string>;
-              alt?: Maybe<string>;
-            }>;
-            contexts?: Maybe<
-              Array<{
-                __typename?: 'SearchContext';
-                breadcrumbs?: Maybe<Array<string>>;
-                relevance?: Maybe<string>;
-                language?: Maybe<string>;
-                learningResourceType?: Maybe<string>;
-                path?: Maybe<string>;
-                subject?: Maybe<string>;
-                resourceTypes?: Maybe<
-                  Array<{
-                    __typename?: 'SearchContextResourceTypes';
-                    id?: Maybe<string>;
-                    name?: Maybe<string>;
-                    language?: Maybe<string>;
-                  }>
-                >;
-              }>
-            >;
-          }
-        | {
-            __typename?: 'LearningpathSearchResult';
-            id: number;
-            url?: Maybe<string>;
-            metaDescription?: Maybe<string>;
-            title?: Maybe<string>;
-            supportedLanguages?: Maybe<Array<string>>;
-            traits?: Maybe<Array<string>>;
-            metaImage?: Maybe<{
-              __typename?: 'MetaImage';
-              url?: Maybe<string>;
-              alt?: Maybe<string>;
-            }>;
-            contexts?: Maybe<
-              Array<{
-                __typename?: 'SearchContext';
-                breadcrumbs?: Maybe<Array<string>>;
-                relevance?: Maybe<string>;
-                language?: Maybe<string>;
-                learningResourceType?: Maybe<string>;
-                path?: Maybe<string>;
-                subject?: Maybe<string>;
-                resourceTypes?: Maybe<
-                  Array<{
-                    __typename?: 'SearchContextResourceTypes';
-                    id?: Maybe<string>;
-                    name?: Maybe<string>;
-                    language?: Maybe<string>;
-                  }>
-                >;
-              }>
-            >;
-          }
-      >
-    >;
-  }>;
-};
+
+export type GQLSearchWithoutPaginationQuery = { __typename?: 'Query', searchWithoutPagination?: Maybe<{ __typename?: 'SearchWithoutPagination', results: Array<(
+      { __typename?: 'ArticleSearchResult' }
+      & GQLSearchFilmArticleSearchResultFragment
+    ) | (
+      { __typename?: 'LearningpathSearchResult' }
+      & GQLSearchFilmLearningpathSearchResultFragment
+    )> }> };
 
 export type GQLGroupSearchQueryVariables = Exact<{
   resourceTypes?: Maybe<Scalars['String']>;
@@ -1266,573 +1200,125 @@ export type GQLGroupSearchQueryVariables = Exact<{
   fallback?: Maybe<Scalars['String']>;
   grepCodes?: Maybe<Scalars['String']>;
   aggregatePaths?: Maybe<Array<Scalars['String']> | Scalars['String']>;
-  grepCodesList?: Maybe<
-    Array<Maybe<Scalars['String']>> | Maybe<Scalars['String']>
-  >;
+  grepCodesList?: Maybe<Array<Maybe<Scalars['String']>> | Maybe<Scalars['String']>>;
 }>;
 
-export type GQLGroupSearchQuery = {
-  __typename?: 'Query';
-  groupSearch?: Maybe<
-    Array<{
-      __typename?: 'GroupSearch';
-      resourceType: string;
-      totalCount: number;
-      language?: Maybe<string>;
-      resources: Array<{
-        __typename?: 'GroupSearchResult';
-        id: number;
-        path: string;
-        name: string;
-        ingress?: Maybe<string>;
-        traits?: Maybe<Array<string>>;
-        contexts?: Maybe<
-          Array<{
-            __typename?: 'SearchContext';
-            language?: Maybe<string>;
-            path?: Maybe<string>;
-            breadcrumbs?: Maybe<Array<string>>;
-            subjectId?: Maybe<string>;
-            subject?: Maybe<string>;
-            relevance?: Maybe<string>;
-            resourceTypes?: Maybe<
-              Array<{
-                __typename?: 'SearchContextResourceTypes';
-                id?: Maybe<string>;
-                name?: Maybe<string>;
-              }>
-            >;
-          }>
-        >;
-        metaImage?: Maybe<{
-          __typename?: 'MetaImage';
-          url?: Maybe<string>;
-          alt?: Maybe<string>;
-        }>;
-      }>;
-      aggregations?: Maybe<
-        Array<{
-          __typename?: 'AggregationResult';
-          values?: Maybe<
-            Array<{ __typename?: 'BucketResult'; value?: Maybe<string> }>
-          >;
-        }>
-      >;
-      suggestions?: Maybe<
-        Array<{
-          __typename?: 'SuggestionResult';
-          suggestions?: Maybe<
-            Array<{
-              __typename?: 'SearchSuggestion';
-              options?: Maybe<
-                Array<{ __typename?: 'SuggestOption'; text?: Maybe<string> }>
-              >;
-            }>
-          >;
-        }>
-      >;
-    }>
-  >;
-  competenceGoals?: Maybe<
-    Array<{
-      __typename?: 'CompetenceGoal';
-      id: string;
-      type: string;
-      name: string;
-      curriculum?: Maybe<{
-        __typename?: 'Reference';
-        id: string;
-        title: string;
-      }>;
-      competenceGoalSet?: Maybe<{
-        __typename?: 'Reference';
-        id: string;
-        title: string;
-      }>;
-    }>
-  >;
-};
+
+export type GQLGroupSearchQuery = { __typename?: 'Query', groupSearch?: Maybe<Array<{ __typename?: 'GroupSearch', resourceType: string, totalCount: number, language: string, resources: Array<{ __typename?: 'GroupSearchResult', id: number, path: string, name: string, ingress: string, traits: Array<string>, contexts: Array<{ __typename?: 'SearchContext', language: string, path: string, breadcrumbs: Array<string>, subjectId: string, subject: string, relevance: string, resourceTypes: Array<{ __typename?: 'SearchContextResourceTypes', id: string, name: string }> }>, metaImage?: Maybe<{ __typename?: 'MetaImage', url?: Maybe<string>, alt?: Maybe<string> }> }>, aggregations: Array<{ __typename?: 'AggregationResult', values: Array<{ __typename?: 'BucketResult', value: string }> }>, suggestions: Array<{ __typename?: 'SuggestionResult', suggestions: Array<{ __typename?: 'SearchSuggestion', options: Array<{ __typename?: 'SuggestOption', text: string }> }> }> }>>, competenceGoals?: Maybe<Array<{ __typename?: 'CompetenceGoal', id: string, type: string, name: string, curriculum?: Maybe<{ __typename?: 'Reference', id: string, title: string }>, competenceGoalSet?: Maybe<{ __typename?: 'Reference', id: string, title: string }> }>> };
 
 export type GQLConceptSearchQueryVariables = Exact<{
   query?: Maybe<Scalars['String']>;
   subjects?: Maybe<Scalars['String']>;
-  exactMatch?: Maybe<Scalars['Boolean']>;
+  exactTitleMatch?: Maybe<Scalars['Boolean']>;
   language?: Maybe<Scalars['String']>;
   fallback?: Maybe<Scalars['Boolean']>;
 }>;
 
-export type GQLConceptSearchQuery = {
-  __typename?: 'Query';
-  conceptSearch?: Maybe<{
-    __typename?: 'ConceptResult';
-    concepts?: Maybe<
-      Array<{
-        __typename?: 'Concept';
-        id?: Maybe<number>;
-        title?: Maybe<string>;
-        text?: Maybe<string>;
-        image?: Maybe<{
-          __typename?: 'MetaImage';
-          url?: Maybe<string>;
-          alt?: Maybe<string>;
-        }>;
-      }>
-    >;
-  }>;
-};
+
+export type GQLConceptSearchQuery = { __typename?: 'Query', conceptSearch?: Maybe<{ __typename?: 'ConceptResult', concepts: Array<{ __typename?: 'Concept', id: number, title: string, text: string, image: { __typename?: 'MetaImage', url?: Maybe<string>, alt?: Maybe<string> } }> }> };
 
 export type GQLFrontpageSearchQueryVariables = Exact<{
   query?: Maybe<Scalars['String']>;
 }>;
 
-export type GQLFrontpageSearchQuery = {
-  __typename?: 'Query';
-  frontpageSearch?: Maybe<{
-    __typename?: 'FrontpageSearch';
-    topicResources?: Maybe<{
-      __typename?: 'FrontPageResources';
-      totalCount?: Maybe<number>;
-      results?: Maybe<
-        Array<{
-          __typename?: 'FrontpageSearchResult';
-          id: string;
-          name?: Maybe<string>;
-          path?: Maybe<string>;
-          subject?: Maybe<string>;
-          resourceTypes?: Maybe<
-            Array<{
-              __typename?: 'SearchContextResourceTypes';
-              name?: Maybe<string>;
-            }>
-          >;
-        }>
-      >;
-      suggestions?: Maybe<
-        Array<{
-          __typename?: 'SuggestionResult';
-          suggestions?: Maybe<
-            Array<{
-              __typename?: 'SearchSuggestion';
-              options?: Maybe<
-                Array<{
-                  __typename?: 'SuggestOption';
-                  text?: Maybe<string>;
-                  score?: Maybe<number>;
-                }>
-              >;
-            }>
-          >;
-        }>
-      >;
-    }>;
-    learningResources?: Maybe<{
-      __typename?: 'FrontPageResources';
-      totalCount?: Maybe<number>;
-      results?: Maybe<
-        Array<{
-          __typename?: 'FrontpageSearchResult';
-          id: string;
-          name?: Maybe<string>;
-          path?: Maybe<string>;
-          subject?: Maybe<string>;
-          resourceTypes?: Maybe<
-            Array<{
-              __typename?: 'SearchContextResourceTypes';
-              name?: Maybe<string>;
-            }>
-          >;
-        }>
-      >;
-      suggestions?: Maybe<
-        Array<{
-          __typename?: 'SuggestionResult';
-          suggestions?: Maybe<
-            Array<{
-              __typename?: 'SearchSuggestion';
-              options?: Maybe<
-                Array<{
-                  __typename?: 'SuggestOption';
-                  text?: Maybe<string>;
-                  score?: Maybe<number>;
-                }>
-              >;
-            }>
-          >;
-        }>
-      >;
-    }>;
-  }>;
-};
 
-export type GQLCopyrightInfoFragment = {
-  __typename?: 'Copyright';
-  origin?: Maybe<string>;
-  license?: Maybe<{
-    __typename?: 'License';
-    license: string;
-    url?: Maybe<string>;
-  }>;
-  creators?: Maybe<
-    Array<{ __typename?: 'Contributor' } & GQLContributorInfoFragment>
-  >;
-  processors?: Maybe<
-    Array<{ __typename?: 'Contributor' } & GQLContributorInfoFragment>
-  >;
-  rightsholders?: Maybe<
-    Array<{ __typename?: 'Contributor' } & GQLContributorInfoFragment>
-  >;
-};
+export type GQLFrontpageSearchQuery = { __typename?: 'Query', frontpageSearch?: Maybe<{ __typename?: 'FrontpageSearch', topicResources: { __typename?: 'FrontPageResources', totalCount: number, results: Array<{ __typename?: 'FrontpageSearchResult', id: string, name: string, path: string, subject: string, resourceTypes: Array<{ __typename?: 'SearchContextResourceTypes', name: string }> }>, suggestions: Array<{ __typename?: 'SuggestionResult', suggestions: Array<{ __typename?: 'SearchSuggestion', options: Array<{ __typename?: 'SuggestOption', text: string, score: number }> }> }> }, learningResources: { __typename?: 'FrontPageResources', totalCount: number, results: Array<{ __typename?: 'FrontpageSearchResult', id: string, name: string, path: string, subject: string, resourceTypes: Array<{ __typename?: 'SearchContextResourceTypes', name: string }> }>, suggestions: Array<{ __typename?: 'SuggestionResult', suggestions: Array<{ __typename?: 'SearchSuggestion', options: Array<{ __typename?: 'SuggestOption', text: string, score: number }> }> }> } }> };
 
-export type GQLMetaInfoFragment = {
-  __typename?: 'Meta';
-  id: number;
-  title: string;
-  introduction?: Maybe<string>;
-  metaDescription?: Maybe<string>;
-  lastUpdated?: Maybe<string>;
-  metaImage?: Maybe<{
-    __typename?: 'MetaImage';
-    url?: Maybe<string>;
-    alt?: Maybe<string>;
-  }>;
-};
+export type GQLCopyrightInfoFragment = { __typename?: 'Copyright', origin?: Maybe<string>, license: { __typename?: 'License', license: string, url?: Maybe<string> }, creators: Array<(
+    { __typename?: 'Contributor' }
+    & GQLContributorInfoFragment
+  )>, processors: Array<(
+    { __typename?: 'Contributor' }
+    & GQLContributorInfoFragment
+  )>, rightsholders: Array<(
+    { __typename?: 'Contributor' }
+    & GQLContributorInfoFragment
+  )> };
 
-export type GQLTopicInfoFragment = {
-  __typename?: 'Topic';
-  id: string;
-  name: string;
-  contentUri?: Maybe<string>;
-  path?: Maybe<string>;
-  availability?: Maybe<string>;
-  parent?: Maybe<string>;
-  relevanceId?: Maybe<string>;
-  meta?: Maybe<{ __typename?: 'Meta' } & GQLMetaInfoFragment>;
-  metadata?: Maybe<{
-    __typename?: 'TaxonomyMetadata';
-    customFields?: Maybe<any>;
-  }>;
-};
+export type GQLMetaInfoFragment = { __typename?: 'Meta', id: number, title: string, introduction?: Maybe<string>, metaDescription?: Maybe<string>, lastUpdated?: Maybe<string>, metaImage?: Maybe<{ __typename?: 'MetaImage', url?: Maybe<string>, alt?: Maybe<string> }> };
 
-export type GQLSubjectInfoFragment = {
-  __typename?: 'Subject';
-  id: string;
-  name: string;
-  path?: Maybe<string>;
-  metadata?: Maybe<{
-    __typename?: 'TaxonomyMetadata';
-    customFields?: Maybe<any>;
-  }>;
-};
+export type GQLTopicInfoFragment = { __typename?: 'Topic', id: string, name: string, contentUri?: Maybe<string>, path?: Maybe<string>, availability?: Maybe<string>, parent?: Maybe<string>, relevanceId?: Maybe<string>, meta?: Maybe<(
+    { __typename?: 'Meta' }
+    & GQLMetaInfoFragment
+  )>, metadata?: Maybe<{ __typename?: 'TaxonomyMetadata', customFields?: Maybe<any> }> };
 
-export type GQLResourceInfoFragment = {
-  __typename?: 'Resource';
-  id: string;
-  name: string;
-  contentUri?: Maybe<string>;
-  path?: Maybe<string>;
-  paths?: Maybe<Array<string>>;
-  relevanceId?: Maybe<string>;
-  rank?: Maybe<number>;
-  resourceTypes?: Maybe<
-    Array<{ __typename?: 'ResourceType'; id: string; name: string }>
-  >;
-};
+export type GQLSubjectInfoFragment = { __typename?: 'Subject', id: string, name: string, path?: Maybe<string>, metadata?: Maybe<{ __typename?: 'TaxonomyMetadata', customFields?: Maybe<any> }> };
 
-export type GQLVisualElementInfoFragment = {
-  __typename?: 'VisualElement';
-  title?: Maybe<string>;
-  resource?: Maybe<string>;
-  url?: Maybe<string>;
-  language?: Maybe<string>;
-  embed?: Maybe<string>;
-  copyright?: Maybe<{ __typename?: 'Copyright' } & GQLCopyrightInfoFragment>;
-  brightcove?: Maybe<{
-    __typename?: 'BrightcoveElement';
-    videoid?: Maybe<string>;
-    player?: Maybe<string>;
-    account?: Maybe<string>;
-    caption?: Maybe<string>;
-    description?: Maybe<string>;
-    cover?: Maybe<string>;
-    src?: Maybe<string>;
-    download?: Maybe<string>;
-    uploadDate?: Maybe<string>;
-    copyText?: Maybe<string>;
-    iframe?: Maybe<{
-      __typename?: 'BrightcoveIframe';
-      src: string;
-      height: number;
-      width: number;
-    }>;
-  }>;
-  h5p?: Maybe<{
-    __typename?: 'H5pElement';
-    src?: Maybe<string>;
-    thumbnail?: Maybe<string>;
-    copyText?: Maybe<string>;
-  }>;
-  oembed?: Maybe<{
-    __typename?: 'VisualElementOembed';
-    title?: Maybe<string>;
-    html?: Maybe<string>;
-    fullscreen?: Maybe<boolean>;
-  }>;
-  image?: Maybe<{
-    __typename?: 'ImageElement';
-    resourceid?: Maybe<string>;
-    alt?: Maybe<string>;
-    caption?: Maybe<string>;
-    lowerRightX?: Maybe<number>;
-    lowerRightY?: Maybe<number>;
-    upperLeftX?: Maybe<number>;
-    upperLeftY?: Maybe<number>;
-    focalX?: Maybe<number>;
-    focalY?: Maybe<number>;
-    src: string;
-    altText: string;
-    contentType?: Maybe<string>;
-    copyText?: Maybe<string>;
-  }>;
-};
+export type GQLResourceInfoFragment = { __typename?: 'Resource', id: string, name: string, contentUri?: Maybe<string>, path?: Maybe<string>, paths?: Maybe<Array<string>>, relevanceId?: Maybe<string>, rank?: Maybe<number>, resourceTypes?: Maybe<Array<{ __typename?: 'ResourceType', id: string, name: string }>> };
 
-export type GQLArticleInfoFragment = {
-  __typename?: 'Article';
-  id: number;
-  title: string;
-  introduction?: Maybe<string>;
-  content: string;
-  articleType: string;
-  revision: number;
-  metaDescription: string;
-  supportedLanguages?: Maybe<Array<string>>;
-  tags?: Maybe<Array<string>>;
-  created: string;
-  updated: string;
-  published: string;
-  oldNdlaUrl?: Maybe<string>;
-  grepCodes?: Maybe<Array<string>>;
-  oembed?: Maybe<string>;
-  conceptIds?: Maybe<Array<string>>;
-  metaImage?: Maybe<{
-    __typename?: 'MetaImage';
-    url?: Maybe<string>;
-    alt?: Maybe<string>;
-  }>;
-  requiredLibraries?: Maybe<
-    Array<{
-      __typename?: 'ArticleRequiredLibrary';
-      name: string;
-      url: string;
-      mediaType: string;
-    }>
-  >;
-  metaData?: Maybe<{
-    __typename?: 'ArticleMetaData';
-    copyText?: Maybe<string>;
-    footnotes?: Maybe<
-      Array<{
-        __typename?: 'FootNote';
-        ref: number;
-        title: string;
-        year: string;
-        authors: Array<string>;
-        edition?: Maybe<string>;
-        publisher?: Maybe<string>;
-        url?: Maybe<string>;
-      }>
-    >;
-    images?: Maybe<
-      Array<{
-        __typename?: 'ImageLicense';
-        title: string;
-        altText: string;
-        src: string;
-        copyText?: Maybe<string>;
-        copyright: { __typename?: 'Copyright' } & GQLCopyrightInfoFragment;
-      }>
-    >;
-    h5ps?: Maybe<
-      Array<{
-        __typename?: 'H5pLicense';
-        title: string;
-        src?: Maybe<string>;
-        copyText?: Maybe<string>;
-        copyright: { __typename?: 'Copyright' } & GQLCopyrightInfoFragment;
-      }>
-    >;
-    audios?: Maybe<
-      Array<{
-        __typename?: 'AudioLicense';
-        title: string;
-        src: string;
-        copyText?: Maybe<string>;
-        copyright: { __typename?: 'Copyright' } & GQLCopyrightInfoFragment;
-      }>
-    >;
-    brightcoves?: Maybe<
-      Array<{
-        __typename?: 'BrightcoveLicense';
-        title: string;
-        description?: Maybe<string>;
-        cover?: Maybe<string>;
-        src?: Maybe<string>;
-        download?: Maybe<string>;
-        uploadDate?: Maybe<string>;
-        copyText?: Maybe<string>;
-        iframe?: Maybe<{
-          __typename?: 'BrightcoveIframe';
-          height: number;
-          src: string;
-          width: number;
-        }>;
-        copyright: { __typename?: 'Copyright' } & GQLCopyrightInfoFragment;
-      }>
-    >;
-    concepts?: Maybe<
-      Array<{
-        __typename?: 'ConceptLicense';
-        title: string;
-        src?: Maybe<string>;
-        copyText?: Maybe<string>;
-        copyright?: Maybe<
-          { __typename?: 'Copyright' } & GQLCopyrightInfoFragment
-        >;
-      }>
-    >;
-  }>;
-  competenceGoals?: Maybe<
-    Array<{
-      __typename?: 'CompetenceGoal';
-      id: string;
-      title: string;
-      type: string;
-      curriculum?: Maybe<{
-        __typename?: 'Reference';
-        id: string;
-        title: string;
-      }>;
-      competenceGoalSet?: Maybe<{
-        __typename?: 'Reference';
-        id: string;
-        title: string;
-      }>;
-    }>
-  >;
-  coreElements?: Maybe<
-    Array<{
-      __typename?: 'CoreElement';
-      id: string;
-      title: string;
-      description?: Maybe<string>;
-      curriculum?: Maybe<{
-        __typename?: 'Reference';
-        id: string;
-        title: string;
-      }>;
-    }>
-  >;
-  copyright: { __typename?: 'Copyright' } & GQLCopyrightInfoFragment;
-  visualElement?: Maybe<
-    { __typename?: 'VisualElement' } & GQLVisualElementInfoFragment
-  >;
-  concepts?: Maybe<
-    Array<{
-      __typename?: 'DetailedConcept';
-      id: number;
-      title: string;
-      content?: Maybe<string>;
-      subjectNames?: Maybe<Array<string>>;
-      copyright?: Maybe<
-        { __typename?: 'Copyright' } & GQLCopyrightInfoFragment
-      >;
-      visualElement?: Maybe<
-        { __typename?: 'VisualElement' } & GQLVisualElementInfoFragment
-      >;
-    }>
-  >;
-  relatedContent?: Maybe<
-    Array<{ __typename?: 'RelatedContent'; title: string; url: string }>
-  >;
-};
+export type GQLVisualElementInfoFragment = { __typename?: 'VisualElement', title?: Maybe<string>, resource?: Maybe<string>, url?: Maybe<string>, language?: Maybe<string>, embed?: Maybe<string>, copyright?: Maybe<(
+    { __typename?: 'Copyright' }
+    & GQLCopyrightInfoFragment
+  )>, brightcove?: Maybe<{ __typename?: 'BrightcoveElement', videoid?: Maybe<string>, player?: Maybe<string>, account?: Maybe<string>, caption?: Maybe<string>, description?: Maybe<string>, cover?: Maybe<string>, src?: Maybe<string>, download?: Maybe<string>, uploadDate?: Maybe<string>, copyText?: Maybe<string>, iframe?: Maybe<{ __typename?: 'BrightcoveIframe', src: string, height: number, width: number }> }>, h5p?: Maybe<{ __typename?: 'H5pElement', src?: Maybe<string>, thumbnail?: Maybe<string>, copyText?: Maybe<string> }>, oembed?: Maybe<{ __typename?: 'VisualElementOembed', title?: Maybe<string>, html?: Maybe<string>, fullscreen?: Maybe<boolean> }>, image?: Maybe<{ __typename?: 'ImageElement', resourceid?: Maybe<string>, alt?: Maybe<string>, caption?: Maybe<string>, lowerRightX?: Maybe<number>, lowerRightY?: Maybe<number>, upperLeftX?: Maybe<number>, upperLeftY?: Maybe<number>, focalX?: Maybe<number>, focalY?: Maybe<number>, src: string, altText: string, contentType?: Maybe<string>, copyText?: Maybe<string> }> };
 
-type GQLTaxonomyEntityInfo_Resource_Fragment = {
-  __typename?: 'Resource';
-  id: string;
-  name: string;
-  contentUri?: Maybe<string>;
-  path?: Maybe<string>;
-  resourceTypes?: Maybe<
-    Array<{ __typename?: 'ResourceType'; id: string; name: string }>
-  >;
-};
+export type GQLArticleInfoFragment = { __typename?: 'Article', id: number, title: string, introduction?: Maybe<string>, content: string, articleType: string, revision: number, metaDescription: string, supportedLanguages?: Maybe<Array<string>>, tags?: Maybe<Array<string>>, created: string, updated: string, published: string, oldNdlaUrl?: Maybe<string>, grepCodes?: Maybe<Array<string>>, oembed?: Maybe<string>, conceptIds?: Maybe<Array<string>>, metaImage?: Maybe<{ __typename?: 'MetaImage', url?: Maybe<string>, alt?: Maybe<string> }>, requiredLibraries?: Maybe<Array<{ __typename?: 'ArticleRequiredLibrary', name: string, url: string, mediaType: string }>>, metaData?: Maybe<{ __typename?: 'ArticleMetaData', copyText?: Maybe<string>, footnotes?: Maybe<Array<{ __typename?: 'FootNote', ref: number, title: string, year: string, authors: Array<string>, edition?: Maybe<string>, publisher?: Maybe<string>, url?: Maybe<string> }>>, images?: Maybe<Array<{ __typename?: 'ImageLicense', title: string, altText: string, src: string, copyText?: Maybe<string>, copyright: (
+        { __typename?: 'Copyright' }
+        & GQLCopyrightInfoFragment
+      ) }>>, h5ps?: Maybe<Array<{ __typename?: 'H5pLicense', title: string, src?: Maybe<string>, copyText?: Maybe<string>, copyright: (
+        { __typename?: 'Copyright' }
+        & GQLCopyrightInfoFragment
+      ) }>>, audios?: Maybe<Array<{ __typename?: 'AudioLicense', title: string, src: string, copyText?: Maybe<string>, copyright: (
+        { __typename?: 'Copyright' }
+        & GQLCopyrightInfoFragment
+      ) }>>, brightcoves?: Maybe<Array<{ __typename?: 'BrightcoveLicense', title: string, description?: Maybe<string>, cover?: Maybe<string>, src?: Maybe<string>, download?: Maybe<string>, uploadDate?: Maybe<string>, copyText?: Maybe<string>, iframe?: Maybe<{ __typename?: 'BrightcoveIframe', height: number, src: string, width: number }>, copyright: (
+        { __typename?: 'Copyright' }
+        & GQLCopyrightInfoFragment
+      ) }>>, concepts?: Maybe<Array<{ __typename?: 'ConceptLicense', title: string, src?: Maybe<string>, copyText?: Maybe<string>, copyright?: Maybe<(
+        { __typename?: 'Copyright' }
+        & GQLCopyrightInfoFragment
+      )> }>> }>, competenceGoals?: Maybe<Array<{ __typename?: 'CompetenceGoal', id: string, title: string, type: string, curriculum?: Maybe<{ __typename?: 'Reference', id: string, title: string }>, competenceGoalSet?: Maybe<{ __typename?: 'Reference', id: string, title: string }> }>>, coreElements?: Maybe<Array<{ __typename?: 'CoreElement', id: string, title: string, description?: Maybe<string>, curriculum?: Maybe<{ __typename?: 'Reference', id: string, title: string }> }>>, copyright: (
+    { __typename?: 'Copyright' }
+    & GQLCopyrightInfoFragment
+  ), visualElement?: Maybe<(
+    { __typename?: 'VisualElement' }
+    & GQLVisualElementInfoFragment
+  )>, concepts?: Maybe<Array<{ __typename?: 'DetailedConcept', id: number, title: string, content?: Maybe<string>, subjectNames?: Maybe<Array<string>>, copyright?: Maybe<(
+      { __typename?: 'Copyright' }
+      & GQLCopyrightInfoFragment
+    )>, visualElement?: Maybe<(
+      { __typename?: 'VisualElement' }
+      & GQLVisualElementInfoFragment
+    )> }>>, relatedContent?: Maybe<Array<{ __typename?: 'RelatedContent', title: string, url: string }>> };
 
-type GQLTaxonomyEntityInfo_Subject_Fragment = {
-  __typename?: 'Subject';
-  id: string;
-  name: string;
-  contentUri?: Maybe<string>;
-  path?: Maybe<string>;
-};
+type GQLTaxonomyEntityInfo_Resource_Fragment = { __typename?: 'Resource', id: string, name: string, contentUri?: Maybe<string>, path?: Maybe<string>, resourceTypes?: Maybe<Array<{ __typename?: 'ResourceType', id: string, name: string }>> };
 
-type GQLTaxonomyEntityInfo_Topic_Fragment = {
-  __typename?: 'Topic';
-  id: string;
-  name: string;
-  contentUri?: Maybe<string>;
-  path?: Maybe<string>;
-};
+type GQLTaxonomyEntityInfo_Subject_Fragment = { __typename?: 'Subject', id: string, name: string, contentUri?: Maybe<string>, path?: Maybe<string> };
 
-export type GQLTaxonomyEntityInfoFragment =
-  | GQLTaxonomyEntityInfo_Resource_Fragment
-  | GQLTaxonomyEntityInfo_Subject_Fragment
-  | GQLTaxonomyEntityInfo_Topic_Fragment;
+type GQLTaxonomyEntityInfo_Topic_Fragment = { __typename?: 'Topic', id: string, name: string, contentUri?: Maybe<string>, path?: Maybe<string> };
 
-type GQLWithArticleInfo_Resource_Fragment = {
-  __typename?: 'Resource';
-  meta?: Maybe<{ __typename?: 'Meta' } & GQLMetaInfoFragment>;
-};
+export type GQLTaxonomyEntityInfoFragment = GQLTaxonomyEntityInfo_Resource_Fragment | GQLTaxonomyEntityInfo_Subject_Fragment | GQLTaxonomyEntityInfo_Topic_Fragment;
 
-type GQLWithArticleInfo_Topic_Fragment = {
-  __typename?: 'Topic';
-  meta?: Maybe<{ __typename?: 'Meta' } & GQLMetaInfoFragment>;
-};
+type GQLWithArticleInfo_Resource_Fragment = { __typename?: 'Resource', meta?: Maybe<(
+    { __typename?: 'Meta' }
+    & GQLMetaInfoFragment
+  )> };
 
-export type GQLWithArticleInfoFragment =
-  | GQLWithArticleInfo_Resource_Fragment
-  | GQLWithArticleInfo_Topic_Fragment;
+type GQLWithArticleInfo_Topic_Fragment = { __typename?: 'Topic', meta?: Maybe<(
+    { __typename?: 'Meta' }
+    & GQLMetaInfoFragment
+  )> };
 
-export type GQLSubjectPageInfoFragment = {
-  __typename?: 'SubjectPage';
-  id: number;
-  metaDescription?: Maybe<string>;
-  topical?: Maybe<
-    | ({ __typename?: 'Resource' } & GQLTaxonomyEntityInfo_Resource_Fragment)
-    | ({ __typename?: 'Subject' } & GQLTaxonomyEntityInfo_Subject_Fragment)
-    | ({ __typename?: 'Topic' } & GQLTaxonomyEntityInfo_Topic_Fragment)
-  >;
-  banner?: Maybe<{
-    __typename?: 'SubjectPageBanner';
-    desktopUrl?: Maybe<string>;
-  }>;
-  about?: Maybe<{
-    __typename?: 'SubjectPageAbout';
-    title?: Maybe<string>;
-    description?: Maybe<string>;
-    visualElement?: Maybe<{
-      __typename?: 'SubjectPageVisualElement';
-      type?: Maybe<string>;
-      url?: Maybe<string>;
-      alt?: Maybe<string>;
-    }>;
-  }>;
-  editorsChoices?: Maybe<
-    Array<
-      | ({ __typename?: 'Resource' } & GQLTaxonomyEntityInfo_Resource_Fragment)
-      | ({ __typename?: 'Subject' } & GQLTaxonomyEntityInfo_Subject_Fragment)
-      | ({ __typename?: 'Topic' } & GQLTaxonomyEntityInfo_Topic_Fragment)
-    >
-  >;
-};
+export type GQLWithArticleInfoFragment = GQLWithArticleInfo_Resource_Fragment | GQLWithArticleInfo_Topic_Fragment;
+
+export type GQLSubjectPageInfoFragment = { __typename?: 'SubjectPage', id: number, metaDescription?: Maybe<string>, topical?: Maybe<(
+    { __typename?: 'Resource' }
+    & GQLTaxonomyEntityInfo_Resource_Fragment
+  ) | (
+    { __typename?: 'Subject' }
+    & GQLTaxonomyEntityInfo_Subject_Fragment
+  ) | (
+    { __typename?: 'Topic' }
+    & GQLTaxonomyEntityInfo_Topic_Fragment
+  )>, banner?: Maybe<{ __typename?: 'SubjectPageBanner', desktopUrl?: Maybe<string> }>, about?: Maybe<{ __typename?: 'SubjectPageAbout', title?: Maybe<string>, description?: Maybe<string>, visualElement?: Maybe<{ __typename?: 'SubjectPageVisualElement', type?: Maybe<string>, url?: Maybe<string>, alt?: Maybe<string> }> }>, editorsChoices?: Maybe<Array<(
+    { __typename?: 'Resource' }
+    & GQLTaxonomyEntityInfo_Resource_Fragment
+  ) | (
+    { __typename?: 'Subject' }
+    & GQLTaxonomyEntityInfo_Subject_Fragment
+  ) | (
+    { __typename?: 'Topic' }
+    & GQLTaxonomyEntityInfo_Topic_Fragment
+  )>> };
 
 export type GQLSubjectPageWithTopicsQueryVariables = Exact<{
   subjectId: Scalars['String'];
@@ -1840,184 +1326,79 @@ export type GQLSubjectPageWithTopicsQueryVariables = Exact<{
   includeTopic: Scalars['Boolean'];
 }>;
 
-export type GQLSubjectPageWithTopicsQuery = {
-  __typename?: 'Query';
-  subject?: Maybe<
-    {
-      __typename?: 'Subject';
-      grepCodes?: Maybe<Array<string>>;
-      topics?: Maybe<
-        Array<
-          {
-            __typename?: 'Topic';
-            article?: Maybe<{
-              __typename?: 'Article';
-              supportedLanguages?: Maybe<Array<string>>;
-            }>;
-          } & GQLTopicInfoFragment
-        >
-      >;
-      allTopics?: Maybe<Array<{ __typename?: 'Topic' } & GQLTopicInfoFragment>>;
-      subjectpage?: Maybe<
-        { __typename?: 'SubjectPage' } & GQLSubjectPageInfoFragment
-      >;
-    } & GQLSubjectInfoFragment
-  >;
-  topic?: Maybe<
-    {
-      __typename?: 'Topic';
-      alternateTopics?: Maybe<
-        Array<{
-          __typename?: 'Topic';
-          id: string;
-          name: string;
-          path?: Maybe<string>;
-          breadcrumbs?: Maybe<Array<Array<string>>>;
-          meta?: Maybe<{ __typename?: 'Meta' } & GQLMetaInfoFragment>;
-        }>
-      >;
-    } & GQLTopicInfoFragment
-  >;
-  subjects?: Maybe<
-    Array<
-      {
-        __typename?: 'Subject';
-        metadata?: Maybe<{
-          __typename?: 'TaxonomyMetadata';
-          customFields?: Maybe<any>;
-        }>;
-      } & GQLSubjectInfoFragment
-    >
-  >;
-};
+
+export type GQLSubjectPageWithTopicsQuery = { __typename?: 'Query', subject?: Maybe<(
+    { __typename?: 'Subject', grepCodes?: Maybe<Array<string>>, topics?: Maybe<Array<(
+      { __typename?: 'Topic', article?: Maybe<{ __typename?: 'Article', supportedLanguages?: Maybe<Array<string>> }> }
+      & GQLTopicInfoFragment
+    )>>, allTopics?: Maybe<Array<(
+      { __typename?: 'Topic' }
+      & GQLTopicInfoFragment
+    )>>, subjectpage?: Maybe<(
+      { __typename?: 'SubjectPage' }
+      & GQLSubjectPageInfoFragment
+    )> }
+    & GQLSubjectInfoFragment
+  )>, topic?: Maybe<(
+    { __typename?: 'Topic', alternateTopics?: Maybe<Array<{ __typename?: 'Topic', id: string, name: string, path?: Maybe<string>, breadcrumbs?: Maybe<Array<Array<string>>>, meta?: Maybe<(
+        { __typename?: 'Meta' }
+        & GQLMetaInfoFragment
+      )> }>> }
+    & GQLTopicInfoFragment
+  )>, subjects?: Maybe<Array<(
+    { __typename?: 'Subject', metadata?: Maybe<{ __typename?: 'TaxonomyMetadata', customFields?: Maybe<any> }> }
+    & GQLSubjectInfoFragment
+  )>> };
 
 export type GQLSubjectPageQueryVariables = Exact<{
   subjectId: Scalars['String'];
 }>;
 
-export type GQLSubjectPageQuery = {
-  __typename?: 'Query';
-  subject?: Maybe<{
-    __typename?: 'Subject';
-    id: string;
-    name: string;
-    path?: Maybe<string>;
-    topics?: Maybe<Array<{ __typename?: 'Topic' } & GQLTopicInfoFragment>>;
-    allTopics?: Maybe<Array<{ __typename?: 'Topic' } & GQLTopicInfoFragment>>;
-    subjectpage?: Maybe<
-      { __typename?: 'SubjectPage' } & GQLSubjectPageInfoFragment
-    >;
-  }>;
-};
 
-export type GQLSubjectsQueryVariables = Exact<{ [key: string]: never }>;
+export type GQLSubjectPageQuery = { __typename?: 'Query', subject?: Maybe<{ __typename?: 'Subject', id: string, name: string, path?: Maybe<string>, topics?: Maybe<Array<(
+      { __typename?: 'Topic' }
+      & GQLTopicInfoFragment
+    )>>, allTopics?: Maybe<Array<(
+      { __typename?: 'Topic' }
+      & GQLTopicInfoFragment
+    )>>, subjectpage?: Maybe<(
+      { __typename?: 'SubjectPage' }
+      & GQLSubjectPageInfoFragment
+    )> }> };
 
-export type GQLSubjectsQuery = {
-  __typename?: 'Query';
-  subjects?: Maybe<Array<{ __typename?: 'Subject' } & GQLSubjectInfoFragment>>;
-};
+export type GQLSubjectsQueryVariables = Exact<{ [key: string]: never; }>;
 
-export type GQLSearchPageQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GQLSearchPageQuery = {
-  __typename?: 'Query';
-  subjects?: Maybe<Array<{ __typename?: 'Subject' } & GQLSubjectInfoFragment>>;
-  resourceTypes?: Maybe<
-    Array<{
-      __typename?: 'ResourceTypeDefinition';
-      id: string;
-      name: string;
-      subtypes?: Maybe<
-        Array<{
-          __typename?: 'ResourceTypeDefinition';
-          id: string;
-          name: string;
-        }>
-      >;
-    }>
-  >;
-};
+export type GQLSubjectsQuery = { __typename?: 'Query', subjects?: Maybe<Array<(
+    { __typename?: 'Subject' }
+    & GQLSubjectInfoFragment
+  )>> };
 
-export type GQLLearningpathInfoFragment = {
-  __typename?: 'Learningpath';
-  id: number;
-  title: string;
-  description?: Maybe<string>;
-  duration?: Maybe<number>;
-  lastUpdated?: Maybe<string>;
-  supportedLanguages?: Maybe<Array<string>>;
-  tags?: Maybe<Array<string>>;
-  copyright?: Maybe<{
-    __typename?: 'LearningpathCopyright';
-    license?: Maybe<{
-      __typename?: 'License';
-      license: string;
-      url?: Maybe<string>;
-      description?: Maybe<string>;
-    }>;
-    contributors?: Maybe<
-      Array<{ __typename?: 'Contributor' } & GQLContributorInfoFragment>
-    >;
-  }>;
-  coverphoto?: Maybe<{
-    __typename?: 'LearningpathCoverphoto';
-    url?: Maybe<string>;
-    metaUrl?: Maybe<string>;
-  }>;
-  learningsteps?: Maybe<
-    Array<{
-      __typename?: 'LearningpathStep';
-      id: number;
-      title: string;
-      description?: Maybe<string>;
-      seqNo: number;
-      type?: Maybe<string>;
-      showTitle?: Maybe<boolean>;
-      oembed?: Maybe<{
-        __typename?: 'LearningpathStepOembed';
-        type: string;
-        version: string;
-        height: number;
-        html: string;
-        width: number;
-      }>;
-      embedUrl?: Maybe<{
-        __typename?: 'LearningpathStepEmbedUrl';
-        url?: Maybe<string>;
-        embedType?: Maybe<string>;
-      }>;
-      resource?: Maybe<
-        {
-          __typename?: 'Resource';
-          article?: Maybe<
-            {
-              __typename?: 'Article';
-              oembed?: Maybe<string>;
-            } & GQLArticleInfoFragment
-          >;
-        } & GQLResourceInfoFragment
-      >;
-      license?: Maybe<{
-        __typename?: 'License';
-        license: string;
-        url?: Maybe<string>;
-        description?: Maybe<string>;
-      }>;
-    }>
-  >;
-};
+export type GQLSearchPageQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GQLSearchPageQuery = { __typename?: 'Query', subjects?: Maybe<Array<(
+    { __typename?: 'Subject' }
+    & GQLSubjectInfoFragment
+  )>>, resourceTypes?: Maybe<Array<{ __typename?: 'ResourceTypeDefinition', id: string, name: string, subtypes?: Maybe<Array<{ __typename?: 'ResourceTypeDefinition', id: string, name: string }>> }>> };
+
+export type GQLLearningpathInfoFragment = { __typename?: 'Learningpath', id: number, title: string, description?: Maybe<string>, duration?: Maybe<number>, lastUpdated?: Maybe<string>, supportedLanguages?: Maybe<Array<string>>, tags?: Maybe<Array<string>>, copyright?: Maybe<{ __typename?: 'LearningpathCopyright', license?: Maybe<{ __typename?: 'License', license: string, url?: Maybe<string>, description?: Maybe<string> }>, contributors?: Maybe<Array<(
+      { __typename?: 'Contributor' }
+      & GQLContributorInfoFragment
+    )>> }>, coverphoto?: Maybe<{ __typename?: 'LearningpathCoverphoto', url?: Maybe<string>, metaUrl?: Maybe<string> }>, learningsteps?: Maybe<Array<{ __typename?: 'LearningpathStep', id: number, title: string, description?: Maybe<string>, seqNo: number, type?: Maybe<string>, showTitle?: Maybe<boolean>, oembed?: Maybe<{ __typename?: 'LearningpathStepOembed', type: string, version: string, height: number, html: string, width: number }>, embedUrl?: Maybe<{ __typename?: 'LearningpathStepEmbedUrl', url?: Maybe<string>, embedType?: Maybe<string> }>, resource?: Maybe<(
+      { __typename?: 'Resource', article?: Maybe<(
+        { __typename?: 'Article', oembed?: Maybe<string> }
+        & GQLArticleInfoFragment
+      )> }
+      & GQLResourceInfoFragment
+    )>, license?: Maybe<{ __typename?: 'License', license: string, url?: Maybe<string>, description?: Maybe<string> }> }>> };
 
 export type GQLMovedResourceQueryVariables = Exact<{
   resourceId: Scalars['String'];
 }>;
 
-export type GQLMovedResourceQuery = {
-  __typename?: 'Query';
-  resource?: Maybe<{
-    __typename?: 'Resource';
-    breadcrumbs?: Maybe<Array<Array<string>>>;
-  }>;
-};
+
+export type GQLMovedResourceQuery = { __typename?: 'Query', resource?: Maybe<{ __typename?: 'Resource', breadcrumbs?: Maybe<Array<Array<string>>> }> };
 
 export type GQLPlainArticleQueryVariables = Exact<{
   articleId: Scalars['String'];
@@ -2025,10 +1406,11 @@ export type GQLPlainArticleQueryVariables = Exact<{
   path?: Maybe<Scalars['String']>;
 }>;
 
-export type GQLPlainArticleQuery = {
-  __typename?: 'Query';
-  article?: Maybe<{ __typename?: 'Article' } & GQLArticleInfoFragment>;
-};
+
+export type GQLPlainArticleQuery = { __typename?: 'Query', article?: Maybe<(
+    { __typename?: 'Article' }
+    & GQLArticleInfoFragment
+  )> };
 
 export type GQLIframeArticleQueryVariables = Exact<{
   articleId: Scalars['String'];
@@ -2039,25 +1421,11 @@ export type GQLIframeArticleQueryVariables = Exact<{
   includeTopic: Scalars['Boolean'];
 }>;
 
-export type GQLIframeArticleQuery = {
-  __typename?: 'Query';
-  article?: Maybe<{ __typename?: 'Article' } & GQLArticleInfoFragment>;
-  resource?: Maybe<{
-    __typename?: 'Resource';
-    id: string;
-    name: string;
-    path?: Maybe<string>;
-    resourceTypes?: Maybe<
-      Array<{ __typename?: 'ResourceType'; id: string; name: string }>
-    >;
-  }>;
-  topic?: Maybe<{
-    __typename?: 'Topic';
-    id: string;
-    name: string;
-    path?: Maybe<string>;
-  }>;
-};
+
+export type GQLIframeArticleQuery = { __typename?: 'Query', article?: Maybe<(
+    { __typename?: 'Article' }
+    & GQLArticleInfoFragment
+  )>, resource?: Maybe<{ __typename?: 'Resource', id: string, name: string, path?: Maybe<string>, resourceTypes?: Maybe<Array<{ __typename?: 'ResourceType', id: string, name: string }>> }>, topic?: Maybe<{ __typename?: 'Topic', id: string, name: string, path?: Maybe<string> }> };
 
 export type GQLTopicWithPathTopicsQueryVariables = Exact<{
   topicId: Scalars['String'];
@@ -2065,116 +1433,56 @@ export type GQLTopicWithPathTopicsQueryVariables = Exact<{
   showVisualElement?: Maybe<Scalars['String']>;
 }>;
 
-export type GQLTopicWithPathTopicsQuery = {
-  __typename?: 'Query';
-  subject?: Maybe<{
-    __typename?: 'Subject';
-    id: string;
-    name: string;
-    path?: Maybe<string>;
-    topics?: Maybe<Array<{ __typename?: 'Topic' } & GQLTopicInfoFragment>>;
-    allTopics?: Maybe<Array<{ __typename?: 'Topic' } & GQLTopicInfoFragment>>;
-  }>;
-  topic?: Maybe<{
-    __typename?: 'Topic';
-    id: string;
-    name: string;
-    path?: Maybe<string>;
-    relevanceId?: Maybe<string>;
-    pathTopics?: Maybe<
-      Array<
-        Array<{
-          __typename?: 'Topic';
-          id: string;
-          name: string;
-          path?: Maybe<string>;
-        }>
-      >
-    >;
-    meta?: Maybe<{ __typename?: 'Meta' } & GQLMetaInfoFragment>;
-    subtopics?: Maybe<
-      Array<{
-        __typename?: 'Topic';
-        id: string;
-        name: string;
-        relevanceId?: Maybe<string>;
-      }>
-    >;
-    article?: Maybe<
-      {
-        __typename?: 'Article';
-        crossSubjectTopics?: Maybe<
-          Array<{
-            __typename?: 'CrossSubjectElement';
-            code?: Maybe<string>;
-            title: string;
-            path?: Maybe<string>;
-          }>
-        >;
-      } & GQLArticleInfoFragment
-    >;
-    coreResources?: Maybe<
-      Array<{ __typename?: 'Resource' } & GQLResourceInfoFragment>
-    >;
-    supplementaryResources?: Maybe<
-      Array<{ __typename?: 'Resource' } & GQLResourceInfoFragment>
-    >;
-  }>;
-  resourceTypes?: Maybe<
-    Array<{ __typename?: 'ResourceTypeDefinition'; id: string; name: string }>
-  >;
-};
+
+export type GQLTopicWithPathTopicsQuery = { __typename?: 'Query', subject?: Maybe<{ __typename?: 'Subject', id: string, name: string, path?: Maybe<string>, topics?: Maybe<Array<(
+      { __typename?: 'Topic' }
+      & GQLTopicInfoFragment
+    )>>, allTopics?: Maybe<Array<(
+      { __typename?: 'Topic' }
+      & GQLTopicInfoFragment
+    )>> }>, topic?: Maybe<{ __typename?: 'Topic', id: string, name: string, path?: Maybe<string>, relevanceId?: Maybe<string>, pathTopics?: Maybe<Array<Array<{ __typename?: 'Topic', id: string, name: string, path?: Maybe<string> }>>>, meta?: Maybe<(
+      { __typename?: 'Meta' }
+      & GQLMetaInfoFragment
+    )>, subtopics?: Maybe<Array<{ __typename?: 'Topic', id: string, name: string, relevanceId?: Maybe<string> }>>, article?: Maybe<(
+      { __typename?: 'Article', crossSubjectTopics?: Maybe<Array<{ __typename?: 'CrossSubjectElement', code?: Maybe<string>, title: string, path?: Maybe<string> }>> }
+      & GQLArticleInfoFragment
+    )>, coreResources?: Maybe<Array<(
+      { __typename?: 'Resource' }
+      & GQLResourceInfoFragment
+    )>>, supplementaryResources?: Maybe<Array<(
+      { __typename?: 'Resource' }
+      & GQLResourceInfoFragment
+    )>> }>, resourceTypes?: Maybe<Array<{ __typename?: 'ResourceTypeDefinition', id: string, name: string }>> };
 
 export type GQLTopicQueryVariables = Exact<{
   topicId: Scalars['String'];
   subjectId?: Maybe<Scalars['String']>;
 }>;
 
-export type GQLTopicQuery = {
-  __typename?: 'Query';
-  topic?: Maybe<{
-    __typename?: 'Topic';
-    id: string;
-    name: string;
-    path?: Maybe<string>;
-    parent?: Maybe<string>;
-    relevanceId?: Maybe<string>;
-    meta?: Maybe<{ __typename?: 'Meta' } & GQLMetaInfoFragment>;
-    subtopics?: Maybe<
-      Array<{
-        __typename?: 'Topic';
-        id: string;
-        name: string;
-        relevanceId?: Maybe<string>;
-      }>
-    >;
-    article?: Maybe<{ __typename?: 'Article' } & GQLArticleInfoFragment>;
-    coreResources?: Maybe<
-      Array<{ __typename?: 'Resource' } & GQLResourceInfoFragment>
-    >;
-    supplementaryResources?: Maybe<
-      Array<{ __typename?: 'Resource' } & GQLResourceInfoFragment>
-    >;
-    metadata?: Maybe<{
-      __typename?: 'TaxonomyMetadata';
-      customFields?: Maybe<any>;
-    }>;
-  }>;
-  resourceTypes?: Maybe<
-    Array<{ __typename?: 'ResourceTypeDefinition'; id: string; name: string }>
-  >;
-};
+
+export type GQLTopicQuery = { __typename?: 'Query', topic?: Maybe<{ __typename?: 'Topic', id: string, name: string, path?: Maybe<string>, parent?: Maybe<string>, relevanceId?: Maybe<string>, meta?: Maybe<(
+      { __typename?: 'Meta' }
+      & GQLMetaInfoFragment
+    )>, subtopics?: Maybe<Array<{ __typename?: 'Topic', id: string, name: string, relevanceId?: Maybe<string> }>>, article?: Maybe<(
+      { __typename?: 'Article' }
+      & GQLArticleInfoFragment
+    )>, coreResources?: Maybe<Array<(
+      { __typename?: 'Resource' }
+      & GQLResourceInfoFragment
+    )>>, supplementaryResources?: Maybe<Array<(
+      { __typename?: 'Resource' }
+      & GQLResourceInfoFragment
+    )>>, metadata?: Maybe<{ __typename?: 'TaxonomyMetadata', customFields?: Maybe<any> }> }>, resourceTypes?: Maybe<Array<{ __typename?: 'ResourceTypeDefinition', id: string, name: string }>> };
 
 export type GQLLearningPathStepQueryVariables = Exact<{
   pathId: Scalars['String'];
 }>;
 
-export type GQLLearningPathStepQuery = {
-  __typename?: 'Query';
-  learningpath?: Maybe<
-    { __typename?: 'Learningpath' } & GQLLearningpathInfoFragment
-  >;
-};
+
+export type GQLLearningPathStepQuery = { __typename?: 'Query', learningpath?: Maybe<(
+    { __typename?: 'Learningpath' }
+    & GQLLearningpathInfoFragment
+  )> };
 
 export type GQLCompetenceGoalsQueryVariables = Exact<{
   codes?: Maybe<Array<Scalars['String']> | Scalars['String']>;
@@ -2182,94 +1490,21 @@ export type GQLCompetenceGoalsQueryVariables = Exact<{
   language?: Maybe<Scalars['String']>;
 }>;
 
-export type GQLCompetenceGoalsQuery = {
-  __typename?: 'Query';
-  competenceGoals?: Maybe<
-    Array<{
-      __typename?: 'CompetenceGoal';
-      id: string;
-      type: string;
-      name: string;
-      curriculum?: Maybe<{
-        __typename?: 'Reference';
-        id: string;
-        title: string;
-      }>;
-      competenceGoalSet?: Maybe<{
-        __typename?: 'Reference';
-        id: string;
-        title: string;
-      }>;
-    }>
-  >;
-  coreElements?: Maybe<
-    Array<{
-      __typename?: 'CoreElement';
-      id: string;
-      name: string;
-      text?: Maybe<string>;
-      curriculum?: Maybe<{
-        __typename?: 'Reference';
-        id: string;
-        title: string;
-      }>;
-    }>
-  >;
-};
 
-export type GQLMovieInfoFragment = {
-  __typename?: 'Movie';
-  id: string;
-  title?: Maybe<string>;
-  metaDescription?: Maybe<string>;
-  path?: Maybe<string>;
-  metaImage?: Maybe<{
-    __typename?: 'MetaImage';
-    alt?: Maybe<string>;
-    url?: Maybe<string>;
-  }>;
-  resourceTypes?: Maybe<
-    Array<{ __typename?: 'ResourceType'; id: string; name: string }>
-  >;
-};
+export type GQLCompetenceGoalsQuery = { __typename?: 'Query', competenceGoals?: Maybe<Array<{ __typename?: 'CompetenceGoal', id: string, type: string, name: string, curriculum?: Maybe<{ __typename?: 'Reference', id: string, title: string }>, competenceGoalSet?: Maybe<{ __typename?: 'Reference', id: string, title: string }> }>>, coreElements?: Maybe<Array<{ __typename?: 'CoreElement', id: string, name: string, text?: Maybe<string>, curriculum?: Maybe<{ __typename?: 'Reference', id: string, title: string }> }>> };
 
-export type GQLFilmFrontPageQueryVariables = Exact<{ [key: string]: never }>;
+export type GQLMovieInfoFragment = { __typename?: 'Movie', id: string, title?: Maybe<string>, metaDescription?: Maybe<string>, path?: Maybe<string>, metaImage?: Maybe<{ __typename?: 'MetaImage', alt?: Maybe<string>, url?: Maybe<string> }>, resourceTypes?: Maybe<Array<{ __typename?: 'ResourceType', id: string, name: string }>> };
 
-export type GQLFilmFrontPageQuery = {
-  __typename?: 'Query';
-  filmfrontpage?: Maybe<{
-    __typename?: 'FilmFrontpage';
-    name?: Maybe<string>;
-    about?: Maybe<
-      Array<{
-        __typename?: 'FilmPageAbout';
-        title?: Maybe<string>;
-        description?: Maybe<string>;
-        language?: Maybe<string>;
-        visualElement?: Maybe<{
-          __typename?: 'SubjectPageVisualElement';
-          type?: Maybe<string>;
-          alt?: Maybe<string>;
-          url?: Maybe<string>;
-        }>;
-      }>
-    >;
-    movieThemes?: Maybe<
-      Array<{
-        __typename?: 'MovieTheme';
-        name?: Maybe<
-          Array<{
-            __typename?: 'Name';
-            name?: Maybe<string>;
-            language?: Maybe<string>;
-          }>
-        >;
-        movies?: Maybe<Array<{ __typename?: 'Movie' } & GQLMovieInfoFragment>>;
-      }>
-    >;
-    slideShow?: Maybe<Array<{ __typename?: 'Movie' } & GQLMovieInfoFragment>>;
-  }>;
-};
+export type GQLFilmFrontPageQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GQLFilmFrontPageQuery = { __typename?: 'Query', filmfrontpage?: Maybe<{ __typename?: 'FilmFrontpage', name?: Maybe<string>, about?: Maybe<Array<{ __typename?: 'FilmPageAbout', title?: Maybe<string>, description?: Maybe<string>, language?: Maybe<string>, visualElement?: Maybe<{ __typename?: 'SubjectPageVisualElement', type?: Maybe<string>, alt?: Maybe<string>, url?: Maybe<string> }> }>>, movieThemes?: Maybe<Array<{ __typename?: 'MovieTheme', name?: Maybe<Array<{ __typename?: 'Name', name?: Maybe<string>, language?: Maybe<string> }>>, movies?: Maybe<Array<(
+        { __typename?: 'Movie' }
+        & GQLMovieInfoFragment
+      )>> }>>, slideShow?: Maybe<Array<(
+      { __typename?: 'Movie' }
+      & GQLMovieInfoFragment
+    )>> }> };
 
 export type GQLMastHeadQueryVariables = Exact<{
   subjectId: Scalars['String'];
@@ -2279,42 +1514,26 @@ export type GQLMastHeadQueryVariables = Exact<{
   skipResource: Scalars['Boolean'];
 }>;
 
-export type GQLMastHeadQuery = {
-  __typename?: 'Query';
-  subject?: Maybe<{
-    __typename?: 'Subject';
-    id: string;
-    name: string;
-    path?: Maybe<string>;
-    topics?: Maybe<Array<{ __typename?: 'Topic' } & GQLTopicInfoFragment>>;
-  }>;
-  resourceTypes?: Maybe<
-    Array<{ __typename?: 'ResourceTypeDefinition'; id: string; name: string }>
-  >;
-  topic?: Maybe<{
-    __typename?: 'Topic';
-    id: string;
-    metadata?: Maybe<{
-      __typename?: 'TaxonomyMetadata';
-      customFields?: Maybe<any>;
-    }>;
-    coreResources?: Maybe<
-      Array<{ __typename?: 'Resource' } & GQLResourceInfoFragment>
-    >;
-    supplementaryResources?: Maybe<
-      Array<{ __typename?: 'Resource' } & GQLResourceInfoFragment>
-    >;
-  }>;
-  resource?: Maybe<
-    {
-      __typename?: 'Resource';
-      article?: Maybe<{ __typename?: 'Article' } & GQLArticleInfoFragment>;
-      learningpath?: Maybe<
-        { __typename?: 'Learningpath' } & GQLLearningpathInfoFragment
-      >;
-    } & GQLResourceInfoFragment
-  >;
-};
+
+export type GQLMastHeadQuery = { __typename?: 'Query', subject?: Maybe<{ __typename?: 'Subject', id: string, name: string, path?: Maybe<string>, topics?: Maybe<Array<(
+      { __typename?: 'Topic' }
+      & GQLTopicInfoFragment
+    )>> }>, resourceTypes?: Maybe<Array<{ __typename?: 'ResourceTypeDefinition', id: string, name: string }>>, topic?: Maybe<{ __typename?: 'Topic', id: string, metadata?: Maybe<{ __typename?: 'TaxonomyMetadata', customFields?: Maybe<any> }>, coreResources?: Maybe<Array<(
+      { __typename?: 'Resource' }
+      & GQLResourceInfoFragment
+    )>>, supplementaryResources?: Maybe<Array<(
+      { __typename?: 'Resource' }
+      & GQLResourceInfoFragment
+    )>> }>, resource?: Maybe<(
+    { __typename?: 'Resource', article?: Maybe<(
+      { __typename?: 'Article' }
+      & GQLArticleInfoFragment
+    )>, learningpath?: Maybe<(
+      { __typename?: 'Learningpath' }
+      & GQLLearningpathInfoFragment
+    )> }
+    & GQLResourceInfoFragment
+  )> };
 
 export type GQLResourcePageQueryVariables = Exact<{
   topicId: Scalars['String'];
@@ -2322,63 +1541,23 @@ export type GQLResourcePageQueryVariables = Exact<{
   resourceId: Scalars['String'];
 }>;
 
-export type GQLResourcePageQuery = {
-  __typename?: 'Query';
-  subject?: Maybe<{
-    __typename?: 'Subject';
-    id: string;
-    name: string;
-    path?: Maybe<string>;
-    topics?: Maybe<
-      Array<{
-        __typename?: 'Topic';
-        id: string;
-        name: string;
-        parent?: Maybe<string>;
-        path?: Maybe<string>;
-        relevanceId?: Maybe<string>;
-        meta?: Maybe<{ __typename?: 'Meta' } & GQLMetaInfoFragment>;
-      }>
-    >;
-  }>;
-  resourceTypes?: Maybe<
-    Array<{
-      __typename?: 'ResourceTypeDefinition';
-      id: string;
-      name: string;
-      subtypes?: Maybe<
-        Array<{
-          __typename?: 'ResourceTypeDefinition';
-          id: string;
-          name: string;
-        }>
-      >;
-    }>
-  >;
-  topic?: Maybe<{
-    __typename?: 'Topic';
-    id: string;
-    name: string;
-    path?: Maybe<string>;
-    relevanceId?: Maybe<string>;
-    coreResources?: Maybe<
-      Array<{ __typename?: 'Resource' } & GQLResourceInfoFragment>
-    >;
-    supplementaryResources?: Maybe<
-      Array<{ __typename?: 'Resource' } & GQLResourceInfoFragment>
-    >;
-    metadata?: Maybe<{
-      __typename?: 'TaxonomyMetadata';
-      customFields?: Maybe<any>;
-    }>;
-  }>;
-  resource?: Maybe<
-    {
-      __typename?: 'Resource';
-      article?: Maybe<{ __typename?: 'Article' } & GQLArticleInfoFragment>;
-      learningpath?: Maybe<
-        { __typename?: 'Learningpath' } & GQLLearningpathInfoFragment
-      >;
-    } & GQLResourceInfoFragment
-  >;
-};
+
+export type GQLResourcePageQuery = { __typename?: 'Query', subject?: Maybe<{ __typename?: 'Subject', id: string, name: string, path?: Maybe<string>, topics?: Maybe<Array<{ __typename?: 'Topic', id: string, name: string, parent?: Maybe<string>, path?: Maybe<string>, relevanceId?: Maybe<string>, meta?: Maybe<(
+        { __typename?: 'Meta' }
+        & GQLMetaInfoFragment
+      )> }>> }>, resourceTypes?: Maybe<Array<{ __typename?: 'ResourceTypeDefinition', id: string, name: string, subtypes?: Maybe<Array<{ __typename?: 'ResourceTypeDefinition', id: string, name: string }>> }>>, topic?: Maybe<{ __typename?: 'Topic', id: string, name: string, path?: Maybe<string>, relevanceId?: Maybe<string>, coreResources?: Maybe<Array<(
+      { __typename?: 'Resource' }
+      & GQLResourceInfoFragment
+    )>>, supplementaryResources?: Maybe<Array<(
+      { __typename?: 'Resource' }
+      & GQLResourceInfoFragment
+    )>>, metadata?: Maybe<{ __typename?: 'TaxonomyMetadata', customFields?: Maybe<any> }> }>, resource?: Maybe<(
+    { __typename?: 'Resource', article?: Maybe<(
+      { __typename?: 'Article' }
+      & GQLArticleInfoFragment
+    )>, learningpath?: Maybe<(
+      { __typename?: 'Learningpath' }
+      & GQLLearningpathInfoFragment
+    )> }
+    & GQLResourceInfoFragment
+  )> };

--- a/src/graphqlTypes.ts
+++ b/src/graphqlTypes.ts
@@ -1,7 +1,11 @@
 export type Maybe<T> = T;
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type Exact<T extends { [key: string]: unknown }> = {
+  [K in keyof T]: T[K];
+};
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> &
+  { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> &
+  { [SubKey in K]: Maybe<T[SubKey]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -51,7 +55,6 @@ export type GQLArticle = {
   updated: Scalars['String'];
   visualElement?: Maybe<GQLVisualElement>;
 };
-
 
 export type GQLArticleCrossSubjectTopicsArgs = {
   subjectId?: Maybe<Scalars['String']>;
@@ -648,7 +651,6 @@ export type GQLQuery = {
   topics?: Maybe<Array<GQLTopic>>;
 };
 
-
 export type GQLQueryArticleArgs = {
   id: Scalars['String'];
   isOembed?: Maybe<Scalars['String']>;
@@ -657,19 +659,16 @@ export type GQLQueryArticleArgs = {
   subjectId?: Maybe<Scalars['String']>;
 };
 
-
 export type GQLQueryCompetenceGoalArgs = {
   code: Scalars['String'];
   language?: Maybe<Scalars['String']>;
 };
-
 
 export type GQLQueryCompetenceGoalsArgs = {
   codes?: Maybe<Array<Maybe<Scalars['String']>>>;
   language?: Maybe<Scalars['String']>;
   nodeId?: Maybe<Scalars['String']>;
 };
-
 
 export type GQLQueryConceptSearchArgs = {
   exactTitleMatch?: Maybe<Scalars['Boolean']>;
@@ -682,33 +681,27 @@ export type GQLQueryConceptSearchArgs = {
   tags?: Maybe<Scalars['String']>;
 };
 
-
 export type GQLQueryConceptsArgs = {
   ids: Array<Scalars['String']>;
 };
-
 
 export type GQLQueryCoreElementArgs = {
   code: Scalars['String'];
   language?: Maybe<Scalars['String']>;
 };
 
-
 export type GQLQueryCoreElementsArgs = {
   codes?: Maybe<Array<Maybe<Scalars['String']>>>;
   language?: Maybe<Scalars['String']>;
 };
 
-
 export type GQLQueryDetailedConceptArgs = {
   id?: Maybe<Scalars['String']>;
 };
 
-
 export type GQLQueryFrontpageSearchArgs = {
   query?: Maybe<Scalars['String']>;
 };
-
 
 export type GQLQueryGroupSearchArgs = {
   aggregatePaths?: Maybe<Array<Scalars['String']>>;
@@ -724,51 +717,42 @@ export type GQLQueryGroupSearchArgs = {
   subjects?: Maybe<Scalars['String']>;
 };
 
-
 export type GQLQueryLearningpathArgs = {
   pathId: Scalars['String'];
 };
-
 
 export type GQLQueryLearningpathStepArgs = {
   pathId: Scalars['String'];
   stepId: Scalars['String'];
 };
 
-
 export type GQLQueryListingPageArgs = {
   subjects?: Maybe<Scalars['String']>;
 };
 
-
 export type GQLQueryPodcastArgs = {
   id: Scalars['Int'];
 };
-
 
 export type GQLQueryPodcastSearchArgs = {
   page?: Maybe<Scalars['Int']>;
   pageSize?: Maybe<Scalars['Int']>;
 };
 
-
 export type GQLQueryPodcastSeriesArgs = {
   id: Scalars['Int'];
 };
-
 
 export type GQLQueryPodcastSeriesSearchArgs = {
   page?: Maybe<Scalars['Int']>;
   pageSize?: Maybe<Scalars['Int']>;
 };
 
-
 export type GQLQueryResourceArgs = {
   id: Scalars['String'];
   subjectId?: Maybe<Scalars['String']>;
   topicId?: Maybe<Scalars['String']>;
 };
-
 
 export type GQLQuerySearchArgs = {
   aggregatePaths?: Maybe<Array<Scalars['String']>>;
@@ -789,7 +773,6 @@ export type GQLQuerySearchArgs = {
   subjects?: Maybe<Scalars['String']>;
 };
 
-
 export type GQLQuerySearchWithoutPaginationArgs = {
   contextFilters?: Maybe<Scalars['String']>;
   contextTypes?: Maybe<Scalars['String']>;
@@ -805,22 +788,18 @@ export type GQLQuerySearchWithoutPaginationArgs = {
   subjects?: Maybe<Scalars['String']>;
 };
 
-
 export type GQLQuerySubjectArgs = {
   id: Scalars['String'];
 };
-
 
 export type GQLQuerySubjectpageArgs = {
   id: Scalars['String'];
 };
 
-
 export type GQLQueryTopicArgs = {
   id: Scalars['String'];
   subjectId?: Maybe<Scalars['String']>;
 };
-
 
 export type GQLQueryTopicsArgs = {
   contentUri?: Maybe<Scalars['String']>;
@@ -840,25 +819,25 @@ export type GQLRelatedContent = {
   url: Scalars['String'];
 };
 
-export type GQLResource = GQLTaxonomyEntity & GQLWithArticle & {
-  __typename?: 'Resource';
-  article?: Maybe<GQLArticle>;
-  availability?: Maybe<Scalars['String']>;
-  breadcrumbs?: Maybe<Array<Array<Scalars['String']>>>;
-  contentUri?: Maybe<Scalars['String']>;
-  id: Scalars['String'];
-  learningpath?: Maybe<GQLLearningpath>;
-  meta?: Maybe<GQLMeta>;
-  metadata?: Maybe<GQLTaxonomyMetadata>;
-  name: Scalars['String'];
-  parentTopics?: Maybe<Array<GQLTopic>>;
-  path?: Maybe<Scalars['String']>;
-  paths?: Maybe<Array<Scalars['String']>>;
-  rank?: Maybe<Scalars['Int']>;
-  relevanceId?: Maybe<Scalars['String']>;
-  resourceTypes?: Maybe<Array<GQLResourceType>>;
-};
-
+export type GQLResource = GQLTaxonomyEntity &
+  GQLWithArticle & {
+    __typename?: 'Resource';
+    article?: Maybe<GQLArticle>;
+    availability?: Maybe<Scalars['String']>;
+    breadcrumbs?: Maybe<Array<Array<Scalars['String']>>>;
+    contentUri?: Maybe<Scalars['String']>;
+    id: Scalars['String'];
+    learningpath?: Maybe<GQLLearningpath>;
+    meta?: Maybe<GQLMeta>;
+    metadata?: Maybe<GQLTaxonomyMetadata>;
+    name: Scalars['String'];
+    parentTopics?: Maybe<Array<GQLTopic>>;
+    path?: Maybe<Scalars['String']>;
+    paths?: Maybe<Array<Scalars['String']>>;
+    rank?: Maybe<Scalars['Int']>;
+    relevanceId?: Maybe<Scalars['String']>;
+    resourceTypes?: Maybe<Array<GQLResourceType>>;
+  };
 
 export type GQLResourceArticleArgs = {
   isOembed?: Maybe<Scalars['String']>;
@@ -871,7 +850,6 @@ export type GQLResourceType = {
   name: Scalars['String'];
   resources?: Maybe<Array<GQLResource>>;
 };
-
 
 export type GQLResourceTypeResourcesArgs = {
   topicId: Scalars['String'];
@@ -964,7 +942,6 @@ export type GQLSubject = GQLTaxonomyEntity & {
   topics?: Maybe<Array<GQLTopic>>;
 };
 
-
 export type GQLSubjectTopicsArgs = {
   all?: Maybe<Scalars['Boolean']>;
 };
@@ -986,21 +963,17 @@ export type GQLSubjectPage = {
   twitter?: Maybe<Scalars['String']>;
 };
 
-
 export type GQLSubjectPageEditorsChoicesArgs = {
   subjectId?: Maybe<Scalars['String']>;
 };
-
 
 export type GQLSubjectPageLatestContentArgs = {
   subjectId?: Maybe<Scalars['String']>;
 };
 
-
 export type GQLSubjectPageMostReadArgs = {
   subjectId?: Maybe<Scalars['String']>;
 };
-
 
 export type GQLSubjectPageTopicalArgs = {
   subjectId?: Maybe<Scalars['String']>;
@@ -1070,40 +1043,38 @@ export type GQLTitle = {
   title: Scalars['String'];
 };
 
-export type GQLTopic = GQLTaxonomyEntity & GQLWithArticle & {
-  __typename?: 'Topic';
-  alternateTopics?: Maybe<Array<GQLTopic>>;
-  article?: Maybe<GQLArticle>;
-  availability?: Maybe<Scalars['String']>;
-  breadcrumbs?: Maybe<Array<Array<Scalars['String']>>>;
-  contentUri?: Maybe<Scalars['String']>;
-  coreResources?: Maybe<Array<GQLResource>>;
-  id: Scalars['String'];
-  isPrimary?: Maybe<Scalars['Boolean']>;
-  meta?: Maybe<GQLMeta>;
-  metadata?: Maybe<GQLTaxonomyMetadata>;
-  name: Scalars['String'];
-  parent?: Maybe<Scalars['String']>;
-  path?: Maybe<Scalars['String']>;
-  pathTopics?: Maybe<Array<Array<GQLTopic>>>;
-  paths?: Maybe<Array<Scalars['String']>>;
-  rank?: Maybe<Scalars['Int']>;
-  relevanceId?: Maybe<Scalars['String']>;
-  subtopics?: Maybe<Array<GQLTopic>>;
-  supplementaryResources?: Maybe<Array<GQLResource>>;
-};
-
+export type GQLTopic = GQLTaxonomyEntity &
+  GQLWithArticle & {
+    __typename?: 'Topic';
+    alternateTopics?: Maybe<Array<GQLTopic>>;
+    article?: Maybe<GQLArticle>;
+    availability?: Maybe<Scalars['String']>;
+    breadcrumbs?: Maybe<Array<Array<Scalars['String']>>>;
+    contentUri?: Maybe<Scalars['String']>;
+    coreResources?: Maybe<Array<GQLResource>>;
+    id: Scalars['String'];
+    isPrimary?: Maybe<Scalars['Boolean']>;
+    meta?: Maybe<GQLMeta>;
+    metadata?: Maybe<GQLTaxonomyMetadata>;
+    name: Scalars['String'];
+    parent?: Maybe<Scalars['String']>;
+    path?: Maybe<Scalars['String']>;
+    pathTopics?: Maybe<Array<Array<GQLTopic>>>;
+    paths?: Maybe<Array<Scalars['String']>>;
+    rank?: Maybe<Scalars['Int']>;
+    relevanceId?: Maybe<Scalars['String']>;
+    subtopics?: Maybe<Array<GQLTopic>>;
+    supplementaryResources?: Maybe<Array<GQLResource>>;
+  };
 
 export type GQLTopicArticleArgs = {
   showVisualElement?: Maybe<Scalars['String']>;
   subjectId?: Maybe<Scalars['String']>;
 };
 
-
 export type GQLTopicCoreResourcesArgs = {
   subjectId?: Maybe<Scalars['String']>;
 };
-
 
 export type GQLTopicSupplementaryResourcesArgs = {
   subjectId?: Maybe<Scalars['String']>;
@@ -1140,7 +1111,11 @@ export type GQLEmbedVisualelement = {
   visualElement?: Maybe<GQLVisualElement>;
 };
 
-export type GQLContributorInfoFragment = { __typename?: 'Contributor', name: string, type: string };
+export type GQLContributorInfoFragment = {
+  __typename?: 'Contributor';
+  name: string;
+  type: string;
+};
 
 export type GQLSearchQueryVariables = Exact<{
   query?: Maybe<Scalars['String']>;
@@ -1159,12 +1134,155 @@ export type GQLSearchQueryVariables = Exact<{
   grepCodes?: Maybe<Scalars['String']>;
 }>;
 
+export type GQLSearchQuery = {
+  __typename?: 'Query';
+  search?: Maybe<{
+    __typename?: 'Search';
+    language: string;
+    page?: Maybe<number>;
+    pageSize: number;
+    totalCount: number;
+    results: Array<
+      | {
+          __typename?: 'ArticleSearchResult';
+          id: number;
+          url: string;
+          metaDescription: string;
+          title: string;
+          supportedLanguages: Array<string>;
+          traits: Array<string>;
+          metaImage?: Maybe<{
+            __typename?: 'MetaImage';
+            url?: Maybe<string>;
+            alt?: Maybe<string>;
+          }>;
+          contexts: Array<{
+            __typename?: 'SearchContext';
+            id: string;
+            breadcrumbs: Array<string>;
+            relevance: string;
+            language: string;
+            learningResourceType: string;
+            path: string;
+            subject: string;
+            subjectId: string;
+            resourceTypes: Array<{
+              __typename?: 'SearchContextResourceTypes';
+              id: string;
+              name: string;
+              language: string;
+            }>;
+          }>;
+        }
+      | {
+          __typename?: 'LearningpathSearchResult';
+          id: number;
+          url: string;
+          metaDescription: string;
+          title: string;
+          supportedLanguages: Array<string>;
+          traits: Array<string>;
+          metaImage?: Maybe<{
+            __typename?: 'MetaImage';
+            url?: Maybe<string>;
+            alt?: Maybe<string>;
+          }>;
+          contexts: Array<{
+            __typename?: 'SearchContext';
+            id: string;
+            breadcrumbs: Array<string>;
+            relevance: string;
+            language: string;
+            learningResourceType: string;
+            path: string;
+            subject: string;
+            subjectId: string;
+            resourceTypes: Array<{
+              __typename?: 'SearchContextResourceTypes';
+              id: string;
+              name: string;
+              language: string;
+            }>;
+          }>;
+        }
+    >;
+    suggestions: Array<{
+      __typename?: 'SuggestionResult';
+      name: string;
+      suggestions: Array<{
+        __typename?: 'SearchSuggestion';
+        text: string;
+        offset: number;
+        length: number;
+        options: Array<{
+          __typename?: 'SuggestOption';
+          text: string;
+          score: number;
+        }>;
+      }>;
+    }>;
+  }>;
+};
 
-export type GQLSearchQuery = { __typename?: 'Query', search?: Maybe<{ __typename?: 'Search', language: string, page?: Maybe<number>, pageSize: number, totalCount: number, results: Array<{ __typename?: 'ArticleSearchResult', id: number, url: string, metaDescription: string, title: string, supportedLanguages: Array<string>, traits: Array<string>, metaImage?: Maybe<{ __typename?: 'MetaImage', url?: Maybe<string>, alt?: Maybe<string> }>, contexts: Array<{ __typename?: 'SearchContext', id: string, breadcrumbs: Array<string>, relevance: string, language: string, learningResourceType: string, path: string, subject: string, subjectId: string, resourceTypes: Array<{ __typename?: 'SearchContextResourceTypes', id: string, name: string, language: string }> }> } | { __typename?: 'LearningpathSearchResult', id: number, url: string, metaDescription: string, title: string, supportedLanguages: Array<string>, traits: Array<string>, metaImage?: Maybe<{ __typename?: 'MetaImage', url?: Maybe<string>, alt?: Maybe<string> }>, contexts: Array<{ __typename?: 'SearchContext', id: string, breadcrumbs: Array<string>, relevance: string, language: string, learningResourceType: string, path: string, subject: string, subjectId: string, resourceTypes: Array<{ __typename?: 'SearchContextResourceTypes', id: string, name: string, language: string }> }> }>, suggestions: Array<{ __typename?: 'SuggestionResult', name: string, suggestions: Array<{ __typename?: 'SearchSuggestion', text: string, offset: number, length: number, options: Array<{ __typename?: 'SuggestOption', text: string, score: number }> }> }> }> };
+export type GQLSearchFilmArticleSearchResultFragment = {
+  __typename?: 'ArticleSearchResult';
+  id: number;
+  url: string;
+  metaDescription: string;
+  title: string;
+  supportedLanguages: Array<string>;
+  traits: Array<string>;
+  metaImage?: Maybe<{
+    __typename?: 'MetaImage';
+    url?: Maybe<string>;
+    alt?: Maybe<string>;
+  }>;
+  contexts: Array<{
+    __typename?: 'SearchContext';
+    breadcrumbs: Array<string>;
+    relevance: string;
+    language: string;
+    learningResourceType: string;
+    path: string;
+    subject: string;
+    resourceTypes: Array<{
+      __typename?: 'SearchContextResourceTypes';
+      id: string;
+      name: string;
+      language: string;
+    }>;
+  }>;
+};
 
-export type GQLSearchFilmArticleSearchResultFragment = { __typename?: 'ArticleSearchResult', id: number, url: string, metaDescription: string, title: string, supportedLanguages: Array<string>, traits: Array<string>, metaImage?: Maybe<{ __typename?: 'MetaImage', url?: Maybe<string>, alt?: Maybe<string> }>, contexts: Array<{ __typename?: 'SearchContext', breadcrumbs: Array<string>, relevance: string, language: string, learningResourceType: string, path: string, subject: string, resourceTypes: Array<{ __typename?: 'SearchContextResourceTypes', id: string, name: string, language: string }> }> };
-
-export type GQLSearchFilmLearningpathSearchResultFragment = { __typename?: 'LearningpathSearchResult', id: number, url: string, metaDescription: string, title: string, supportedLanguages: Array<string>, traits: Array<string>, metaImage?: Maybe<{ __typename?: 'MetaImage', url?: Maybe<string>, alt?: Maybe<string> }>, contexts: Array<{ __typename?: 'SearchContext', breadcrumbs: Array<string>, relevance: string, language: string, learningResourceType: string, path: string, subject: string, resourceTypes: Array<{ __typename?: 'SearchContextResourceTypes', id: string, name: string, language: string }> }> };
+export type GQLSearchFilmLearningpathSearchResultFragment = {
+  __typename?: 'LearningpathSearchResult';
+  id: number;
+  url: string;
+  metaDescription: string;
+  title: string;
+  supportedLanguages: Array<string>;
+  traits: Array<string>;
+  metaImage?: Maybe<{
+    __typename?: 'MetaImage';
+    url?: Maybe<string>;
+    alt?: Maybe<string>;
+  }>;
+  contexts: Array<{
+    __typename?: 'SearchContext';
+    breadcrumbs: Array<string>;
+    relevance: string;
+    language: string;
+    learningResourceType: string;
+    path: string;
+    subject: string;
+    resourceTypes: Array<{
+      __typename?: 'SearchContextResourceTypes';
+      id: string;
+      name: string;
+      language: string;
+    }>;
+  }>;
+};
 
 export type GQLSearchWithoutPaginationQueryVariables = Exact<{
   query?: Maybe<Scalars['String']>;
@@ -1180,14 +1298,20 @@ export type GQLSearchWithoutPaginationQueryVariables = Exact<{
   relevance?: Maybe<Scalars['String']>;
 }>;
 
-
-export type GQLSearchWithoutPaginationQuery = { __typename?: 'Query', searchWithoutPagination?: Maybe<{ __typename?: 'SearchWithoutPagination', results: Array<(
-      { __typename?: 'ArticleSearchResult' }
-      & GQLSearchFilmArticleSearchResultFragment
-    ) | (
-      { __typename?: 'LearningpathSearchResult' }
-      & GQLSearchFilmLearningpathSearchResultFragment
-    )> }> };
+export type GQLSearchWithoutPaginationQuery = {
+  __typename?: 'Query';
+  searchWithoutPagination?: Maybe<{
+    __typename?: 'SearchWithoutPagination';
+    results: Array<
+      | ({
+          __typename?: 'ArticleSearchResult';
+        } & GQLSearchFilmArticleSearchResultFragment)
+      | ({
+          __typename?: 'LearningpathSearchResult';
+        } & GQLSearchFilmLearningpathSearchResultFragment)
+    >;
+  }>;
+};
 
 export type GQLGroupSearchQueryVariables = Exact<{
   resourceTypes?: Maybe<Scalars['String']>;
@@ -1200,11 +1324,78 @@ export type GQLGroupSearchQueryVariables = Exact<{
   fallback?: Maybe<Scalars['String']>;
   grepCodes?: Maybe<Scalars['String']>;
   aggregatePaths?: Maybe<Array<Scalars['String']> | Scalars['String']>;
-  grepCodesList?: Maybe<Array<Maybe<Scalars['String']>> | Maybe<Scalars['String']>>;
+  grepCodesList?: Maybe<
+    Array<Maybe<Scalars['String']>> | Maybe<Scalars['String']>
+  >;
 }>;
 
-
-export type GQLGroupSearchQuery = { __typename?: 'Query', groupSearch?: Maybe<Array<{ __typename?: 'GroupSearch', resourceType: string, totalCount: number, language: string, resources: Array<{ __typename?: 'GroupSearchResult', id: number, path: string, name: string, ingress: string, traits: Array<string>, contexts: Array<{ __typename?: 'SearchContext', language: string, path: string, breadcrumbs: Array<string>, subjectId: string, subject: string, relevance: string, resourceTypes: Array<{ __typename?: 'SearchContextResourceTypes', id: string, name: string }> }>, metaImage?: Maybe<{ __typename?: 'MetaImage', url?: Maybe<string>, alt?: Maybe<string> }> }>, aggregations: Array<{ __typename?: 'AggregationResult', values: Array<{ __typename?: 'BucketResult', value: string }> }>, suggestions: Array<{ __typename?: 'SuggestionResult', suggestions: Array<{ __typename?: 'SearchSuggestion', options: Array<{ __typename?: 'SuggestOption', text: string }> }> }> }>>, competenceGoals?: Maybe<Array<{ __typename?: 'CompetenceGoal', id: string, type: string, name: string, curriculum?: Maybe<{ __typename?: 'Reference', id: string, title: string }>, competenceGoalSet?: Maybe<{ __typename?: 'Reference', id: string, title: string }> }>> };
+export type GQLGroupSearchQuery = {
+  __typename?: 'Query';
+  groupSearch?: Maybe<
+    Array<{
+      __typename?: 'GroupSearch';
+      resourceType: string;
+      totalCount: number;
+      language: string;
+      resources: Array<{
+        __typename?: 'GroupSearchResult';
+        id: number;
+        path: string;
+        name: string;
+        ingress: string;
+        traits: Array<string>;
+        contexts: Array<{
+          __typename?: 'SearchContext';
+          language: string;
+          path: string;
+          breadcrumbs: Array<string>;
+          subjectId: string;
+          subject: string;
+          relevance: string;
+          resourceTypes: Array<{
+            __typename?: 'SearchContextResourceTypes';
+            id: string;
+            name: string;
+          }>;
+        }>;
+        metaImage?: Maybe<{
+          __typename?: 'MetaImage';
+          url?: Maybe<string>;
+          alt?: Maybe<string>;
+        }>;
+      }>;
+      aggregations: Array<{
+        __typename?: 'AggregationResult';
+        values: Array<{ __typename?: 'BucketResult'; value: string }>;
+      }>;
+      suggestions: Array<{
+        __typename?: 'SuggestionResult';
+        suggestions: Array<{
+          __typename?: 'SearchSuggestion';
+          options: Array<{ __typename?: 'SuggestOption'; text: string }>;
+        }>;
+      }>;
+    }>
+  >;
+  competenceGoals?: Maybe<
+    Array<{
+      __typename?: 'CompetenceGoal';
+      id: string;
+      type: string;
+      name: string;
+      curriculum?: Maybe<{
+        __typename?: 'Reference';
+        id: string;
+        title: string;
+      }>;
+      competenceGoalSet?: Maybe<{
+        __typename?: 'Reference';
+        id: string;
+        title: string;
+      }>;
+    }>
+  >;
+};
 
 export type GQLConceptSearchQueryVariables = Exact<{
   query?: Maybe<Scalars['String']>;
@@ -1214,111 +1405,450 @@ export type GQLConceptSearchQueryVariables = Exact<{
   fallback?: Maybe<Scalars['Boolean']>;
 }>;
 
-
-export type GQLConceptSearchQuery = { __typename?: 'Query', conceptSearch?: Maybe<{ __typename?: 'ConceptResult', concepts: Array<{ __typename?: 'Concept', id: number, title: string, text: string, image: { __typename?: 'MetaImage', url?: Maybe<string>, alt?: Maybe<string> } }> }> };
+export type GQLConceptSearchQuery = {
+  __typename?: 'Query';
+  conceptSearch?: Maybe<{
+    __typename?: 'ConceptResult';
+    concepts: Array<{
+      __typename?: 'Concept';
+      id: number;
+      title: string;
+      text: string;
+      image: {
+        __typename?: 'MetaImage';
+        url?: Maybe<string>;
+        alt?: Maybe<string>;
+      };
+    }>;
+  }>;
+};
 
 export type GQLFrontpageSearchQueryVariables = Exact<{
   query?: Maybe<Scalars['String']>;
 }>;
 
+export type GQLFrontpageSearchQuery = {
+  __typename?: 'Query';
+  frontpageSearch?: Maybe<{
+    __typename?: 'FrontpageSearch';
+    topicResources: {
+      __typename?: 'FrontPageResources';
+      totalCount: number;
+      results: Array<{
+        __typename?: 'FrontpageSearchResult';
+        id: string;
+        name: string;
+        path: string;
+        subject: string;
+        resourceTypes: Array<{
+          __typename?: 'SearchContextResourceTypes';
+          name: string;
+        }>;
+      }>;
+      suggestions: Array<{
+        __typename?: 'SuggestionResult';
+        suggestions: Array<{
+          __typename?: 'SearchSuggestion';
+          options: Array<{
+            __typename?: 'SuggestOption';
+            text: string;
+            score: number;
+          }>;
+        }>;
+      }>;
+    };
+    learningResources: {
+      __typename?: 'FrontPageResources';
+      totalCount: number;
+      results: Array<{
+        __typename?: 'FrontpageSearchResult';
+        id: string;
+        name: string;
+        path: string;
+        subject: string;
+        resourceTypes: Array<{
+          __typename?: 'SearchContextResourceTypes';
+          name: string;
+        }>;
+      }>;
+      suggestions: Array<{
+        __typename?: 'SuggestionResult';
+        suggestions: Array<{
+          __typename?: 'SearchSuggestion';
+          options: Array<{
+            __typename?: 'SuggestOption';
+            text: string;
+            score: number;
+          }>;
+        }>;
+      }>;
+    };
+  }>;
+};
 
-export type GQLFrontpageSearchQuery = { __typename?: 'Query', frontpageSearch?: Maybe<{ __typename?: 'FrontpageSearch', topicResources: { __typename?: 'FrontPageResources', totalCount: number, results: Array<{ __typename?: 'FrontpageSearchResult', id: string, name: string, path: string, subject: string, resourceTypes: Array<{ __typename?: 'SearchContextResourceTypes', name: string }> }>, suggestions: Array<{ __typename?: 'SuggestionResult', suggestions: Array<{ __typename?: 'SearchSuggestion', options: Array<{ __typename?: 'SuggestOption', text: string, score: number }> }> }> }, learningResources: { __typename?: 'FrontPageResources', totalCount: number, results: Array<{ __typename?: 'FrontpageSearchResult', id: string, name: string, path: string, subject: string, resourceTypes: Array<{ __typename?: 'SearchContextResourceTypes', name: string }> }>, suggestions: Array<{ __typename?: 'SuggestionResult', suggestions: Array<{ __typename?: 'SearchSuggestion', options: Array<{ __typename?: 'SuggestOption', text: string, score: number }> }> }> } }> };
+export type GQLCopyrightInfoFragment = {
+  __typename?: 'Copyright';
+  origin?: Maybe<string>;
+  license: { __typename?: 'License'; license: string; url?: Maybe<string> };
+  creators: Array<{ __typename?: 'Contributor' } & GQLContributorInfoFragment>;
+  processors: Array<
+    { __typename?: 'Contributor' } & GQLContributorInfoFragment
+  >;
+  rightsholders: Array<
+    { __typename?: 'Contributor' } & GQLContributorInfoFragment
+  >;
+};
 
-export type GQLCopyrightInfoFragment = { __typename?: 'Copyright', origin?: Maybe<string>, license: { __typename?: 'License', license: string, url?: Maybe<string> }, creators: Array<(
-    { __typename?: 'Contributor' }
-    & GQLContributorInfoFragment
-  )>, processors: Array<(
-    { __typename?: 'Contributor' }
-    & GQLContributorInfoFragment
-  )>, rightsholders: Array<(
-    { __typename?: 'Contributor' }
-    & GQLContributorInfoFragment
-  )> };
+export type GQLMetaInfoFragment = {
+  __typename?: 'Meta';
+  id: number;
+  title: string;
+  introduction?: Maybe<string>;
+  metaDescription?: Maybe<string>;
+  lastUpdated?: Maybe<string>;
+  metaImage?: Maybe<{
+    __typename?: 'MetaImage';
+    url?: Maybe<string>;
+    alt?: Maybe<string>;
+  }>;
+};
 
-export type GQLMetaInfoFragment = { __typename?: 'Meta', id: number, title: string, introduction?: Maybe<string>, metaDescription?: Maybe<string>, lastUpdated?: Maybe<string>, metaImage?: Maybe<{ __typename?: 'MetaImage', url?: Maybe<string>, alt?: Maybe<string> }> };
+export type GQLTopicInfoFragment = {
+  __typename?: 'Topic';
+  id: string;
+  name: string;
+  contentUri?: Maybe<string>;
+  path?: Maybe<string>;
+  availability?: Maybe<string>;
+  parent?: Maybe<string>;
+  relevanceId?: Maybe<string>;
+  meta?: Maybe<{ __typename?: 'Meta' } & GQLMetaInfoFragment>;
+  metadata?: Maybe<{
+    __typename?: 'TaxonomyMetadata';
+    customFields?: Maybe<any>;
+  }>;
+};
 
-export type GQLTopicInfoFragment = { __typename?: 'Topic', id: string, name: string, contentUri?: Maybe<string>, path?: Maybe<string>, availability?: Maybe<string>, parent?: Maybe<string>, relevanceId?: Maybe<string>, meta?: Maybe<(
-    { __typename?: 'Meta' }
-    & GQLMetaInfoFragment
-  )>, metadata?: Maybe<{ __typename?: 'TaxonomyMetadata', customFields?: Maybe<any> }> };
+export type GQLSubjectInfoFragment = {
+  __typename?: 'Subject';
+  id: string;
+  name: string;
+  path?: Maybe<string>;
+  metadata?: Maybe<{
+    __typename?: 'TaxonomyMetadata';
+    customFields?: Maybe<any>;
+  }>;
+};
 
-export type GQLSubjectInfoFragment = { __typename?: 'Subject', id: string, name: string, path?: Maybe<string>, metadata?: Maybe<{ __typename?: 'TaxonomyMetadata', customFields?: Maybe<any> }> };
+export type GQLResourceInfoFragment = {
+  __typename?: 'Resource';
+  id: string;
+  name: string;
+  contentUri?: Maybe<string>;
+  path?: Maybe<string>;
+  paths?: Maybe<Array<string>>;
+  relevanceId?: Maybe<string>;
+  rank?: Maybe<number>;
+  resourceTypes?: Maybe<
+    Array<{ __typename?: 'ResourceType'; id: string; name: string }>
+  >;
+};
 
-export type GQLResourceInfoFragment = { __typename?: 'Resource', id: string, name: string, contentUri?: Maybe<string>, path?: Maybe<string>, paths?: Maybe<Array<string>>, relevanceId?: Maybe<string>, rank?: Maybe<number>, resourceTypes?: Maybe<Array<{ __typename?: 'ResourceType', id: string, name: string }>> };
+export type GQLVisualElementInfoFragment = {
+  __typename?: 'VisualElement';
+  title?: Maybe<string>;
+  resource?: Maybe<string>;
+  url?: Maybe<string>;
+  language?: Maybe<string>;
+  embed?: Maybe<string>;
+  copyright?: Maybe<{ __typename?: 'Copyright' } & GQLCopyrightInfoFragment>;
+  brightcove?: Maybe<{
+    __typename?: 'BrightcoveElement';
+    videoid?: Maybe<string>;
+    player?: Maybe<string>;
+    account?: Maybe<string>;
+    caption?: Maybe<string>;
+    description?: Maybe<string>;
+    cover?: Maybe<string>;
+    src?: Maybe<string>;
+    download?: Maybe<string>;
+    uploadDate?: Maybe<string>;
+    copyText?: Maybe<string>;
+    iframe?: Maybe<{
+      __typename?: 'BrightcoveIframe';
+      src: string;
+      height: number;
+      width: number;
+    }>;
+  }>;
+  h5p?: Maybe<{
+    __typename?: 'H5pElement';
+    src?: Maybe<string>;
+    thumbnail?: Maybe<string>;
+    copyText?: Maybe<string>;
+  }>;
+  oembed?: Maybe<{
+    __typename?: 'VisualElementOembed';
+    title?: Maybe<string>;
+    html?: Maybe<string>;
+    fullscreen?: Maybe<boolean>;
+  }>;
+  image?: Maybe<{
+    __typename?: 'ImageElement';
+    resourceid?: Maybe<string>;
+    alt?: Maybe<string>;
+    caption?: Maybe<string>;
+    lowerRightX?: Maybe<number>;
+    lowerRightY?: Maybe<number>;
+    upperLeftX?: Maybe<number>;
+    upperLeftY?: Maybe<number>;
+    focalX?: Maybe<number>;
+    focalY?: Maybe<number>;
+    src: string;
+    altText: string;
+    contentType?: Maybe<string>;
+    copyText?: Maybe<string>;
+  }>;
+};
 
-export type GQLVisualElementInfoFragment = { __typename?: 'VisualElement', title?: Maybe<string>, resource?: Maybe<string>, url?: Maybe<string>, language?: Maybe<string>, embed?: Maybe<string>, copyright?: Maybe<(
-    { __typename?: 'Copyright' }
-    & GQLCopyrightInfoFragment
-  )>, brightcove?: Maybe<{ __typename?: 'BrightcoveElement', videoid?: Maybe<string>, player?: Maybe<string>, account?: Maybe<string>, caption?: Maybe<string>, description?: Maybe<string>, cover?: Maybe<string>, src?: Maybe<string>, download?: Maybe<string>, uploadDate?: Maybe<string>, copyText?: Maybe<string>, iframe?: Maybe<{ __typename?: 'BrightcoveIframe', src: string, height: number, width: number }> }>, h5p?: Maybe<{ __typename?: 'H5pElement', src?: Maybe<string>, thumbnail?: Maybe<string>, copyText?: Maybe<string> }>, oembed?: Maybe<{ __typename?: 'VisualElementOembed', title?: Maybe<string>, html?: Maybe<string>, fullscreen?: Maybe<boolean> }>, image?: Maybe<{ __typename?: 'ImageElement', resourceid?: Maybe<string>, alt?: Maybe<string>, caption?: Maybe<string>, lowerRightX?: Maybe<number>, lowerRightY?: Maybe<number>, upperLeftX?: Maybe<number>, upperLeftY?: Maybe<number>, focalX?: Maybe<number>, focalY?: Maybe<number>, src: string, altText: string, contentType?: Maybe<string>, copyText?: Maybe<string> }> };
+export type GQLArticleInfoFragment = {
+  __typename?: 'Article';
+  id: number;
+  title: string;
+  introduction?: Maybe<string>;
+  content: string;
+  articleType: string;
+  revision: number;
+  metaDescription: string;
+  supportedLanguages?: Maybe<Array<string>>;
+  tags?: Maybe<Array<string>>;
+  created: string;
+  updated: string;
+  published: string;
+  oldNdlaUrl?: Maybe<string>;
+  grepCodes?: Maybe<Array<string>>;
+  oembed?: Maybe<string>;
+  conceptIds?: Maybe<Array<string>>;
+  metaImage?: Maybe<{
+    __typename?: 'MetaImage';
+    url?: Maybe<string>;
+    alt?: Maybe<string>;
+  }>;
+  requiredLibraries?: Maybe<
+    Array<{
+      __typename?: 'ArticleRequiredLibrary';
+      name: string;
+      url: string;
+      mediaType: string;
+    }>
+  >;
+  metaData?: Maybe<{
+    __typename?: 'ArticleMetaData';
+    copyText?: Maybe<string>;
+    footnotes?: Maybe<
+      Array<{
+        __typename?: 'FootNote';
+        ref: number;
+        title: string;
+        year: string;
+        authors: Array<string>;
+        edition?: Maybe<string>;
+        publisher?: Maybe<string>;
+        url?: Maybe<string>;
+      }>
+    >;
+    images?: Maybe<
+      Array<{
+        __typename?: 'ImageLicense';
+        title: string;
+        altText: string;
+        src: string;
+        copyText?: Maybe<string>;
+        copyright: { __typename?: 'Copyright' } & GQLCopyrightInfoFragment;
+      }>
+    >;
+    h5ps?: Maybe<
+      Array<{
+        __typename?: 'H5pLicense';
+        title: string;
+        src?: Maybe<string>;
+        copyText?: Maybe<string>;
+        copyright: { __typename?: 'Copyright' } & GQLCopyrightInfoFragment;
+      }>
+    >;
+    audios?: Maybe<
+      Array<{
+        __typename?: 'AudioLicense';
+        title: string;
+        src: string;
+        copyText?: Maybe<string>;
+        copyright: { __typename?: 'Copyright' } & GQLCopyrightInfoFragment;
+      }>
+    >;
+    brightcoves?: Maybe<
+      Array<{
+        __typename?: 'BrightcoveLicense';
+        title: string;
+        description?: Maybe<string>;
+        cover?: Maybe<string>;
+        src?: Maybe<string>;
+        download?: Maybe<string>;
+        uploadDate?: Maybe<string>;
+        copyText?: Maybe<string>;
+        iframe?: Maybe<{
+          __typename?: 'BrightcoveIframe';
+          height: number;
+          src: string;
+          width: number;
+        }>;
+        copyright: { __typename?: 'Copyright' } & GQLCopyrightInfoFragment;
+      }>
+    >;
+    concepts?: Maybe<
+      Array<{
+        __typename?: 'ConceptLicense';
+        title: string;
+        src?: Maybe<string>;
+        copyText?: Maybe<string>;
+        copyright?: Maybe<
+          { __typename?: 'Copyright' } & GQLCopyrightInfoFragment
+        >;
+      }>
+    >;
+  }>;
+  competenceGoals?: Maybe<
+    Array<{
+      __typename?: 'CompetenceGoal';
+      id: string;
+      title: string;
+      type: string;
+      curriculum?: Maybe<{
+        __typename?: 'Reference';
+        id: string;
+        title: string;
+      }>;
+      competenceGoalSet?: Maybe<{
+        __typename?: 'Reference';
+        id: string;
+        title: string;
+      }>;
+    }>
+  >;
+  coreElements?: Maybe<
+    Array<{
+      __typename?: 'CoreElement';
+      id: string;
+      title: string;
+      description?: Maybe<string>;
+      curriculum?: Maybe<{
+        __typename?: 'Reference';
+        id: string;
+        title: string;
+      }>;
+    }>
+  >;
+  copyright: { __typename?: 'Copyright' } & GQLCopyrightInfoFragment;
+  visualElement?: Maybe<
+    { __typename?: 'VisualElement' } & GQLVisualElementInfoFragment
+  >;
+  concepts?: Maybe<
+    Array<{
+      __typename?: 'DetailedConcept';
+      id: number;
+      title: string;
+      content?: Maybe<string>;
+      subjectNames?: Maybe<Array<string>>;
+      copyright?: Maybe<
+        { __typename?: 'Copyright' } & GQLCopyrightInfoFragment
+      >;
+      visualElement?: Maybe<
+        { __typename?: 'VisualElement' } & GQLVisualElementInfoFragment
+      >;
+    }>
+  >;
+  relatedContent?: Maybe<
+    Array<{ __typename?: 'RelatedContent'; title: string; url: string }>
+  >;
+};
 
-export type GQLArticleInfoFragment = { __typename?: 'Article', id: number, title: string, introduction?: Maybe<string>, content: string, articleType: string, revision: number, metaDescription: string, supportedLanguages?: Maybe<Array<string>>, tags?: Maybe<Array<string>>, created: string, updated: string, published: string, oldNdlaUrl?: Maybe<string>, grepCodes?: Maybe<Array<string>>, oembed?: Maybe<string>, conceptIds?: Maybe<Array<string>>, metaImage?: Maybe<{ __typename?: 'MetaImage', url?: Maybe<string>, alt?: Maybe<string> }>, requiredLibraries?: Maybe<Array<{ __typename?: 'ArticleRequiredLibrary', name: string, url: string, mediaType: string }>>, metaData?: Maybe<{ __typename?: 'ArticleMetaData', copyText?: Maybe<string>, footnotes?: Maybe<Array<{ __typename?: 'FootNote', ref: number, title: string, year: string, authors: Array<string>, edition?: Maybe<string>, publisher?: Maybe<string>, url?: Maybe<string> }>>, images?: Maybe<Array<{ __typename?: 'ImageLicense', title: string, altText: string, src: string, copyText?: Maybe<string>, copyright: (
-        { __typename?: 'Copyright' }
-        & GQLCopyrightInfoFragment
-      ) }>>, h5ps?: Maybe<Array<{ __typename?: 'H5pLicense', title: string, src?: Maybe<string>, copyText?: Maybe<string>, copyright: (
-        { __typename?: 'Copyright' }
-        & GQLCopyrightInfoFragment
-      ) }>>, audios?: Maybe<Array<{ __typename?: 'AudioLicense', title: string, src: string, copyText?: Maybe<string>, copyright: (
-        { __typename?: 'Copyright' }
-        & GQLCopyrightInfoFragment
-      ) }>>, brightcoves?: Maybe<Array<{ __typename?: 'BrightcoveLicense', title: string, description?: Maybe<string>, cover?: Maybe<string>, src?: Maybe<string>, download?: Maybe<string>, uploadDate?: Maybe<string>, copyText?: Maybe<string>, iframe?: Maybe<{ __typename?: 'BrightcoveIframe', height: number, src: string, width: number }>, copyright: (
-        { __typename?: 'Copyright' }
-        & GQLCopyrightInfoFragment
-      ) }>>, concepts?: Maybe<Array<{ __typename?: 'ConceptLicense', title: string, src?: Maybe<string>, copyText?: Maybe<string>, copyright?: Maybe<(
-        { __typename?: 'Copyright' }
-        & GQLCopyrightInfoFragment
-      )> }>> }>, competenceGoals?: Maybe<Array<{ __typename?: 'CompetenceGoal', id: string, title: string, type: string, curriculum?: Maybe<{ __typename?: 'Reference', id: string, title: string }>, competenceGoalSet?: Maybe<{ __typename?: 'Reference', id: string, title: string }> }>>, coreElements?: Maybe<Array<{ __typename?: 'CoreElement', id: string, title: string, description?: Maybe<string>, curriculum?: Maybe<{ __typename?: 'Reference', id: string, title: string }> }>>, copyright: (
-    { __typename?: 'Copyright' }
-    & GQLCopyrightInfoFragment
-  ), visualElement?: Maybe<(
-    { __typename?: 'VisualElement' }
-    & GQLVisualElementInfoFragment
-  )>, concepts?: Maybe<Array<{ __typename?: 'DetailedConcept', id: number, title: string, content?: Maybe<string>, subjectNames?: Maybe<Array<string>>, copyright?: Maybe<(
-      { __typename?: 'Copyright' }
-      & GQLCopyrightInfoFragment
-    )>, visualElement?: Maybe<(
-      { __typename?: 'VisualElement' }
-      & GQLVisualElementInfoFragment
-    )> }>>, relatedContent?: Maybe<Array<{ __typename?: 'RelatedContent', title: string, url: string }>> };
+type GQLTaxonomyEntityInfo_Resource_Fragment = {
+  __typename?: 'Resource';
+  id: string;
+  name: string;
+  contentUri?: Maybe<string>;
+  path?: Maybe<string>;
+  resourceTypes?: Maybe<
+    Array<{ __typename?: 'ResourceType'; id: string; name: string }>
+  >;
+};
 
-type GQLTaxonomyEntityInfo_Resource_Fragment = { __typename?: 'Resource', id: string, name: string, contentUri?: Maybe<string>, path?: Maybe<string>, resourceTypes?: Maybe<Array<{ __typename?: 'ResourceType', id: string, name: string }>> };
+type GQLTaxonomyEntityInfo_Subject_Fragment = {
+  __typename?: 'Subject';
+  id: string;
+  name: string;
+  contentUri?: Maybe<string>;
+  path?: Maybe<string>;
+};
 
-type GQLTaxonomyEntityInfo_Subject_Fragment = { __typename?: 'Subject', id: string, name: string, contentUri?: Maybe<string>, path?: Maybe<string> };
+type GQLTaxonomyEntityInfo_Topic_Fragment = {
+  __typename?: 'Topic';
+  id: string;
+  name: string;
+  contentUri?: Maybe<string>;
+  path?: Maybe<string>;
+};
 
-type GQLTaxonomyEntityInfo_Topic_Fragment = { __typename?: 'Topic', id: string, name: string, contentUri?: Maybe<string>, path?: Maybe<string> };
+export type GQLTaxonomyEntityInfoFragment =
+  | GQLTaxonomyEntityInfo_Resource_Fragment
+  | GQLTaxonomyEntityInfo_Subject_Fragment
+  | GQLTaxonomyEntityInfo_Topic_Fragment;
 
-export type GQLTaxonomyEntityInfoFragment = GQLTaxonomyEntityInfo_Resource_Fragment | GQLTaxonomyEntityInfo_Subject_Fragment | GQLTaxonomyEntityInfo_Topic_Fragment;
+type GQLWithArticleInfo_Resource_Fragment = {
+  __typename?: 'Resource';
+  meta?: Maybe<{ __typename?: 'Meta' } & GQLMetaInfoFragment>;
+};
 
-type GQLWithArticleInfo_Resource_Fragment = { __typename?: 'Resource', meta?: Maybe<(
-    { __typename?: 'Meta' }
-    & GQLMetaInfoFragment
-  )> };
+type GQLWithArticleInfo_Topic_Fragment = {
+  __typename?: 'Topic';
+  meta?: Maybe<{ __typename?: 'Meta' } & GQLMetaInfoFragment>;
+};
 
-type GQLWithArticleInfo_Topic_Fragment = { __typename?: 'Topic', meta?: Maybe<(
-    { __typename?: 'Meta' }
-    & GQLMetaInfoFragment
-  )> };
+export type GQLWithArticleInfoFragment =
+  | GQLWithArticleInfo_Resource_Fragment
+  | GQLWithArticleInfo_Topic_Fragment;
 
-export type GQLWithArticleInfoFragment = GQLWithArticleInfo_Resource_Fragment | GQLWithArticleInfo_Topic_Fragment;
-
-export type GQLSubjectPageInfoFragment = { __typename?: 'SubjectPage', id: number, metaDescription?: Maybe<string>, topical?: Maybe<(
-    { __typename?: 'Resource' }
-    & GQLTaxonomyEntityInfo_Resource_Fragment
-  ) | (
-    { __typename?: 'Subject' }
-    & GQLTaxonomyEntityInfo_Subject_Fragment
-  ) | (
-    { __typename?: 'Topic' }
-    & GQLTaxonomyEntityInfo_Topic_Fragment
-  )>, banner?: Maybe<{ __typename?: 'SubjectPageBanner', desktopUrl?: Maybe<string> }>, about?: Maybe<{ __typename?: 'SubjectPageAbout', title?: Maybe<string>, description?: Maybe<string>, visualElement?: Maybe<{ __typename?: 'SubjectPageVisualElement', type?: Maybe<string>, url?: Maybe<string>, alt?: Maybe<string> }> }>, editorsChoices?: Maybe<Array<(
-    { __typename?: 'Resource' }
-    & GQLTaxonomyEntityInfo_Resource_Fragment
-  ) | (
-    { __typename?: 'Subject' }
-    & GQLTaxonomyEntityInfo_Subject_Fragment
-  ) | (
-    { __typename?: 'Topic' }
-    & GQLTaxonomyEntityInfo_Topic_Fragment
-  )>> };
+export type GQLSubjectPageInfoFragment = {
+  __typename?: 'SubjectPage';
+  id: number;
+  metaDescription?: Maybe<string>;
+  topical?: Maybe<
+    | ({ __typename?: 'Resource' } & GQLTaxonomyEntityInfo_Resource_Fragment)
+    | ({ __typename?: 'Subject' } & GQLTaxonomyEntityInfo_Subject_Fragment)
+    | ({ __typename?: 'Topic' } & GQLTaxonomyEntityInfo_Topic_Fragment)
+  >;
+  banner?: Maybe<{
+    __typename?: 'SubjectPageBanner';
+    desktopUrl?: Maybe<string>;
+  }>;
+  about?: Maybe<{
+    __typename?: 'SubjectPageAbout';
+    title?: Maybe<string>;
+    description?: Maybe<string>;
+    visualElement?: Maybe<{
+      __typename?: 'SubjectPageVisualElement';
+      type?: Maybe<string>;
+      url?: Maybe<string>;
+      alt?: Maybe<string>;
+    }>;
+  }>;
+  editorsChoices?: Maybe<
+    Array<
+      | ({ __typename?: 'Resource' } & GQLTaxonomyEntityInfo_Resource_Fragment)
+      | ({ __typename?: 'Subject' } & GQLTaxonomyEntityInfo_Subject_Fragment)
+      | ({ __typename?: 'Topic' } & GQLTaxonomyEntityInfo_Topic_Fragment)
+    >
+  >;
+};
 
 export type GQLSubjectPageWithTopicsQueryVariables = Exact<{
   subjectId: Scalars['String'];
@@ -1326,79 +1856,184 @@ export type GQLSubjectPageWithTopicsQueryVariables = Exact<{
   includeTopic: Scalars['Boolean'];
 }>;
 
-
-export type GQLSubjectPageWithTopicsQuery = { __typename?: 'Query', subject?: Maybe<(
-    { __typename?: 'Subject', grepCodes?: Maybe<Array<string>>, topics?: Maybe<Array<(
-      { __typename?: 'Topic', article?: Maybe<{ __typename?: 'Article', supportedLanguages?: Maybe<Array<string>> }> }
-      & GQLTopicInfoFragment
-    )>>, allTopics?: Maybe<Array<(
-      { __typename?: 'Topic' }
-      & GQLTopicInfoFragment
-    )>>, subjectpage?: Maybe<(
-      { __typename?: 'SubjectPage' }
-      & GQLSubjectPageInfoFragment
-    )> }
-    & GQLSubjectInfoFragment
-  )>, topic?: Maybe<(
-    { __typename?: 'Topic', alternateTopics?: Maybe<Array<{ __typename?: 'Topic', id: string, name: string, path?: Maybe<string>, breadcrumbs?: Maybe<Array<Array<string>>>, meta?: Maybe<(
-        { __typename?: 'Meta' }
-        & GQLMetaInfoFragment
-      )> }>> }
-    & GQLTopicInfoFragment
-  )>, subjects?: Maybe<Array<(
-    { __typename?: 'Subject', metadata?: Maybe<{ __typename?: 'TaxonomyMetadata', customFields?: Maybe<any> }> }
-    & GQLSubjectInfoFragment
-  )>> };
+export type GQLSubjectPageWithTopicsQuery = {
+  __typename?: 'Query';
+  subject?: Maybe<
+    {
+      __typename?: 'Subject';
+      grepCodes?: Maybe<Array<string>>;
+      topics?: Maybe<
+        Array<
+          {
+            __typename?: 'Topic';
+            article?: Maybe<{
+              __typename?: 'Article';
+              supportedLanguages?: Maybe<Array<string>>;
+            }>;
+          } & GQLTopicInfoFragment
+        >
+      >;
+      allTopics?: Maybe<Array<{ __typename?: 'Topic' } & GQLTopicInfoFragment>>;
+      subjectpage?: Maybe<
+        { __typename?: 'SubjectPage' } & GQLSubjectPageInfoFragment
+      >;
+    } & GQLSubjectInfoFragment
+  >;
+  topic?: Maybe<
+    {
+      __typename?: 'Topic';
+      alternateTopics?: Maybe<
+        Array<{
+          __typename?: 'Topic';
+          id: string;
+          name: string;
+          path?: Maybe<string>;
+          breadcrumbs?: Maybe<Array<Array<string>>>;
+          meta?: Maybe<{ __typename?: 'Meta' } & GQLMetaInfoFragment>;
+        }>
+      >;
+    } & GQLTopicInfoFragment
+  >;
+  subjects?: Maybe<
+    Array<
+      {
+        __typename?: 'Subject';
+        metadata?: Maybe<{
+          __typename?: 'TaxonomyMetadata';
+          customFields?: Maybe<any>;
+        }>;
+      } & GQLSubjectInfoFragment
+    >
+  >;
+};
 
 export type GQLSubjectPageQueryVariables = Exact<{
   subjectId: Scalars['String'];
 }>;
 
+export type GQLSubjectPageQuery = {
+  __typename?: 'Query';
+  subject?: Maybe<{
+    __typename?: 'Subject';
+    id: string;
+    name: string;
+    path?: Maybe<string>;
+    topics?: Maybe<Array<{ __typename?: 'Topic' } & GQLTopicInfoFragment>>;
+    allTopics?: Maybe<Array<{ __typename?: 'Topic' } & GQLTopicInfoFragment>>;
+    subjectpage?: Maybe<
+      { __typename?: 'SubjectPage' } & GQLSubjectPageInfoFragment
+    >;
+  }>;
+};
 
-export type GQLSubjectPageQuery = { __typename?: 'Query', subject?: Maybe<{ __typename?: 'Subject', id: string, name: string, path?: Maybe<string>, topics?: Maybe<Array<(
-      { __typename?: 'Topic' }
-      & GQLTopicInfoFragment
-    )>>, allTopics?: Maybe<Array<(
-      { __typename?: 'Topic' }
-      & GQLTopicInfoFragment
-    )>>, subjectpage?: Maybe<(
-      { __typename?: 'SubjectPage' }
-      & GQLSubjectPageInfoFragment
-    )> }> };
+export type GQLSubjectsQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GQLSubjectsQueryVariables = Exact<{ [key: string]: never; }>;
+export type GQLSubjectsQuery = {
+  __typename?: 'Query';
+  subjects?: Maybe<Array<{ __typename?: 'Subject' } & GQLSubjectInfoFragment>>;
+};
 
+export type GQLSearchPageQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GQLSubjectsQuery = { __typename?: 'Query', subjects?: Maybe<Array<(
-    { __typename?: 'Subject' }
-    & GQLSubjectInfoFragment
-  )>> };
+export type GQLSearchPageQuery = {
+  __typename?: 'Query';
+  subjects?: Maybe<Array<{ __typename?: 'Subject' } & GQLSubjectInfoFragment>>;
+  resourceTypes?: Maybe<
+    Array<{
+      __typename?: 'ResourceTypeDefinition';
+      id: string;
+      name: string;
+      subtypes?: Maybe<
+        Array<{
+          __typename?: 'ResourceTypeDefinition';
+          id: string;
+          name: string;
+        }>
+      >;
+    }>
+  >;
+};
 
-export type GQLSearchPageQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type GQLSearchPageQuery = { __typename?: 'Query', subjects?: Maybe<Array<(
-    { __typename?: 'Subject' }
-    & GQLSubjectInfoFragment
-  )>>, resourceTypes?: Maybe<Array<{ __typename?: 'ResourceTypeDefinition', id: string, name: string, subtypes?: Maybe<Array<{ __typename?: 'ResourceTypeDefinition', id: string, name: string }>> }>> };
-
-export type GQLLearningpathInfoFragment = { __typename?: 'Learningpath', id: number, title: string, description?: Maybe<string>, duration?: Maybe<number>, lastUpdated?: Maybe<string>, supportedLanguages?: Maybe<Array<string>>, tags?: Maybe<Array<string>>, copyright?: Maybe<{ __typename?: 'LearningpathCopyright', license?: Maybe<{ __typename?: 'License', license: string, url?: Maybe<string>, description?: Maybe<string> }>, contributors?: Maybe<Array<(
-      { __typename?: 'Contributor' }
-      & GQLContributorInfoFragment
-    )>> }>, coverphoto?: Maybe<{ __typename?: 'LearningpathCoverphoto', url?: Maybe<string>, metaUrl?: Maybe<string> }>, learningsteps?: Maybe<Array<{ __typename?: 'LearningpathStep', id: number, title: string, description?: Maybe<string>, seqNo: number, type?: Maybe<string>, showTitle?: Maybe<boolean>, oembed?: Maybe<{ __typename?: 'LearningpathStepOembed', type: string, version: string, height: number, html: string, width: number }>, embedUrl?: Maybe<{ __typename?: 'LearningpathStepEmbedUrl', url?: Maybe<string>, embedType?: Maybe<string> }>, resource?: Maybe<(
-      { __typename?: 'Resource', article?: Maybe<(
-        { __typename?: 'Article', oembed?: Maybe<string> }
-        & GQLArticleInfoFragment
-      )> }
-      & GQLResourceInfoFragment
-    )>, license?: Maybe<{ __typename?: 'License', license: string, url?: Maybe<string>, description?: Maybe<string> }> }>> };
+export type GQLLearningpathInfoFragment = {
+  __typename?: 'Learningpath';
+  id: number;
+  title: string;
+  description?: Maybe<string>;
+  duration?: Maybe<number>;
+  lastUpdated?: Maybe<string>;
+  supportedLanguages?: Maybe<Array<string>>;
+  tags?: Maybe<Array<string>>;
+  copyright?: Maybe<{
+    __typename?: 'LearningpathCopyright';
+    license?: Maybe<{
+      __typename?: 'License';
+      license: string;
+      url?: Maybe<string>;
+      description?: Maybe<string>;
+    }>;
+    contributors?: Maybe<
+      Array<{ __typename?: 'Contributor' } & GQLContributorInfoFragment>
+    >;
+  }>;
+  coverphoto?: Maybe<{
+    __typename?: 'LearningpathCoverphoto';
+    url?: Maybe<string>;
+    metaUrl?: Maybe<string>;
+  }>;
+  learningsteps?: Maybe<
+    Array<{
+      __typename?: 'LearningpathStep';
+      id: number;
+      title: string;
+      description?: Maybe<string>;
+      seqNo: number;
+      type?: Maybe<string>;
+      showTitle?: Maybe<boolean>;
+      oembed?: Maybe<{
+        __typename?: 'LearningpathStepOembed';
+        type: string;
+        version: string;
+        height: number;
+        html: string;
+        width: number;
+      }>;
+      embedUrl?: Maybe<{
+        __typename?: 'LearningpathStepEmbedUrl';
+        url?: Maybe<string>;
+        embedType?: Maybe<string>;
+      }>;
+      resource?: Maybe<
+        {
+          __typename?: 'Resource';
+          article?: Maybe<
+            {
+              __typename?: 'Article';
+              oembed?: Maybe<string>;
+            } & GQLArticleInfoFragment
+          >;
+        } & GQLResourceInfoFragment
+      >;
+      license?: Maybe<{
+        __typename?: 'License';
+        license: string;
+        url?: Maybe<string>;
+        description?: Maybe<string>;
+      }>;
+    }>
+  >;
+};
 
 export type GQLMovedResourceQueryVariables = Exact<{
   resourceId: Scalars['String'];
 }>;
 
-
-export type GQLMovedResourceQuery = { __typename?: 'Query', resource?: Maybe<{ __typename?: 'Resource', breadcrumbs?: Maybe<Array<Array<string>>> }> };
+export type GQLMovedResourceQuery = {
+  __typename?: 'Query';
+  resource?: Maybe<{
+    __typename?: 'Resource';
+    breadcrumbs?: Maybe<Array<Array<string>>>;
+  }>;
+};
 
 export type GQLPlainArticleQueryVariables = Exact<{
   articleId: Scalars['String'];
@@ -1406,11 +2041,10 @@ export type GQLPlainArticleQueryVariables = Exact<{
   path?: Maybe<Scalars['String']>;
 }>;
 
-
-export type GQLPlainArticleQuery = { __typename?: 'Query', article?: Maybe<(
-    { __typename?: 'Article' }
-    & GQLArticleInfoFragment
-  )> };
+export type GQLPlainArticleQuery = {
+  __typename?: 'Query';
+  article?: Maybe<{ __typename?: 'Article' } & GQLArticleInfoFragment>;
+};
 
 export type GQLIframeArticleQueryVariables = Exact<{
   articleId: Scalars['String'];
@@ -1421,11 +2055,25 @@ export type GQLIframeArticleQueryVariables = Exact<{
   includeTopic: Scalars['Boolean'];
 }>;
 
-
-export type GQLIframeArticleQuery = { __typename?: 'Query', article?: Maybe<(
-    { __typename?: 'Article' }
-    & GQLArticleInfoFragment
-  )>, resource?: Maybe<{ __typename?: 'Resource', id: string, name: string, path?: Maybe<string>, resourceTypes?: Maybe<Array<{ __typename?: 'ResourceType', id: string, name: string }>> }>, topic?: Maybe<{ __typename?: 'Topic', id: string, name: string, path?: Maybe<string> }> };
+export type GQLIframeArticleQuery = {
+  __typename?: 'Query';
+  article?: Maybe<{ __typename?: 'Article' } & GQLArticleInfoFragment>;
+  resource?: Maybe<{
+    __typename?: 'Resource';
+    id: string;
+    name: string;
+    path?: Maybe<string>;
+    resourceTypes?: Maybe<
+      Array<{ __typename?: 'ResourceType'; id: string; name: string }>
+    >;
+  }>;
+  topic?: Maybe<{
+    __typename?: 'Topic';
+    id: string;
+    name: string;
+    path?: Maybe<string>;
+  }>;
+};
 
 export type GQLTopicWithPathTopicsQueryVariables = Exact<{
   topicId: Scalars['String'];
@@ -1433,56 +2081,116 @@ export type GQLTopicWithPathTopicsQueryVariables = Exact<{
   showVisualElement?: Maybe<Scalars['String']>;
 }>;
 
-
-export type GQLTopicWithPathTopicsQuery = { __typename?: 'Query', subject?: Maybe<{ __typename?: 'Subject', id: string, name: string, path?: Maybe<string>, topics?: Maybe<Array<(
-      { __typename?: 'Topic' }
-      & GQLTopicInfoFragment
-    )>>, allTopics?: Maybe<Array<(
-      { __typename?: 'Topic' }
-      & GQLTopicInfoFragment
-    )>> }>, topic?: Maybe<{ __typename?: 'Topic', id: string, name: string, path?: Maybe<string>, relevanceId?: Maybe<string>, pathTopics?: Maybe<Array<Array<{ __typename?: 'Topic', id: string, name: string, path?: Maybe<string> }>>>, meta?: Maybe<(
-      { __typename?: 'Meta' }
-      & GQLMetaInfoFragment
-    )>, subtopics?: Maybe<Array<{ __typename?: 'Topic', id: string, name: string, relevanceId?: Maybe<string> }>>, article?: Maybe<(
-      { __typename?: 'Article', crossSubjectTopics?: Maybe<Array<{ __typename?: 'CrossSubjectElement', code?: Maybe<string>, title: string, path?: Maybe<string> }>> }
-      & GQLArticleInfoFragment
-    )>, coreResources?: Maybe<Array<(
-      { __typename?: 'Resource' }
-      & GQLResourceInfoFragment
-    )>>, supplementaryResources?: Maybe<Array<(
-      { __typename?: 'Resource' }
-      & GQLResourceInfoFragment
-    )>> }>, resourceTypes?: Maybe<Array<{ __typename?: 'ResourceTypeDefinition', id: string, name: string }>> };
+export type GQLTopicWithPathTopicsQuery = {
+  __typename?: 'Query';
+  subject?: Maybe<{
+    __typename?: 'Subject';
+    id: string;
+    name: string;
+    path?: Maybe<string>;
+    topics?: Maybe<Array<{ __typename?: 'Topic' } & GQLTopicInfoFragment>>;
+    allTopics?: Maybe<Array<{ __typename?: 'Topic' } & GQLTopicInfoFragment>>;
+  }>;
+  topic?: Maybe<{
+    __typename?: 'Topic';
+    id: string;
+    name: string;
+    path?: Maybe<string>;
+    relevanceId?: Maybe<string>;
+    pathTopics?: Maybe<
+      Array<
+        Array<{
+          __typename?: 'Topic';
+          id: string;
+          name: string;
+          path?: Maybe<string>;
+        }>
+      >
+    >;
+    meta?: Maybe<{ __typename?: 'Meta' } & GQLMetaInfoFragment>;
+    subtopics?: Maybe<
+      Array<{
+        __typename?: 'Topic';
+        id: string;
+        name: string;
+        relevanceId?: Maybe<string>;
+      }>
+    >;
+    article?: Maybe<
+      {
+        __typename?: 'Article';
+        crossSubjectTopics?: Maybe<
+          Array<{
+            __typename?: 'CrossSubjectElement';
+            code?: Maybe<string>;
+            title: string;
+            path?: Maybe<string>;
+          }>
+        >;
+      } & GQLArticleInfoFragment
+    >;
+    coreResources?: Maybe<
+      Array<{ __typename?: 'Resource' } & GQLResourceInfoFragment>
+    >;
+    supplementaryResources?: Maybe<
+      Array<{ __typename?: 'Resource' } & GQLResourceInfoFragment>
+    >;
+  }>;
+  resourceTypes?: Maybe<
+    Array<{ __typename?: 'ResourceTypeDefinition'; id: string; name: string }>
+  >;
+};
 
 export type GQLTopicQueryVariables = Exact<{
   topicId: Scalars['String'];
   subjectId?: Maybe<Scalars['String']>;
 }>;
 
-
-export type GQLTopicQuery = { __typename?: 'Query', topic?: Maybe<{ __typename?: 'Topic', id: string, name: string, path?: Maybe<string>, parent?: Maybe<string>, relevanceId?: Maybe<string>, meta?: Maybe<(
-      { __typename?: 'Meta' }
-      & GQLMetaInfoFragment
-    )>, subtopics?: Maybe<Array<{ __typename?: 'Topic', id: string, name: string, relevanceId?: Maybe<string> }>>, article?: Maybe<(
-      { __typename?: 'Article' }
-      & GQLArticleInfoFragment
-    )>, coreResources?: Maybe<Array<(
-      { __typename?: 'Resource' }
-      & GQLResourceInfoFragment
-    )>>, supplementaryResources?: Maybe<Array<(
-      { __typename?: 'Resource' }
-      & GQLResourceInfoFragment
-    )>>, metadata?: Maybe<{ __typename?: 'TaxonomyMetadata', customFields?: Maybe<any> }> }>, resourceTypes?: Maybe<Array<{ __typename?: 'ResourceTypeDefinition', id: string, name: string }>> };
+export type GQLTopicQuery = {
+  __typename?: 'Query';
+  topic?: Maybe<{
+    __typename?: 'Topic';
+    id: string;
+    name: string;
+    path?: Maybe<string>;
+    parent?: Maybe<string>;
+    relevanceId?: Maybe<string>;
+    meta?: Maybe<{ __typename?: 'Meta' } & GQLMetaInfoFragment>;
+    subtopics?: Maybe<
+      Array<{
+        __typename?: 'Topic';
+        id: string;
+        name: string;
+        relevanceId?: Maybe<string>;
+      }>
+    >;
+    article?: Maybe<{ __typename?: 'Article' } & GQLArticleInfoFragment>;
+    coreResources?: Maybe<
+      Array<{ __typename?: 'Resource' } & GQLResourceInfoFragment>
+    >;
+    supplementaryResources?: Maybe<
+      Array<{ __typename?: 'Resource' } & GQLResourceInfoFragment>
+    >;
+    metadata?: Maybe<{
+      __typename?: 'TaxonomyMetadata';
+      customFields?: Maybe<any>;
+    }>;
+  }>;
+  resourceTypes?: Maybe<
+    Array<{ __typename?: 'ResourceTypeDefinition'; id: string; name: string }>
+  >;
+};
 
 export type GQLLearningPathStepQueryVariables = Exact<{
   pathId: Scalars['String'];
 }>;
 
-
-export type GQLLearningPathStepQuery = { __typename?: 'Query', learningpath?: Maybe<(
-    { __typename?: 'Learningpath' }
-    & GQLLearningpathInfoFragment
-  )> };
+export type GQLLearningPathStepQuery = {
+  __typename?: 'Query';
+  learningpath?: Maybe<
+    { __typename?: 'Learningpath' } & GQLLearningpathInfoFragment
+  >;
+};
 
 export type GQLCompetenceGoalsQueryVariables = Exact<{
   codes?: Maybe<Array<Scalars['String']> | Scalars['String']>;
@@ -1490,21 +2198,94 @@ export type GQLCompetenceGoalsQueryVariables = Exact<{
   language?: Maybe<Scalars['String']>;
 }>;
 
+export type GQLCompetenceGoalsQuery = {
+  __typename?: 'Query';
+  competenceGoals?: Maybe<
+    Array<{
+      __typename?: 'CompetenceGoal';
+      id: string;
+      type: string;
+      name: string;
+      curriculum?: Maybe<{
+        __typename?: 'Reference';
+        id: string;
+        title: string;
+      }>;
+      competenceGoalSet?: Maybe<{
+        __typename?: 'Reference';
+        id: string;
+        title: string;
+      }>;
+    }>
+  >;
+  coreElements?: Maybe<
+    Array<{
+      __typename?: 'CoreElement';
+      id: string;
+      name: string;
+      text?: Maybe<string>;
+      curriculum?: Maybe<{
+        __typename?: 'Reference';
+        id: string;
+        title: string;
+      }>;
+    }>
+  >;
+};
 
-export type GQLCompetenceGoalsQuery = { __typename?: 'Query', competenceGoals?: Maybe<Array<{ __typename?: 'CompetenceGoal', id: string, type: string, name: string, curriculum?: Maybe<{ __typename?: 'Reference', id: string, title: string }>, competenceGoalSet?: Maybe<{ __typename?: 'Reference', id: string, title: string }> }>>, coreElements?: Maybe<Array<{ __typename?: 'CoreElement', id: string, name: string, text?: Maybe<string>, curriculum?: Maybe<{ __typename?: 'Reference', id: string, title: string }> }>> };
+export type GQLMovieInfoFragment = {
+  __typename?: 'Movie';
+  id: string;
+  title?: Maybe<string>;
+  metaDescription?: Maybe<string>;
+  path?: Maybe<string>;
+  metaImage?: Maybe<{
+    __typename?: 'MetaImage';
+    alt?: Maybe<string>;
+    url?: Maybe<string>;
+  }>;
+  resourceTypes?: Maybe<
+    Array<{ __typename?: 'ResourceType'; id: string; name: string }>
+  >;
+};
 
-export type GQLMovieInfoFragment = { __typename?: 'Movie', id: string, title?: Maybe<string>, metaDescription?: Maybe<string>, path?: Maybe<string>, metaImage?: Maybe<{ __typename?: 'MetaImage', alt?: Maybe<string>, url?: Maybe<string> }>, resourceTypes?: Maybe<Array<{ __typename?: 'ResourceType', id: string, name: string }>> };
+export type GQLFilmFrontPageQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GQLFilmFrontPageQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type GQLFilmFrontPageQuery = { __typename?: 'Query', filmfrontpage?: Maybe<{ __typename?: 'FilmFrontpage', name?: Maybe<string>, about?: Maybe<Array<{ __typename?: 'FilmPageAbout', title?: Maybe<string>, description?: Maybe<string>, language?: Maybe<string>, visualElement?: Maybe<{ __typename?: 'SubjectPageVisualElement', type?: Maybe<string>, alt?: Maybe<string>, url?: Maybe<string> }> }>>, movieThemes?: Maybe<Array<{ __typename?: 'MovieTheme', name?: Maybe<Array<{ __typename?: 'Name', name?: Maybe<string>, language?: Maybe<string> }>>, movies?: Maybe<Array<(
-        { __typename?: 'Movie' }
-        & GQLMovieInfoFragment
-      )>> }>>, slideShow?: Maybe<Array<(
-      { __typename?: 'Movie' }
-      & GQLMovieInfoFragment
-    )>> }> };
+export type GQLFilmFrontPageQuery = {
+  __typename?: 'Query';
+  filmfrontpage?: Maybe<{
+    __typename?: 'FilmFrontpage';
+    name?: Maybe<string>;
+    about?: Maybe<
+      Array<{
+        __typename?: 'FilmPageAbout';
+        title?: Maybe<string>;
+        description?: Maybe<string>;
+        language?: Maybe<string>;
+        visualElement?: Maybe<{
+          __typename?: 'SubjectPageVisualElement';
+          type?: Maybe<string>;
+          alt?: Maybe<string>;
+          url?: Maybe<string>;
+        }>;
+      }>
+    >;
+    movieThemes?: Maybe<
+      Array<{
+        __typename?: 'MovieTheme';
+        name?: Maybe<
+          Array<{
+            __typename?: 'Name';
+            name?: Maybe<string>;
+            language?: Maybe<string>;
+          }>
+        >;
+        movies?: Maybe<Array<{ __typename?: 'Movie' } & GQLMovieInfoFragment>>;
+      }>
+    >;
+    slideShow?: Maybe<Array<{ __typename?: 'Movie' } & GQLMovieInfoFragment>>;
+  }>;
+};
 
 export type GQLMastHeadQueryVariables = Exact<{
   subjectId: Scalars['String'];
@@ -1514,26 +2295,42 @@ export type GQLMastHeadQueryVariables = Exact<{
   skipResource: Scalars['Boolean'];
 }>;
 
-
-export type GQLMastHeadQuery = { __typename?: 'Query', subject?: Maybe<{ __typename?: 'Subject', id: string, name: string, path?: Maybe<string>, topics?: Maybe<Array<(
-      { __typename?: 'Topic' }
-      & GQLTopicInfoFragment
-    )>> }>, resourceTypes?: Maybe<Array<{ __typename?: 'ResourceTypeDefinition', id: string, name: string }>>, topic?: Maybe<{ __typename?: 'Topic', id: string, metadata?: Maybe<{ __typename?: 'TaxonomyMetadata', customFields?: Maybe<any> }>, coreResources?: Maybe<Array<(
-      { __typename?: 'Resource' }
-      & GQLResourceInfoFragment
-    )>>, supplementaryResources?: Maybe<Array<(
-      { __typename?: 'Resource' }
-      & GQLResourceInfoFragment
-    )>> }>, resource?: Maybe<(
-    { __typename?: 'Resource', article?: Maybe<(
-      { __typename?: 'Article' }
-      & GQLArticleInfoFragment
-    )>, learningpath?: Maybe<(
-      { __typename?: 'Learningpath' }
-      & GQLLearningpathInfoFragment
-    )> }
-    & GQLResourceInfoFragment
-  )> };
+export type GQLMastHeadQuery = {
+  __typename?: 'Query';
+  subject?: Maybe<{
+    __typename?: 'Subject';
+    id: string;
+    name: string;
+    path?: Maybe<string>;
+    topics?: Maybe<Array<{ __typename?: 'Topic' } & GQLTopicInfoFragment>>;
+  }>;
+  resourceTypes?: Maybe<
+    Array<{ __typename?: 'ResourceTypeDefinition'; id: string; name: string }>
+  >;
+  topic?: Maybe<{
+    __typename?: 'Topic';
+    id: string;
+    metadata?: Maybe<{
+      __typename?: 'TaxonomyMetadata';
+      customFields?: Maybe<any>;
+    }>;
+    coreResources?: Maybe<
+      Array<{ __typename?: 'Resource' } & GQLResourceInfoFragment>
+    >;
+    supplementaryResources?: Maybe<
+      Array<{ __typename?: 'Resource' } & GQLResourceInfoFragment>
+    >;
+  }>;
+  resource?: Maybe<
+    {
+      __typename?: 'Resource';
+      article?: Maybe<{ __typename?: 'Article' } & GQLArticleInfoFragment>;
+      learningpath?: Maybe<
+        { __typename?: 'Learningpath' } & GQLLearningpathInfoFragment
+      >;
+    } & GQLResourceInfoFragment
+  >;
+};
 
 export type GQLResourcePageQueryVariables = Exact<{
   topicId: Scalars['String'];
@@ -1541,23 +2338,63 @@ export type GQLResourcePageQueryVariables = Exact<{
   resourceId: Scalars['String'];
 }>;
 
-
-export type GQLResourcePageQuery = { __typename?: 'Query', subject?: Maybe<{ __typename?: 'Subject', id: string, name: string, path?: Maybe<string>, topics?: Maybe<Array<{ __typename?: 'Topic', id: string, name: string, parent?: Maybe<string>, path?: Maybe<string>, relevanceId?: Maybe<string>, meta?: Maybe<(
-        { __typename?: 'Meta' }
-        & GQLMetaInfoFragment
-      )> }>> }>, resourceTypes?: Maybe<Array<{ __typename?: 'ResourceTypeDefinition', id: string, name: string, subtypes?: Maybe<Array<{ __typename?: 'ResourceTypeDefinition', id: string, name: string }>> }>>, topic?: Maybe<{ __typename?: 'Topic', id: string, name: string, path?: Maybe<string>, relevanceId?: Maybe<string>, coreResources?: Maybe<Array<(
-      { __typename?: 'Resource' }
-      & GQLResourceInfoFragment
-    )>>, supplementaryResources?: Maybe<Array<(
-      { __typename?: 'Resource' }
-      & GQLResourceInfoFragment
-    )>>, metadata?: Maybe<{ __typename?: 'TaxonomyMetadata', customFields?: Maybe<any> }> }>, resource?: Maybe<(
-    { __typename?: 'Resource', article?: Maybe<(
-      { __typename?: 'Article' }
-      & GQLArticleInfoFragment
-    )>, learningpath?: Maybe<(
-      { __typename?: 'Learningpath' }
-      & GQLLearningpathInfoFragment
-    )> }
-    & GQLResourceInfoFragment
-  )> };
+export type GQLResourcePageQuery = {
+  __typename?: 'Query';
+  subject?: Maybe<{
+    __typename?: 'Subject';
+    id: string;
+    name: string;
+    path?: Maybe<string>;
+    topics?: Maybe<
+      Array<{
+        __typename?: 'Topic';
+        id: string;
+        name: string;
+        parent?: Maybe<string>;
+        path?: Maybe<string>;
+        relevanceId?: Maybe<string>;
+        meta?: Maybe<{ __typename?: 'Meta' } & GQLMetaInfoFragment>;
+      }>
+    >;
+  }>;
+  resourceTypes?: Maybe<
+    Array<{
+      __typename?: 'ResourceTypeDefinition';
+      id: string;
+      name: string;
+      subtypes?: Maybe<
+        Array<{
+          __typename?: 'ResourceTypeDefinition';
+          id: string;
+          name: string;
+        }>
+      >;
+    }>
+  >;
+  topic?: Maybe<{
+    __typename?: 'Topic';
+    id: string;
+    name: string;
+    path?: Maybe<string>;
+    relevanceId?: Maybe<string>;
+    coreResources?: Maybe<
+      Array<{ __typename?: 'Resource' } & GQLResourceInfoFragment>
+    >;
+    supplementaryResources?: Maybe<
+      Array<{ __typename?: 'Resource' } & GQLResourceInfoFragment>
+    >;
+    metadata?: Maybe<{
+      __typename?: 'TaxonomyMetadata';
+      customFields?: Maybe<any>;
+    }>;
+  }>;
+  resource?: Maybe<
+    {
+      __typename?: 'Resource';
+      article?: Maybe<{ __typename?: 'Article' } & GQLArticleInfoFragment>;
+      learningpath?: Maybe<
+        { __typename?: 'Learningpath' } & GQLLearningpathInfoFragment
+      >;
+    } & GQLResourceInfoFragment
+  >;
+};

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -97,6 +97,56 @@ export const searchQuery = gql`
 `;
 
 export const searchFilmQuery = gql`
+  fragment SearchFilmArticleSearchResult on ArticleSearchResult {
+    id
+    url
+    metaDescription
+    metaImage {
+      url
+      alt
+    }
+    title
+    contexts {
+      breadcrumbs
+      relevance
+      language
+      learningResourceType
+      path
+      resourceTypes {
+        id
+        name
+        language
+      }
+      subject
+    }
+    supportedLanguages
+    traits
+  }
+  fragment SearchFilmLearningpathSearchResult on LearningpathSearchResult {
+    id
+    url
+    metaDescription
+    metaImage {
+      url
+      alt
+    }
+    title
+    contexts {
+      breadcrumbs
+      relevance
+      language
+      learningResourceType
+      path
+      resourceTypes {
+        id
+        name
+        language
+      }
+      subject
+    }
+    supportedLanguages
+    traits
+  }
   query SearchWithoutPagination(
     $query: String
     $contextTypes: String
@@ -123,35 +173,14 @@ export const searchFilmQuery = gql`
       languageFilter: $languageFilter
       relevance: $relevance
     ) {
-      language
-      page
-      pageSize
       results {
-        id
-        url
-        metaDescription
-        metaImage {
-          url
-          alt
+        ... on ArticleSearchResult {
+          ...SearchFilmArticleSearchResult
         }
-        title
-        contexts {
-          breadcrumbs
-          relevance
-          language
-          learningResourceType
-          path
-          resourceTypes {
-            id
-            name
-            language
-          }
-          subject
+        ... on LearningpathSearchResult {
+          ...SearchFilmLearningpathSearchResult
         }
-        supportedLanguages
-        traits
       }
-      totalCount
     }
   }
 `;
@@ -241,14 +270,14 @@ export const conceptSearchQuery = gql`
   query ConceptSearch(
     $query: String
     $subjects: String
-    $exactMatch: Boolean
+    $exactTitleMatch: Boolean
     $language: String
     $fallback: Boolean
   ) {
     conceptSearch(
       query: $query
       subjects: $subjects
-      exactMatch: $exactMatch
+      exactTitleMatch: $exactTitleMatch
       language: $language
       fallback: $fallback
     ) {

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -270,14 +270,14 @@ export const conceptSearchQuery = gql`
   query ConceptSearch(
     $query: String
     $subjects: String
-    $exactTitleMatch: Boolean
+    $exactMatch: Boolean
     $language: String
     $fallback: Boolean
   ) {
     conceptSearch(
       query: $query
       subjects: $subjects
-      exactTitleMatch: $exactTitleMatch
+      exactMatch: $exactMatch
       language: $language
       fallback: $fallback
     ) {


### PR DESCRIPTION
Denne PR-en er ikke lenger relatert til NDLANO/Issues#2978.

Henter nå kun nye versjon av GQL-skjemaer fra graphql-api og retter opp i typefeil som oppsto. Som diskutert brukes fragments nå for ikke-fullstendige spørringer på objekter. Dette gjør at vi får generert matchende TS-typer.