### PR TITLE
Update schema and fix resulting typescript errors

### DIFF
--- a/src/components/license/licenseHelpers.ts
+++ b/src/components/license/licenseHelpers.ts
@@ -6,10 +6,10 @@
  *
  */
 
-import { GQLCopyright } from '../../graphqlTypes';
+import { GQLConceptCopyright, GQLCopyright } from '../../graphqlTypes';
 
 export const licenseCopyrightToCopyrightType = (
-  copyright: GQLCopyright | undefined,
+  copyright: GQLCopyright | GQLConceptCopyright | undefined,
 ) => {
   const processors = copyright?.processors ?? [];
   const rightsholders = copyright?.rightsholders ?? [];

--- a/src/containers/FilmFrontpage/FilmFrontpage.tsx
+++ b/src/containers/FilmFrontpage/FilmFrontpage.tsx
@@ -27,7 +27,7 @@ import { htmlTitle } from '../../util/titleHelper';
 import {
   GQLFilmFrontpage,
   GQLFilmPageAbout,
-  GQLSubject,
+  GQLSubjectPageQuery,
 } from '../../graphqlTypes';
 import MoreAboutNdlaFilm from './MoreAboutNdlaFilm';
 import { MoviesByType } from './NdlaFilmFrontpage';
@@ -45,19 +45,23 @@ const sortAlphabetically = (movies: MoviesByType[], locale: string) =>
     } else return a.title!.localeCompare(b.title!, locale);
   });
 
+type FilmFrontpageSubject = GQLSubjectPageQuery['subject'];
+
 interface Props extends WithTranslation {
   filmFrontpage?: GQLFilmFrontpage;
   showingAll?: boolean;
   fetchingMoviesByType?: boolean;
   moviesByType?: MoviesByType[];
-  subject?: GQLSubject;
+  subject?: FilmFrontpageSubject;
   resourceTypes: { id: string; name: string }[];
   onSelectedMovieByType: (resourceId: string) => void;
   aboutNDLAVideo?: GQLFilmPageAbout;
   skipToContentId?: string;
 }
-const getDocumentTitle = (t: TFunction, subject: GQLSubject | undefined) =>
-  htmlTitle(subject?.name, [t('htmlTitles.titleTemplate')]);
+const getDocumentTitle = (
+  t: TFunction,
+  subject: FilmFrontpageSubject | undefined,
+) => htmlTitle(subject?.name, [t('htmlTitles.titleTemplate')]);
 
 const FilmFrontpage = ({
   filmFrontpage,

--- a/src/containers/MultidisciplinarySubject/components/MultidisciplinaryTopic.tsx
+++ b/src/containers/MultidisciplinarySubject/components/MultidisciplinaryTopic.tsx
@@ -25,11 +25,11 @@ import VisualElementWrapper, {
 import {
   GQLArticle,
   GQLResourceTypeDefinition,
-  GQLSubject,
   GQLTopic,
 } from '../../../graphqlTypes';
 import { LocaleType } from '../../../interfaces';
 import { FeideUserWithGroups } from '../../../util/feideApi';
+import { MultiDisciplinarySubjectType } from './MultidisciplinaryTopicWrapper';
 
 interface Props extends WithTranslation {
   topicId: string;
@@ -37,7 +37,7 @@ interface Props extends WithTranslation {
   subTopicId?: string;
   locale: LocaleType;
   ndlaFilm?: boolean;
-  subject: GQLSubject;
+  subject: MultiDisciplinarySubjectType;
   topic: GQLTopic;
   resourceTypes?: GQLResourceTypeDefinition[];
   loading?: boolean;

--- a/src/containers/MultidisciplinarySubject/components/MultidisciplinaryTopicWrapper.tsx
+++ b/src/containers/MultidisciplinarySubject/components/MultidisciplinaryTopicWrapper.tsx
@@ -5,7 +5,7 @@ import { topicQuery } from '../../../queries';
 import { useGraphQuery } from '../../../util/runQueries';
 import MultidisciplinaryTopic from './MultidisciplinaryTopic';
 import {
-  GQLSubject,
+  GQLSubjectPageQuery,
   GQLTopicQuery,
   GQLTopicQueryVariables,
 } from '../../../graphqlTypes';
@@ -13,12 +13,15 @@ import DefaultErrorMessage from '../../../components/DefaultErrorMessage';
 import { LocaleType } from '../../../interfaces';
 import { FeideUserWithGroups } from '../../../util/feideApi';
 
+export type MultiDisciplinarySubjectType = Required<
+  GQLSubjectPageQuery
+>['subject'];
 interface Props {
   topicId: string;
   subjectId: string;
   subTopicId?: string;
   locale: LocaleType;
-  subject: GQLSubject;
+  subject: MultiDisciplinarySubjectType;
   ndlaFilm?: boolean;
   disableNav?: boolean;
   user?: FeideUserWithGroups;

--- a/src/containers/SubjectPage/SubjectContainer.tsx
+++ b/src/containers/SubjectPage/SubjectContainer.tsx
@@ -36,15 +36,18 @@ import { parseAndMatchUrl } from '../../util/urlHelper';
 import { getAllDimensions } from '../../util/trackingUtil';
 import { htmlTitle } from '../../util/titleHelper';
 import { BreadcrumbItem, LocaleType } from '../../interfaces';
-import { GQLSubject } from '../../graphqlTypes';
+import { GQLSubjectPageWithTopicsQuery } from '../../graphqlTypes';
 import { FeideUserWithGroups } from '../../util/feideApi';
 
+export type GQLSubjectContainerType = Required<
+  GQLSubjectPageWithTopicsQuery
+>['subject'];
 type Props = {
   locale: LocaleType;
   skipToContentId?: string;
   subjectId: string;
   topicIds: string[];
-  subject: GQLSubject;
+  subject: GQLSubjectContainerType;
   ndlaFilm?: boolean;
   loading?: boolean;
   user?: FeideUserWithGroups;
@@ -125,7 +128,7 @@ const SubjectContainer = ({
   };
 
   function renderCompetenceGoals(
-    subject: GQLSubject,
+    subject: GQLSubjectContainerType,
     locale: LocaleType,
   ):
     | ((inp: {

--- a/src/containers/SubjectPage/components/SubjectPageContent.tsx
+++ b/src/containers/SubjectPage/components/SubjectPageContent.tsx
@@ -12,11 +12,11 @@ import { RELEVANCE_SUPPLEMENTARY } from '../../../constants';
 import { scrollToRef } from '../subjectPageHelpers';
 import { toTopic } from '../../../routeHelpers';
 import TopicWrapper from './TopicWrapper';
-import { GQLSubject } from '../../../graphqlTypes';
 import { BreadcrumbItem, LocaleType } from '../../../interfaces';
+import { GQLSubjectContainerType } from '../SubjectContainer';
 
 interface Props {
-  subject: GQLSubject;
+  subject: GQLSubjectContainerType;
   locale: LocaleType;
   ndlaFilm?: boolean;
   onClickTopics: (e: React.MouseEvent<HTMLAnchorElement>) => void;

--- a/src/containers/SubjectPage/components/SubjectPageInformation.tsx
+++ b/src/containers/SubjectPage/components/SubjectPageInformation.tsx
@@ -9,10 +9,10 @@
 import React from 'react';
 import SubjectTopical from './SubjectTopical';
 import SubjectPageAbout from './SubjectPageAbout';
-import { GQLSubjectPage } from '../../../graphqlTypes';
+import { GQLSubjectContainerType } from '../SubjectContainer';
 
 interface Props {
-  subjectpage?: GQLSubjectPage;
+  subjectpage?: GQLSubjectContainerType['subjectpage'];
   twoColumns?: boolean;
   wide: boolean;
 }

--- a/src/containers/SubjectPage/components/Topic.tsx
+++ b/src/containers/SubjectPage/components/Topic.tsx
@@ -24,16 +24,13 @@ import {
   getImageWithoutCrop,
 } from '../../../util/imageHelpers';
 import { getSubjectLongName } from '../../../data/subjects';
-import {
-  GQLResourceTypeDefinition,
-  GQLSubject,
-  GQLTopic,
-} from '../../../graphqlTypes';
+import { GQLResourceTypeDefinition, GQLTopic } from '../../../graphqlTypes';
 import { LocaleType } from '../../../interfaces';
 import VisualElementWrapper, {
   getResourceType,
 } from '../../../components/VisualElement/VisualElementWrapper';
 import { FeideUserWithGroups } from '../../../util/feideApi';
+import { GQLSubjectContainerType } from '../SubjectContainer';
 
 const getDocumentTitle = ({
   t,
@@ -54,7 +51,7 @@ type Props = {
   onClickTopics: (e: React.MouseEvent<HTMLAnchorElement>) => void;
   index?: number;
   showResources?: boolean;
-  subject?: GQLSubject;
+  subject?: GQLSubjectContainerType;
   loading?: boolean;
   topic: GQLTopic;
   resourceTypes?: Array<GQLResourceTypeDefinition>;

--- a/src/containers/SubjectPage/components/TopicWrapper.tsx
+++ b/src/containers/SubjectPage/components/TopicWrapper.tsx
@@ -8,11 +8,8 @@ import { topicQuery } from '../../../queries';
 import { useGraphQuery } from '../../../util/runQueries';
 import handleError, { isAccessDeniedError } from '../../../util/handleError';
 import { BreadcrumbItem, LocaleType } from '../../../interfaces';
-import {
-  GQLSubject,
-  GQLTopicQuery,
-  GQLTopicQueryVariables,
-} from '../../../graphqlTypes';
+import { GQLTopicQuery, GQLTopicQueryVariables } from '../../../graphqlTypes';
+import { GQLSubjectContainerType } from '../SubjectContainer';
 
 type Props = {
   topicId: string;
@@ -24,7 +21,7 @@ type Props = {
   setBreadCrumb: (item: BreadcrumbItem) => void;
   index: number;
   showResources: boolean;
-  subject: GQLSubject;
+  subject: GQLSubjectContainerType;
 } & WithTranslation;
 
 const TopicWrapper = ({

--- a/src/containers/ToolboxSubject/ToolboxSubjectContainer.tsx
+++ b/src/containers/ToolboxSubject/ToolboxSubjectContainer.tsx
@@ -17,7 +17,7 @@ import {
 } from 'react-i18next';
 import { RouteComponentProps, withRouter } from 'react-router';
 import { getSubjectLongName } from '../../data/subjects';
-import { GQLSubject, GQLTopic } from '../../graphqlTypes';
+import { GQLSubjectPageQuery, GQLTopic } from '../../graphqlTypes';
 import { LocaleType } from '../../interfaces';
 import { toTopic } from '../../routeHelpers';
 import { htmlTitle } from '../../util/titleHelper';
@@ -27,8 +27,10 @@ import { ToolboxTopicContainer } from './components/ToolboxTopicContainer';
 import SocialMediaMetadata from '../../components/SocialMediaMetadata';
 import { FeideUserWithGroups } from '../../util/feideApi';
 
+export type ToolboxSubjectType = Required<GQLSubjectPageQuery>['subject'];
+
 interface Props extends WithTranslation, RouteComponentProps {
-  subject: GQLSubject;
+  subject: ToolboxSubjectType;
   topicList: string[];
   locale: LocaleType;
   user?: FeideUserWithGroups;
@@ -71,7 +73,7 @@ const getDocumentTitle = (props: Props) => {
 
 const getInitialSelectedTopics = (
   topicList: string[],
-  subject: GQLSubject,
+  subject: ToolboxSubjectType,
 ): string[] => {
   let initialSelectedTopics: string[] = [];
   topicList.forEach(topicId => {

--- a/src/containers/ToolboxSubject/components/ToolboxTopicContainer.tsx
+++ b/src/containers/ToolboxSubject/components/ToolboxTopicContainer.tsx
@@ -11,18 +11,15 @@ import React, { useContext } from 'react';
 import { Spinner } from '@ndla/ui';
 import DefaultErrorMessage from '../../../components/DefaultErrorMessage';
 import { AuthContext } from '../../../components/AuthenticationContext';
-import {
-  GQLSubject,
-  GQLTopicQuery,
-  GQLTopicQueryVariables,
-} from '../../../graphqlTypes';
+import { GQLTopicQuery, GQLTopicQueryVariables } from '../../../graphqlTypes';
 import { LocaleType } from '../../../interfaces';
 import { topicQuery } from '../../../queries';
 import { useGraphQuery } from '../../../util/runQueries';
 import ToolboxTopicWrapper from './ToolboxTopicWrapper';
+import { ToolboxSubjectType } from '../ToolboxSubjectContainer';
 
 interface Props {
-  subject: GQLSubject;
+  subject: ToolboxSubjectType;
   topicId: string;
   locale: LocaleType;
   onSelectTopic: (

--- a/src/containers/ToolboxSubject/components/ToolboxTopicWrapper.tsx
+++ b/src/containers/ToolboxSubject/components/ToolboxTopicWrapper.tsx
@@ -18,18 +18,15 @@ import { toTopic } from '../../../routeHelpers';
 import { getCrop, getFocalPoint } from '../../../util/imageHelpers';
 import Resources from '../../Resources/Resources';
 import { LocaleType } from '../../../interfaces';
-import {
-  GQLSubject,
-  GQLTopic,
-  GQLResourceTypeDefinition,
-} from '../../../graphqlTypes';
+import { GQLTopic, GQLResourceTypeDefinition } from '../../../graphqlTypes';
 import { getSubjectLongName } from '../../../data/subjects';
 import { getAllDimensions } from '../../../util/trackingUtil';
 import { htmlTitle } from '../../../util/titleHelper';
 import { FeideUserWithGroups } from '../../../util/feideApi';
+import { ToolboxSubjectType } from '../ToolboxSubjectContainer';
 
 interface Props extends WithTranslation {
-  subject: GQLSubject;
+  subject: ToolboxSubjectType;
   topic: GQLTopic;
   resourceTypes?: GQLResourceTypeDefinition[];
   locale: LocaleType;

--- a/src/gqlSchema.json
+++ b/src/gqlSchema.json
@@ -4019,6 +4019,114 @@
       },
       {
         "kind": "OBJECT",
+        "name": "ConceptCopyright",
+        "description": null,
+        "specifiedByUrl": null,
+        "fields": [
+          {
+            "name": "license",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "License",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "creators",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Contributor",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "processors",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Contributor",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rightsholders",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Contributor",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "origin",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "ConceptLicense",
         "description": null,
         "specifiedByUrl": null,
@@ -4057,7 +4165,7 @@
             "args": [],
             "type": {
               "kind": "OBJECT",
-              "name": "Copyright",
+              "name": "ConceptCopyright",
               "ofType": null
             },
             "isDeprecated": false,
@@ -5257,9 +5365,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -5269,12 +5381,20 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
-                "name": "Subject",
-                "ofType": null
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Subject",
+                    "ofType": null
+                  }
+                }
               }
             },
             "isDeprecated": false,
@@ -5297,15 +5417,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Resource",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Resource",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -5317,15 +5441,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Category",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Category",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -5405,9 +5533,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -5417,9 +5549,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -5429,9 +5565,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "OBJECT",
-              "name": "SubjectPageVisualElement",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "SubjectPageVisualElement",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -5453,9 +5593,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -5465,9 +5609,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -5551,15 +5699,19 @@
               }
             ],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "INTERFACE",
-                  "name": "TaxonomyEntity",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INTERFACE",
+                    "name": "TaxonomyEntity",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -5571,9 +5723,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "OBJECT",
-              "name": "SubjectPageBanner",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "SubjectPageBanner",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -5599,9 +5755,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -5636,15 +5796,19 @@
               }
             ],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "INTERFACE",
-                  "name": "TaxonomyEntity",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INTERFACE",
+                    "name": "TaxonomyEntity",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -5701,15 +5865,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "ResourceTypeDefinition",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ResourceTypeDefinition",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -5733,9 +5901,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -5748,6 +5920,30 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "supportedLanguages",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -8487,7 +8683,7 @@
             "args": [],
             "type": {
               "kind": "OBJECT",
-              "name": "Copyright",
+              "name": "ConceptCopyright",
               "ofType": null
             },
             "isDeprecated": false,
@@ -9608,7 +9804,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "SCALAR",
-                    "name": "String",
+                    "name": "Int",
                     "ofType": null
                   }
                 },

--- a/src/graphqlTypes.ts
+++ b/src/graphqlTypes.ts
@@ -189,8 +189,8 @@ export type GQLBucketResult = {
 
 export type GQLCategory = {
   __typename?: 'Category';
-  name?: Maybe<Scalars['String']>;
-  subjects?: Maybe<Array<Maybe<GQLSubject>>>;
+  name: Scalars['String'];
+  subjects: Array<GQLSubject>;
 };
 
 export type GQLCompetenceGoal = {
@@ -224,10 +224,19 @@ export type GQLConcept = {
   visualElement?: Maybe<GQLVisualElement>;
 };
 
+export type GQLConceptCopyright = {
+  __typename?: 'ConceptCopyright';
+  creators: Array<GQLContributor>;
+  license?: Maybe<GQLLicense>;
+  origin?: Maybe<Scalars['String']>;
+  processors: Array<GQLContributor>;
+  rightsholders: Array<GQLContributor>;
+};
+
 export type GQLConceptLicense = {
   __typename?: 'ConceptLicense';
   copyText?: Maybe<Scalars['String']>;
-  copyright?: Maybe<GQLCopyright>;
+  copyright?: Maybe<GQLConceptCopyright>;
   src?: Maybe<Scalars['String']>;
   title: Scalars['String'];
 };
@@ -291,7 +300,7 @@ export type GQLDetailedConcept = {
   articleIds?: Maybe<Array<Scalars['String']>>;
   articles?: Maybe<Array<GQLMeta>>;
   content?: Maybe<Scalars['String']>;
-  copyright?: Maybe<GQLCopyright>;
+  copyright?: Maybe<GQLConceptCopyright>;
   created?: Maybe<Scalars['String']>;
   id: Scalars['Int'];
   image?: Maybe<GQLImageLicense>;
@@ -344,8 +353,8 @@ export type GQLFrontPageResources = {
 
 export type GQLFrontpage = {
   __typename?: 'Frontpage';
-  categories?: Maybe<Array<GQLCategory>>;
-  topical?: Maybe<Array<GQLResource>>;
+  categories: Array<GQLCategory>;
+  topical: Array<GQLResource>;
 };
 
 export type GQLFrontpageSearch = {
@@ -790,7 +799,7 @@ export type GQLQuerySubjectArgs = {
 };
 
 export type GQLQuerySubjectpageArgs = {
-  id: Scalars['String'];
+  id: Scalars['Int'];
 };
 
 export type GQLQueryTopicArgs = {
@@ -946,16 +955,17 @@ export type GQLSubjectTopicsArgs = {
 export type GQLSubjectPage = {
   __typename?: 'SubjectPage';
   about?: Maybe<GQLSubjectPageAbout>;
-  banner?: Maybe<GQLSubjectPageBanner>;
-  editorsChoices?: Maybe<Array<GQLTaxonomyEntity>>;
+  banner: GQLSubjectPageBanner;
+  editorsChoices: Array<GQLTaxonomyEntity>;
   facebook?: Maybe<Scalars['String']>;
-  goTo?: Maybe<Array<GQLResourceTypeDefinition>>;
+  goTo: Array<GQLResourceTypeDefinition>;
   id: Scalars['Int'];
   latestContent?: Maybe<Array<GQLTaxonomyEntity>>;
-  layout?: Maybe<Scalars['String']>;
+  layout: Scalars['String'];
   metaDescription?: Maybe<Scalars['String']>;
-  mostRead?: Maybe<Array<GQLTaxonomyEntity>>;
-  name?: Maybe<Scalars['String']>;
+  mostRead: Array<GQLTaxonomyEntity>;
+  name: Scalars['String'];
+  supportedLanguages: Array<Scalars['String']>;
   topical?: Maybe<GQLTaxonomyEntity>;
   twitter?: Maybe<Scalars['String']>;
 };
@@ -978,15 +988,15 @@ export type GQLSubjectPageTopicalArgs = {
 
 export type GQLSubjectPageAbout = {
   __typename?: 'SubjectPageAbout';
-  description?: Maybe<Scalars['String']>;
-  title?: Maybe<Scalars['String']>;
-  visualElement?: Maybe<GQLSubjectPageVisualElement>;
+  description: Scalars['String'];
+  title: Scalars['String'];
+  visualElement: GQLSubjectPageVisualElement;
 };
 
 export type GQLSubjectPageBanner = {
   __typename?: 'SubjectPageBanner';
-  desktopId?: Maybe<Scalars['String']>;
-  desktopUrl?: Maybe<Scalars['String']>;
+  desktopId: Scalars['String'];
+  desktopUrl: Scalars['String'];
   mobileId?: Maybe<Scalars['String']>;
   mobileUrl?: Maybe<Scalars['String']>;
 };
@@ -1483,6 +1493,23 @@ export type GQLFrontpageSearchQuery = {
   }>;
 };
 
+export type GQLConceptCopyrightInfoFragment = {
+  __typename?: 'ConceptCopyright';
+  origin?: Maybe<string>;
+  license?: Maybe<{
+    __typename?: 'License';
+    license: string;
+    url?: Maybe<string>;
+  }>;
+  creators: Array<{ __typename?: 'Contributor' } & GQLContributorInfoFragment>;
+  processors: Array<
+    { __typename?: 'Contributor' } & GQLContributorInfoFragment
+  >;
+  rightsholders: Array<
+    { __typename?: 'Contributor' } & GQLContributorInfoFragment
+  >;
+};
+
 export type GQLCopyrightInfoFragment = {
   __typename?: 'Copyright';
   origin?: Maybe<string>;
@@ -1708,7 +1735,7 @@ export type GQLArticleInfoFragment = {
         src?: Maybe<string>;
         copyText?: Maybe<string>;
         copyright?: Maybe<
-          { __typename?: 'Copyright' } & GQLCopyrightInfoFragment
+          { __typename?: 'ConceptCopyright' } & GQLConceptCopyrightInfoFragment
         >;
       }>
     >;
@@ -1756,7 +1783,7 @@ export type GQLArticleInfoFragment = {
       content?: Maybe<string>;
       subjectNames?: Maybe<Array<string>>;
       copyright?: Maybe<
-        { __typename?: 'Copyright' } & GQLCopyrightInfoFragment
+        { __typename?: 'ConceptCopyright' } & GQLConceptCopyrightInfoFragment
       >;
       visualElement?: Maybe<
         { __typename?: 'VisualElement' } & GQLVisualElementInfoFragment
@@ -1823,27 +1850,22 @@ export type GQLSubjectPageInfoFragment = {
     | ({ __typename?: 'Subject' } & GQLTaxonomyEntityInfo_Subject_Fragment)
     | ({ __typename?: 'Topic' } & GQLTaxonomyEntityInfo_Topic_Fragment)
   >;
-  banner?: Maybe<{
-    __typename?: 'SubjectPageBanner';
-    desktopUrl?: Maybe<string>;
-  }>;
+  banner: { __typename?: 'SubjectPageBanner'; desktopUrl: string };
   about?: Maybe<{
     __typename?: 'SubjectPageAbout';
-    title?: Maybe<string>;
-    description?: Maybe<string>;
-    visualElement?: Maybe<{
+    title: string;
+    description: string;
+    visualElement: {
       __typename?: 'SubjectPageVisualElement';
       type: string;
       url: string;
       alt?: Maybe<string>;
-    }>;
+    };
   }>;
-  editorsChoices?: Maybe<
-    Array<
-      | ({ __typename?: 'Resource' } & GQLTaxonomyEntityInfo_Resource_Fragment)
-      | ({ __typename?: 'Subject' } & GQLTaxonomyEntityInfo_Subject_Fragment)
-      | ({ __typename?: 'Topic' } & GQLTaxonomyEntityInfo_Topic_Fragment)
-    >
+  editorsChoices: Array<
+    | ({ __typename?: 'Resource' } & GQLTaxonomyEntityInfo_Resource_Fragment)
+    | ({ __typename?: 'Subject' } & GQLTaxonomyEntityInfo_Subject_Fragment)
+    | ({ __typename?: 'Topic' } & GQLTaxonomyEntityInfo_Topic_Fragment)
   >;
 };
 

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -341,6 +341,26 @@ export const frontpageSearchQuery = gql`
   }
 `;
 
+const conceptCopyrightInfoFragment = gql`
+  ${contributorInfoFragment}
+  fragment ConceptCopyrightInfo on ConceptCopyright {
+    license {
+      license
+      url
+    }
+    creators {
+      ...ContributorInfo
+    }
+    processors {
+      ...ContributorInfo
+    }
+    rightsholders {
+      ...ContributorInfo
+    }
+    origin
+  }
+`;
+
 const copyrightInfoFragment = gql`
   ${contributorInfoFragment}
   fragment CopyrightInfo on Copyright {
@@ -479,6 +499,7 @@ export const visualElementFragment = gql`
 
 export const articleInfoFragment = gql`
   ${copyrightInfoFragment}
+  ${conceptCopyrightInfoFragment}
   ${visualElementFragment}
   fragment ArticleInfo on Article {
     id
@@ -561,7 +582,7 @@ export const articleInfoFragment = gql`
         title
         src
         copyright {
-          ...CopyrightInfo
+          ...ConceptCopyrightInfo
         }
         copyText
       }
@@ -602,7 +623,7 @@ export const articleInfoFragment = gql`
       content
       subjectNames
       copyright {
-        ...CopyrightInfo
+        ...ConceptCopyrightInfo
       }
       visualElement {
         ...VisualElementInfo


### PR DESCRIPTION
Feilen kommer av at vi prøvde å bruke en fragment av en type som ikke lenger gjaldt for forklaringer. 

Jo mer "riktig" GQL-typene blir, jo vanskeligere blir det å type det ordentlig. Kanskje det er på tide at vi ser nærmere på colocation snart?