### PR TITLE
Switched over to automatic runtime for jsx transform

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { ErrorInfo } from 'react';
+import { ErrorInfo, ComponentType, Component } from 'react';
 import { configureTracker } from '@ndla/tracker';
 import {
   Route,
@@ -45,7 +45,7 @@ interface NDLARouteProps extends RouteProps {
   skipToContent?: string;
   hideBreadcrumb?: boolean;
   initialSelectMenu?: string;
-  component: React.ComponentType<RootComponentProps>;
+  component: ComponentType<RootComponentProps>;
 }
 
 const NDLARoute = ({
@@ -150,7 +150,7 @@ interface AppState {
   location: H.Location | null;
 }
 
-class App extends React.Component<AppProps, AppState> {
+class App extends Component<AppProps, AppState> {
   private location: H.Location | null;
 
   constructor(props: AppProps) {

--- a/src/I18nWrapper.tsx
+++ b/src/I18nWrapper.tsx
@@ -1,5 +1,5 @@
 import { useApolloClient } from '@apollo/client';
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router';
 import { BrowserRouter } from 'react-router-dom';

--- a/src/client.tsx
+++ b/src/client.tsx
@@ -13,7 +13,7 @@ import ErrorReporter from '@ndla/error-reporter';
 import createCache from '@emotion/cache';
 // @ts-ignore
 import queryString from 'query-string';
-import React from 'react';
+import { ReactNode } from 'react';
 import ReactDOM from 'react-dom';
 import { MemoryRouter, Router } from 'react-router-dom';
 import { EmotionCacheKey, STORED_LANGUAGE_KEY } from './constants';
@@ -72,7 +72,7 @@ const isGoogleUrl =
   decodeURIComponent(window.location.search).indexOf(testLocation) > -1;
 
 interface RCProps {
-  children?: React.ReactNode;
+  children?: ReactNode;
 }
 
 const RouterComponent = ({ children }: RCProps) =>

--- a/src/components/Article/Article.tsx
+++ b/src/components/Article/Article.tsx
@@ -6,7 +6,13 @@
  *
  */
 
-import React, { ComponentType, ReactNode, useEffect, useMemo } from 'react';
+import {
+  ComponentType,
+  ReactElement,
+  ReactNode,
+  useEffect,
+  useMemo,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router';
 import { Remarkable } from 'remarkable';
@@ -64,7 +70,7 @@ interface Props {
   article: GQLArticleInfoFragment;
   resourceType?: string;
   isTopicArticle?: boolean;
-  children?: React.ReactElement;
+  children?: ReactElement;
   contentType?: string;
   label: string;
   locale: LocaleType;

--- a/src/components/Article/ArticleContents.tsx
+++ b/src/components/Article/ArticleContents.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { Remarkable } from 'remarkable';
 import {
   ArticleWrapper,

--- a/src/components/AuthenticationContext.tsx
+++ b/src/components/AuthenticationContext.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useState, createContext, useEffect } from 'react';
+import { useState, createContext, useEffect, ReactNode } from 'react';
 import {
   FeideUserWithGroups,
   fetchFeideUserWithGroups,
@@ -29,7 +29,7 @@ export const AuthContext = createContext<AuthContextType>({
 });
 
 interface Props {
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 const AuthenticationContext = ({ children }: Props) => {

--- a/src/components/BaseNameContext.tsx
+++ b/src/components/BaseNameContext.tsx
@@ -1,11 +1,11 @@
-import React, { useContext } from 'react';
+import { createContext, ReactNode, useContext } from 'react';
 import { LocaleType } from '../interfaces';
 
-const BaseNameContext = React.createContext<LocaleType | ''>('');
+const BaseNameContext = createContext<LocaleType | ''>('');
 type BaseNameType = LocaleType | '';
 
 interface Props {
-  children: React.ReactNode;
+  children: ReactNode;
   value?: BaseNameType;
 }
 

--- a/src/components/CompetenceGoals.tsx
+++ b/src/components/CompetenceGoals.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree. *
  */
 
-import React, { ComponentType } from 'react';
+import { ComponentType } from 'react';
 import { CompetenceGoalTab } from '@ndla/ui';
 import { useTranslation } from 'react-i18next';
 import Spinner from '@ndla/ui/lib/Spinner';

--- a/src/components/DefaultErrorMessage.tsx
+++ b/src/components/DefaultErrorMessage.tsx
@@ -7,7 +7,6 @@
  */
 
 import { OneColumn, ErrorMessage } from '@ndla/ui';
-import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 interface Props {

--- a/src/components/FeideLoginButton/FeideLoginButton.tsx
+++ b/src/components/FeideLoginButton/FeideLoginButton.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { ReactElement, useContext } from 'react';
+import { ReactElement, useContext } from 'react';
 import { RouteProps, useHistory } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { compact } from 'lodash';

--- a/src/components/Learningpath/LastLearningpathStepInfo.tsx
+++ b/src/components/Learningpath/LastLearningpathStepInfo.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import { LearningPathLastStepNavigation } from '@ndla/ui';
 import Resources from '../../containers/Resources/Resources';
 import { GQLResourcePageQuery, GQLTopic } from '../../graphqlTypes';

--- a/src/components/Learningpath/Learningpath.tsx
+++ b/src/components/Learningpath/Learningpath.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useWindowSize } from '@ndla/hooks';
 import {
   LearningPathWrapper,

--- a/src/components/Learningpath/LearningpathEmbed.tsx
+++ b/src/components/Learningpath/LearningpathEmbed.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import { Helmet } from 'react-helmet';
 import { spacing } from '@ndla/core';
 import styled from '@emotion/styled';

--- a/src/components/Learningpath/LearningpathIframe.tsx
+++ b/src/components/Learningpath/LearningpathIframe.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useEffect, useRef, useState } from 'react';
+import { MutableRefObject, useEffect, useRef, useState } from 'react';
 import parse from 'html-react-parser';
 
 export const urlIsNDLAApiUrl = (url: string) =>
@@ -24,7 +24,7 @@ interface Props {
 }
 
 const LearningpathIframe = ({ html, url }: Props) => {
-  const iframeRef = useRef() as React.MutableRefObject<HTMLInputElement>;
+  const iframeRef = useRef() as MutableRefObject<HTMLInputElement>;
   const [listeningToMessages, setListeningToMessages] = useState(true);
 
   const handleIframeResizing = (url: string) => {

--- a/src/components/SocialMediaMetadata.tsx
+++ b/src/components/SocialMediaMetadata.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React from 'react';
+import { ReactNode } from 'react';
 import { Helmet } from 'react-helmet';
 import { Location } from 'history';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
@@ -70,7 +70,7 @@ interface Props extends RouteComponentProps {
   locale: LocaleType;
   image?: Pick<GQLMetaImage, 'url'>;
   trackableContent?: TrackableContent;
-  children?: React.ReactNode;
+  children?: ReactNode;
 }
 
 const SocialMediaMetadata = ({

--- a/src/components/Status.tsx
+++ b/src/components/Status.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { Route } from 'react-router-dom';
 
 interface Props {

--- a/src/components/SubjectLinkList.tsx
+++ b/src/components/SubjectLinkList.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import SafeLink from '@ndla/safelink';
 import { toSubject } from '../routeHelpers';
 import { GQLSubjectInfoFragment } from '../graphqlTypes';

--- a/src/components/VisualElement/VisualElement.tsx
+++ b/src/components/VisualElement/VisualElement.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Image } from '@ndla/ui';
 import { GQLVisualElement } from '../../graphqlTypes';
 import { getCrop, getFocalPoint } from '../../util/imageHelpers';

--- a/src/components/VisualElement/VisualElementLicenseButtons.tsx
+++ b/src/components/VisualElement/VisualElementLicenseButtons.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { StyledButton } from '@ndla/button';
 import queryString from 'query-string';

--- a/src/components/VisualElement/VisualElementWrapper.tsx
+++ b/src/components/VisualElement/VisualElementWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FigureCaption, FigureLicenseDialog, Figure } from '@ndla/ui';
 import {

--- a/src/components/__tests__/RedirectExternal-test.js
+++ b/src/components/__tests__/RedirectExternal-test.js
@@ -7,7 +7,6 @@
  * @jest-environment jsdom
  */
 
-import React from 'react';
 import { StaticRouter, MemoryRouter } from 'react-router';
 import renderer from 'react-test-renderer';
 import sinon from 'sinon';

--- a/src/components/license/AudioLicenseList.tsx
+++ b/src/components/license/AudioLicenseList.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import { uuid } from '@ndla/util';
 import {
   MediaList,

--- a/src/components/license/ConceptLicenseList.tsx
+++ b/src/components/license/ConceptLicenseList.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import {
   MediaList,
   MediaListItem,

--- a/src/components/license/CopyTextButton.tsx
+++ b/src/components/license/CopyTextButton.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { copyTextToClipboard } from '@ndla/util';
 import Button from '@ndla/button';
 

--- a/src/components/license/H5pLicenseList.tsx
+++ b/src/components/license/H5pLicenseList.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import { uuid } from '@ndla/util';
 import {
   MediaList,

--- a/src/components/license/ImageLicenseList.tsx
+++ b/src/components/license/ImageLicenseList.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import { uuid } from '@ndla/util';
 import {
   Image,

--- a/src/components/license/LicenseBox.tsx
+++ b/src/components/license/LicenseBox.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import Tabs from '@ndla/tabs';
 import { useTranslation, TFunction } from 'react-i18next';
 import ImageLicenseList from './ImageLicenseList';

--- a/src/components/license/OembedItem.tsx
+++ b/src/components/license/OembedItem.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useTranslation } from 'react-i18next';
 import CopyTextButton from './CopyTextButton';
 

--- a/src/components/license/TextLicenseList.tsx
+++ b/src/components/license/TextLicenseList.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import { uuid } from '@ndla/util';
 import {
   MediaList,

--- a/src/components/license/VideoLicenseList.tsx
+++ b/src/components/license/VideoLicenseList.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import { uuid } from '@ndla/util';
 import {
   MediaList,

--- a/src/containers/AccessDeniedPage/AccessDeniedPage.tsx
+++ b/src/containers/AccessDeniedPage/AccessDeniedPage.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { OneColumn, ErrorResourceAccessDenied } from '@ndla/ui';
 import { HelmetWithTracker } from '@ndla/tracker';
 import { useTranslation } from 'react-i18next';

--- a/src/containers/AllSubjectsPage/AllSubjectsPage.tsx
+++ b/src/containers/AllSubjectsPage/AllSubjectsPage.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import { HelmetWithTracker } from '@ndla/tracker';
 import { OneColumn, ErrorMessage } from '@ndla/ui';
 import { useTranslation } from 'react-i18next';

--- a/src/containers/ArticlePage/ArticlePage.tsx
+++ b/src/containers/ArticlePage/ArticlePage.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { OneColumn, LayoutItem } from '@ndla/ui';
 import { withTracker } from '@ndla/tracker';

--- a/src/containers/ArticlePage/components/ArticleErrorMessage.tsx
+++ b/src/containers/ArticlePage/components/ArticleErrorMessage.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import PropTypes from 'prop-types';
 import { OneColumn, ErrorMessage } from '@ndla/ui';
 import { useTranslation } from 'react-i18next';

--- a/src/containers/ArticlePage/components/ArticleHero.tsx
+++ b/src/containers/ArticlePage/components/ArticleHero.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import PropTypes from 'prop-types';
 import { Hero, OneColumn, Breadcrumb, NdlaFilmHero } from '@ndla/ui';
 import { HeroContentType } from '@ndla/ui/lib/Hero';

--- a/src/containers/ErrorPage/ErrorBoundary.tsx
+++ b/src/containers/ErrorPage/ErrorBoundary.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { ErrorInfo } from 'react';
+import { Component, ErrorInfo } from 'react';
 import DefaultErrorMessage from '../../components/DefaultErrorMessage';
 import handleError from '../../util/handleError';
 
@@ -15,7 +15,7 @@ interface State {
 }
 
 interface Props {}
-class ErrorBoundary extends React.Component<Props, State> {
+class ErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = { hasError: false };

--- a/src/containers/ErrorPage/ErrorPage.tsx
+++ b/src/containers/ErrorPage/ErrorPage.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Content, Masthead, MastheadItem, Logo } from '@ndla/ui';
 import { RouteProps } from 'react-router';

--- a/src/containers/ErrorPage/__tests__/ErrorPage-test.js
+++ b/src/containers/ErrorPage/__tests__/ErrorPage-test.js
@@ -7,7 +7,6 @@
  * @jest-environment jsdom
  */
 
-import React from 'react';
 import { StaticRouter } from 'react-router';
 import renderer from 'react-test-renderer';
 import serializer from 'jest-emotion';

--- a/src/containers/FilmFrontpage/FilmFrontpage.tsx
+++ b/src/containers/FilmFrontpage/FilmFrontpage.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { css } from '@emotion/core';
 import { spacingUnit } from '@ndla/core';

--- a/src/containers/FilmFrontpage/MoreAboutNdlaFilm.tsx
+++ b/src/containers/FilmFrontpage/MoreAboutNdlaFilm.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { WithTranslation, withTranslation } from 'react-i18next';
 
 const MoreAboutNdlaFilm = ({ t }: WithTranslation) => (

--- a/src/containers/FilmFrontpage/MovieCategory.tsx
+++ b/src/containers/FilmFrontpage/MovieCategory.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import { CarouselAutosize } from '@ndla/carousel';
 import { FilmMovieList, MovieGrid } from '@ndla/ui';
 import { WithTranslation, withTranslation } from 'react-i18next';

--- a/src/containers/FilmFrontpage/NdlaFilmFrontpage.tsx
+++ b/src/containers/FilmFrontpage/NdlaFilmFrontpage.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { useLazyQuery } from '@apollo/client';
 
 import { useTranslation } from 'react-i18next';

--- a/src/containers/LearningpathPage/LearningpathPage.tsx
+++ b/src/containers/LearningpathPage/LearningpathPage.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 import { Helmet } from 'react-helmet';
 import { withTracker } from '@ndla/tracker';

--- a/src/containers/Login/Login.tsx
+++ b/src/containers/Login/Login.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { Fragment, useContext } from 'react';
+import { useContext } from 'react';
 import { Switch, Route } from 'react-router-dom';
 import { OneColumn } from '@ndla/ui';
 import { RouteComponentProps, withRouter } from 'react-router';
@@ -21,7 +21,7 @@ export const Login = ({ match }: Props) => {
   const { authenticated, authContextLoaded } = useContext(AuthContext);
 
   return (
-    <Fragment>
+    <>
       <OneColumn cssModifier="clear">
         <div className="u-2/3@desktop u-push-1/3@desktop">
           <Switch>
@@ -39,7 +39,7 @@ export const Login = ({ match }: Props) => {
           </Switch>
         </div>
       </OneColumn>
-    </Fragment>
+    </>
   );
 };
 

--- a/src/containers/Login/LoginFailure.tsx
+++ b/src/containers/Login/LoginFailure.tsx
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { toLogin } from '../../util/routeHelpers';

--- a/src/containers/Login/LoginSuccess.tsx
+++ b/src/containers/Login/LoginSuccess.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useContext, useEffect } from 'react';
+import { useContext, useEffect } from 'react';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 import queryString from 'query-string';
 import { AuthContext } from '../../components/AuthenticationContext';

--- a/src/containers/Logout/Logout.tsx
+++ b/src/containers/Logout/Logout.tsx
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { Fragment } from 'react';
 import {
   Switch,
   Route,
@@ -21,7 +20,7 @@ interface Props extends RouteComponentProps, RootComponentProps {}
 
 const Logout = ({ match }: Props) => {
   return (
-    <Fragment>
+    <>
       <OneColumn cssModifier="clear">
         <div className="u-2/3@desktop u-push-1/3@desktop">
           <Switch>
@@ -30,7 +29,7 @@ const Logout = ({ match }: Props) => {
           </Switch>
         </div>
       </OneColumn>
-    </Fragment>
+    </>
   );
 };
 

--- a/src/containers/Masthead/MastheadContainer.tsx
+++ b/src/containers/Masthead/MastheadContainer.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect, ReactNode } from 'react';
 import {
   Masthead,
   MastheadItem,
@@ -46,7 +46,7 @@ import config from '../../config';
 
 interface Props extends RouteComponentProps {
   locale: LocaleType;
-  infoContent?: React.ReactNode;
+  infoContent?: ReactNode;
   ndlaFilm?: boolean;
   skipToMainContentId?: string;
   hideBreadcrumb?: boolean;

--- a/src/containers/Masthead/components/MastheadMenu.tsx
+++ b/src/containers/Masthead/components/MastheadMenu.tsx
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import { Component, Fragment, ReactNode } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { Location } from 'history';
 import { getUrnIdsFromProps } from '../../../routeHelpers';
@@ -25,7 +25,7 @@ interface Props extends RouteComponentProps {
     topicId?: string,
     resourceId?: string,
   ) => void;
-  searchFieldComponent: React.ReactNode;
+  searchFieldComponent: ReactNode;
   ndlaFilm?: boolean;
   subjectCategories: {
     name: string;

--- a/src/containers/Masthead/components/MastheadMenu.tsx
+++ b/src/containers/Masthead/components/MastheadMenu.tsx
@@ -1,4 +1,4 @@
-import { Component, Fragment, ReactNode } from 'react';
+import { Component, ReactNode } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { Location } from 'history';
 import { getUrnIdsFromProps } from '../../../routeHelpers';
@@ -111,7 +111,7 @@ class MastheadMenu extends Component<Props, State> {
     const { expandedTopicId, expandedSubtopicsId } = this.state;
 
     return (
-      <Fragment>
+      <>
         <MastheadMenuModal ndlaFilm={ndlaFilm}>
           {(onClose: () => void) => (
             <MastheadTopics
@@ -130,7 +130,7 @@ class MastheadMenu extends Component<Props, State> {
             />
           )}
         </MastheadMenuModal>
-      </Fragment>
+      </>
     );
   }
 }

--- a/src/containers/Masthead/components/MastheadMenuModal.tsx
+++ b/src/containers/Masthead/components/MastheadMenuModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { ReactNode } from 'react';
 import PropTypes from 'prop-types';
 import Modal from '@ndla/modal';
 //@ts-ignore
@@ -6,7 +6,7 @@ import { TopicMenuButton } from '@ndla/ui';
 import { WithTranslation, withTranslation } from 'react-i18next';
 
 interface Props {
-  children: (onClose: () => void) => React.ReactNode;
+  children: (onClose: () => void) => ReactNode;
   onMenuExit?: () => void;
   ndlaFilm?: boolean;
 }

--- a/src/containers/Masthead/components/MastheadSearch.tsx
+++ b/src/containers/Masthead/components/MastheadSearch.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, FormEvent } from 'react';
+import { useState, useRef, useEffect, FormEvent } from 'react';
 import {
   //@ts-ignore
   SearchField,

--- a/src/containers/Masthead/components/MastheadTopics.tsx
+++ b/src/containers/Masthead/components/MastheadTopics.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { ReactNode } from 'react';
 //@ts-ignore
 import { TopicMenu } from '@ndla/ui';
 import { toSubject, removeUrn, toTopic } from '../../../routeHelpers';
@@ -41,7 +41,7 @@ interface Props {
     subtopicId?: string,
     currentIndex?: number,
   ) => void;
-  searchFieldComponent: React.ReactNode;
+  searchFieldComponent: ReactNode;
   programmes: ProgramSubjectType[];
   currentProgramme?: MastheadProgramme;
   subjectCategories: {

--- a/src/containers/MovedResourcePage/MovedResourcePage.tsx
+++ b/src/containers/MovedResourcePage/MovedResourcePage.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 //@ts-ignore
 import { SearchResultList, OneColumn } from '@ndla/ui';
 

--- a/src/containers/MultidisciplinarySubject/MultidisciplinarySubjectArticlePage.tsx
+++ b/src/containers/MultidisciplinarySubject/MultidisciplinarySubjectArticlePage.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router';
 import Spinner from '@ndla/ui/lib/Spinner';
 import { Helmet } from 'react-helmet';

--- a/src/containers/MultidisciplinarySubject/MultidisciplinarySubjectPage.tsx
+++ b/src/containers/MultidisciplinarySubject/MultidisciplinarySubjectPage.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useContext, useEffect } from 'react';
+import { createRef, useContext, useEffect } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router';
 import { MultidisciplinarySubject, NavigationBox } from '@ndla/ui';
 
@@ -35,7 +35,7 @@ const MultidisciplinarySubjectPage = ({ match, locale }: Props) => {
     ndlaFilm: false,
     match,
   });
-  const refs = selectedTopics.map(_ => React.createRef<HTMLDivElement>());
+  const refs = selectedTopics.map(_ => createRef<HTMLDivElement>());
 
   useEffect(() => {
     if (selectedTopics.length) {

--- a/src/containers/MultidisciplinarySubject/components/MultidisciplinarySubjectArticle.tsx
+++ b/src/containers/MultidisciplinarySubject/components/MultidisciplinarySubjectArticle.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useRef } from 'react';
+import { useRef, MouseEvent } from 'react';
 import {
   ArticleSideBar,
   Breadcrumblist,
@@ -54,7 +54,7 @@ const MultidisciplinarySubjectArticle = ({
   skipToContentId,
 }: Props) => {
   const resourcesRef = useRef(null);
-  const onLinkToResourcesClick = (e: React.MouseEvent) => {
+  const onLinkToResourcesClick = (e: MouseEvent) => {
     e.preventDefault();
     scrollToRef(resourcesRef, 0);
   };

--- a/src/containers/MultidisciplinarySubject/components/MultidisciplinaryTopic.tsx
+++ b/src/containers/MultidisciplinarySubject/components/MultidisciplinaryTopic.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import React, { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Remarkable } from 'remarkable';
 import { Topic as UITopic } from '@ndla/ui';
 import { TopicProps } from '@ndla/ui/lib/Topic/Topic';

--- a/src/containers/MultidisciplinarySubject/components/MultidisciplinaryTopicWrapper.tsx
+++ b/src/containers/MultidisciplinarySubject/components/MultidisciplinaryTopicWrapper.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Spinner from '@ndla/ui/lib/Spinner';
 import { topicQuery } from '../../../queries';
 import { useGraphQuery } from '../../../util/runQueries';

--- a/src/containers/NotFoundPage/NotFoundPage.tsx
+++ b/src/containers/NotFoundPage/NotFoundPage.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import { OneColumn, ErrorMessage } from '@ndla/ui';
 import { HelmetWithTracker } from '@ndla/tracker';
 import { useTranslation } from 'react-i18next';

--- a/src/containers/Page/Page.tsx
+++ b/src/containers/Page/Page.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { Helmet } from 'react-helmet';
 import { RouteProps } from 'react-router';
 import { PageContainer } from '@ndla/ui';

--- a/src/containers/Page/components/FeideFooter.tsx
+++ b/src/containers/Page/components/FeideFooter.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { RouteProps } from 'react-router';
 
 import { useTranslation } from 'react-i18next';

--- a/src/containers/Page/components/Footer.tsx
+++ b/src/containers/Page/components/Footer.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import { useLocation } from 'react-router';
 import { Footer, LanguageSelector, FooterText, EditorName } from '@ndla/ui';
 import { Facebook, Twitter, EmailOutline, Youtube } from '@ndla/icons/common';

--- a/src/containers/PlainArticlePage/PlainArticleContainer.tsx
+++ b/src/containers/PlainArticlePage/PlainArticleContainer.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import { CustomWithTranslation, withTranslation } from 'react-i18next';
 import { OneColumn } from '@ndla/ui';

--- a/src/containers/PlainArticlePage/PlainArticlePage.tsx
+++ b/src/containers/PlainArticlePage/PlainArticlePage.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router';
 import DefaultErrorMessage from '../../components/DefaultErrorMessage';
 import NotFoundPage from '../NotFoundPage/NotFoundPage';

--- a/src/containers/PlainLearningpathPage/PlainLearningpathContainer.tsx
+++ b/src/containers/PlainLearningpathPage/PlainLearningpathContainer.tsx
@@ -7,7 +7,7 @@
  */
 
 import { withTracker } from '@ndla/tracker';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import { CustomWithTranslation, withTranslation } from 'react-i18next';
 import { useHistory } from 'react-router';

--- a/src/containers/PlainLearningpathPage/PlainLearningpathPage.tsx
+++ b/src/containers/PlainLearningpathPage/PlainLearningpathPage.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { Spinner } from '@ndla/ui';
 import { RouteComponentProps, withRouter } from 'react-router';
 

--- a/src/containers/ProgrammePage/ProgrammeContainer.tsx
+++ b/src/containers/ProgrammePage/ProgrammeContainer.tsx
@@ -8,7 +8,6 @@
 
 import { withTracker } from '@ndla/tracker';
 import { Programme } from '@ndla/ui';
-import React from 'react';
 import { Helmet } from 'react-helmet';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { LocaleType, ProgrammeType } from '../../interfaces';

--- a/src/containers/ProgrammePage/ProgrammePage.tsx
+++ b/src/containers/ProgrammePage/ProgrammePage.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { RouteComponentProps, useHistory, withRouter } from 'react-router';
 import NotFoundPage from '../NotFoundPage/NotFoundPage';
 import { getProgrammeBySlug } from '../../data/programmes';

--- a/src/containers/ResourcePage/ResourcePage.tsx
+++ b/src/containers/ResourcePage/ResourcePage.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { Redirect, RouteComponentProps, withRouter } from 'react-router-dom';
 import { Location } from 'history';
 import { useTranslation } from 'react-i18next';

--- a/src/containers/Resources/Resources.tsx
+++ b/src/containers/Resources/Resources.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ResourcesWrapper, ResourcesTopicTitle, ResourceGroup } from '@ndla/ui';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';

--- a/src/containers/SearchPage/SearchContainer.tsx
+++ b/src/containers/SearchPage/SearchContainer.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree. *
  */
 
-import React, { ReactNode, useMemo } from 'react';
+import { ReactNode, useMemo } from 'react';
 import { Remarkable } from 'remarkable';
 import { Location } from 'history';
 import styled from '@emotion/styled';

--- a/src/containers/SearchPage/SearchInnerPage.tsx
+++ b/src/containers/SearchPage/SearchInnerPage.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree. *
  */
 
-import React, { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Location } from 'history';
 import SearchContainer from './SearchContainer';

--- a/src/containers/SearchPage/SearchPage.tsx
+++ b/src/containers/SearchPage/SearchPage.tsx
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree. *
  */
 
-import React from 'react';
 import { HelmetWithTracker } from '@ndla/tracker';
 import { OneColumn } from '@ndla/ui';
 import queryString from 'query-string';

--- a/src/containers/SearchPage/components/SearchHeader.tsx
+++ b/src/containers/SearchPage/components/SearchHeader.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree. *
  */
 
-import React, { useState, useEffect, useMemo, FormEvent } from 'react';
+import { useState, useEffect, useMemo, FormEvent } from 'react';
 import { SearchHeader as SearchHeaderUI } from '@ndla/ui';
 import { useTranslation } from 'react-i18next';
 import { subjectsCategories, getSubjectLongName } from '../../../data/subjects';

--- a/src/containers/SearchPage/components/SearchResults.tsx
+++ b/src/containers/SearchPage/components/SearchResults.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree. *
  */
 
-import React, { Fragment } from 'react';
+import { Fragment } from 'react';
 import { SearchTypeResult, constants } from '@ndla/ui';
 import { SearchGroup, TypeFilter } from '../searchHelpers';
 

--- a/src/containers/SearchPage/searchHelpers.tsx
+++ b/src/containers/SearchPage/searchHelpers.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import queryString from 'query-string';
 import { TFunction } from 'i18next';
 import { Location } from 'history';

--- a/src/containers/SubjectPage/SubjectContainer.tsx
+++ b/src/containers/SubjectPage/SubjectContainer.tsx
@@ -6,7 +6,14 @@
  *
  */
 
-import React, { ComponentType, ReactNode, useState, useRef } from 'react';
+import {
+  ComponentType,
+  ReactNode,
+  useState,
+  useRef,
+  createRef,
+  MouseEvent,
+} from 'react';
 import { Helmet } from 'react-helmet';
 import {
   ArticleHeaderWrapper,
@@ -154,12 +161,9 @@ const SubjectContainer = ({
   }
 
   const headerRef = useRef<HTMLDivElement>(null);
-  const topicRefs = topicIds.map(_ => React.createRef<HTMLDivElement>());
+  const topicRefs = topicIds.map(_ => createRef<HTMLDivElement>());
 
-  const handleNav = (
-    e: React.MouseEvent<HTMLElement>,
-    item: BreadcrumbItem,
-  ) => {
+  const handleNav = (e: MouseEvent<HTMLElement>, item: BreadcrumbItem) => {
     e.preventDefault();
     const { typename, index } = item;
     if (typename === 'Subjecttype' || typename === 'Subject') {
@@ -174,7 +178,7 @@ const SubjectContainer = ({
     }
   };
 
-  const onClickTopics = (e: React.MouseEvent<HTMLAnchorElement>) => {
+  const onClickTopics = (e: MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
     const path = parseAndMatchUrl(e.currentTarget?.href, true);
     history.push({ pathname: path?.url });

--- a/src/containers/SubjectPage/SubjectPage.tsx
+++ b/src/containers/SubjectPage/SubjectPage.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useContext, useRef } from 'react';
+import { useContext, useRef } from 'react';
 import { Redirect, withRouter } from 'react-router-dom';
 import { RouteComponentProps } from 'react-router';
 import SubjectContainer from './SubjectContainer';

--- a/src/containers/SubjectPage/components/MovedTopicPage.tsx
+++ b/src/containers/SubjectPage/components/MovedTopicPage.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 // @ts-ignore
 import { SearchResultList, OneColumn } from '@ndla/ui';
 import { useTranslation } from 'react-i18next';

--- a/src/containers/SubjectPage/components/SubjectEditorChoices.tsx
+++ b/src/containers/SubjectPage/components/SubjectEditorChoices.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import { SubjectCarousel } from '@ndla/ui';
 import { TFunction, useTranslation } from 'react-i18next';
 import { toLinkProps } from '../../../routeHelpers';

--- a/src/containers/SubjectPage/components/SubjectPageAbout.tsx
+++ b/src/containers/SubjectPage/components/SubjectPageAbout.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import PropTypes from 'prop-types';
 import { SubjectAbout, Image } from '@ndla/ui';
 import SubjectPageFlexChild from './SubjectPageFlexChild';

--- a/src/containers/SubjectPage/components/SubjectPageContent.tsx
+++ b/src/containers/SubjectPage/components/SubjectPageContent.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { RefObject, useEffect } from 'react';
+import { RefObject, useEffect, MouseEvent } from 'react';
 import { NavigationBox } from '@ndla/ui';
 import { RELEVANCE_SUPPLEMENTARY } from '../../../constants';
 import { scrollToRef } from '../subjectPageHelpers';
@@ -19,7 +19,7 @@ interface Props {
   subject: GQLSubjectContainerType;
   locale: LocaleType;
   ndlaFilm?: boolean;
-  onClickTopics: (e: React.MouseEvent<HTMLAnchorElement>) => void;
+  onClickTopics: (e: MouseEvent<HTMLAnchorElement>) => void;
   topicIds: Array<string>;
   refs: Array<RefObject<HTMLDivElement>>;
   setBreadCrumb: (topic: BreadcrumbItem) => void;
@@ -56,7 +56,7 @@ const SubjectPageContent = ({
         invertedStyle={ndlaFilm}
         listDirection="horizontal"
         onClick={e => {
-          onClickTopics(e as React.MouseEvent<HTMLAnchorElement>);
+          onClickTopics(e as MouseEvent<HTMLAnchorElement>);
         }}
       />
       {topicIds.map((topicId, index) => {

--- a/src/containers/SubjectPage/components/SubjectPageFlexChild.tsx
+++ b/src/containers/SubjectPage/components/SubjectPageFlexChild.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { ReactElement } from 'react';
+import { ReactElement } from 'react';
 import { SubjectFlexChild } from '@ndla/ui';
 
 interface Props {

--- a/src/containers/SubjectPage/components/SubjectPageInformation.tsx
+++ b/src/containers/SubjectPage/components/SubjectPageInformation.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import SubjectTopical from './SubjectTopical';
 import SubjectPageAbout from './SubjectPageAbout';
 import { GQLSubjectContainerType } from '../SubjectContainer';

--- a/src/containers/SubjectPage/components/SubjectPageSidebar.tsx
+++ b/src/containers/SubjectPage/components/SubjectPageSidebar.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { SubjectLinks, SubjectShortcuts } from '@ndla/ui';
 import { toLinkProps } from '../../../routeHelpers';

--- a/src/containers/SubjectPage/components/SubjectPageTopics.tsx
+++ b/src/containers/SubjectPage/components/SubjectPageTopics.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import {
   //@ts-ignore
   TopicIntroductionList,

--- a/src/containers/SubjectPage/components/SubjectTopical.jsx
+++ b/src/containers/SubjectPage/components/SubjectTopical.jsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Image, SubjectArchive } from '@ndla/ui';
 import { useTranslation } from 'react-i18next';

--- a/src/containers/SubjectPage/components/Topic.tsx
+++ b/src/containers/SubjectPage/components/Topic.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import React, { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, MouseEvent } from 'react';
 import { Remarkable } from 'remarkable';
 import { TFunction, withTranslation, WithTranslation } from 'react-i18next';
 import { Topic as UITopic } from '@ndla/ui';
@@ -51,7 +51,7 @@ type Props = {
   subTopicId?: string;
   locale: LocaleType;
   ndlaFilm?: boolean;
-  onClickTopics: (e: React.MouseEvent<HTMLAnchorElement>) => void;
+  onClickTopics: (e: MouseEvent<HTMLAnchorElement>) => void;
   index?: number;
   showResources?: boolean;
   subject?: GQLSubjectContainerType;
@@ -161,8 +161,8 @@ const Topic = ({
       renderMarkdown={renderMarkdown}
       invertedStyle={ndlaFilm}
       isAdditionalTopic={topic.relevanceId === RELEVANCE_SUPPLEMENTARY}
-      onSubTopicSelected={(e: React.MouseEvent<HTMLElement>) =>
-        onClickTopics(e as React.MouseEvent<HTMLAnchorElement>)
+      onSubTopicSelected={(e: MouseEvent<HTMLElement>) =>
+        onClickTopics(e as MouseEvent<HTMLAnchorElement>)
       }>
       <ArticleContents
         topic={topic}

--- a/src/containers/SubjectPage/components/TopicWrapper.tsx
+++ b/src/containers/SubjectPage/components/TopicWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react';
+import { useContext, useEffect, MouseEvent } from 'react';
 import { useHistory, useLocation } from 'react-router';
 import { withTranslation, WithTranslation } from 'react-i18next';
 import Spinner from '@ndla/ui/lib/Spinner';
@@ -17,7 +17,7 @@ type Props = {
   subTopicId?: string;
   locale: LocaleType;
   ndlaFilm?: boolean;
-  onClickTopics: (e: React.MouseEvent<HTMLAnchorElement>) => void;
+  onClickTopics: (e: MouseEvent<HTMLAnchorElement>) => void;
   setBreadCrumb: (item: BreadcrumbItem) => void;
   index: number;
   showResources: boolean;

--- a/src/containers/ToolboxSubject/ToolboxSubjectContainer.tsx
+++ b/src/containers/ToolboxSubject/ToolboxSubjectContainer.tsx
@@ -8,7 +8,7 @@
 
 import { withTracker } from '@ndla/tracker';
 import { OneColumn, SubjectBanner, ToolboxInfo } from '@ndla/ui';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState, MouseEvent, createRef } from 'react';
 import { Helmet } from 'react-helmet';
 import {
   useTranslation,
@@ -94,7 +94,7 @@ const ToolboxSubjectContainer = (props: Props) => {
   const { t } = useTranslation();
   const location = useLocation();
 
-  const refs = topicList.map(() => React.createRef<HTMLDivElement>());
+  const refs = topicList.map(() => createRef<HTMLDivElement>());
   const initialSelectedTopics = getInitialSelectedTopics(topicList, subject);
   const [selectedTopics, setSelectedTopics] = useState(initialSelectedTopics);
 
@@ -133,7 +133,7 @@ const ToolboxSubjectContainer = (props: Props) => {
   });
 
   const onSelectTopic = (
-    e: React.MouseEvent<HTMLAnchorElement>,
+    e: MouseEvent<HTMLAnchorElement>,
     index: number,
     id?: string,
   ) => {
@@ -205,8 +205,8 @@ const ToolboxSubjectContainer = (props: Props) => {
       <OneColumn className={''}>
         <ToolboxInfo
           topics={topics}
-          onSelectTopic={(e: React.MouseEvent<HTMLElement>, id?: string) =>
-            onSelectTopic(e as React.MouseEvent<HTMLAnchorElement>, 0, id)
+          onSelectTopic={(e: MouseEvent<HTMLElement>, id?: string) =>
+            onSelectTopic(e as MouseEvent<HTMLAnchorElement>, 0, id)
           }
           title={getSubjectLongName(subject.id, locale) || subject.name}
           introduction={t('htmlTitles.toolbox.introduction')}

--- a/src/containers/ToolboxSubject/ToolboxSubjectPage.tsx
+++ b/src/containers/ToolboxSubject/ToolboxSubjectPage.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { getUrnIdsFromProps } from '../../routeHelpers';
 import { useGraphQuery } from '../../util/runQueries';

--- a/src/containers/ToolboxSubject/components/ToolboxTopicContainer.tsx
+++ b/src/containers/ToolboxSubject/components/ToolboxTopicContainer.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useContext } from 'react';
+import { useContext, MouseEvent } from 'react';
 import { Spinner } from '@ndla/ui';
 import DefaultErrorMessage from '../../../components/DefaultErrorMessage';
 import { AuthContext } from '../../../components/AuthenticationContext';
@@ -22,7 +22,7 @@ interface Props {
   topicId: string;
   locale: LocaleType;
   onSelectTopic: (
-    e: React.MouseEvent<HTMLAnchorElement>,
+    e: MouseEvent<HTMLAnchorElement>,
     index: number,
     id?: string,
   ) => void;

--- a/src/containers/ToolboxSubject/components/ToolboxTopicWrapper.tsx
+++ b/src/containers/ToolboxSubject/components/ToolboxTopicWrapper.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import React from 'react';
+import { MouseEvent } from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { Topic } from '@ndla/ui';
 import { withTracker } from '@ndla/tracker';
@@ -33,7 +33,7 @@ interface Props extends WithTranslation {
   resourceTypes?: GQLResourceTypeDefinition[];
   locale: LocaleType;
   onSelectTopic: (
-    e: React.MouseEvent<HTMLAnchorElement>,
+    e: MouseEvent<HTMLAnchorElement>,
     index: number,
     id?: string,
   ) => void;
@@ -119,8 +119,8 @@ const ToolboxTopicWrapper = ({
         frame={subTopics?.length === 0}
         isLoading={loading}
         subTopics={subTopics}
-        onSubTopicSelected={(e: React.MouseEvent<HTMLElement>, id?: string) =>
-          onSelectTopic(e as React.MouseEvent<HTMLAnchorElement>, index + 1, id)
+        onSubTopicSelected={(e: MouseEvent<HTMLElement>, id?: string) =>
+          onSelectTopic(e as MouseEvent<HTMLAnchorElement>, index + 1, id)
         }
         topic={toolboxTopic.topic}
       />

--- a/src/containers/WelcomePage/BlogPosts.tsx
+++ b/src/containers/WelcomePage/BlogPosts.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import { BlogPostWrapper, BlogPost, SubjectSectionTitle } from '@ndla/ui';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { LocaleType } from '../../interfaces';

--- a/src/containers/WelcomePage/FrontpageSubjects.tsx
+++ b/src/containers/WelcomePage/FrontpageSubjects.tsx
@@ -7,7 +7,6 @@
  *
  */
 
-import React from 'react';
 import { FrontpageProgramMenu } from '@ndla/ui';
 
 import {

--- a/src/containers/WelcomePage/WelcomePage.tsx
+++ b/src/containers/WelcomePage/WelcomePage.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import { HelmetWithTracker } from '@ndla/tracker';
 import {
   FrontpageHeader,

--- a/src/containers/WelcomePage/WelcomePageInfo.tsx
+++ b/src/containers/WelcomePage/WelcomePageInfo.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import { InfoWidget, FrontpageInfo } from '@ndla/ui';
 import { EmailOutline, Facebook, Twitter } from '@ndla/icons/common';
 import { WithTranslation, withTranslation } from 'react-i18next';

--- a/src/containers/WelcomePage/WelcomePageSearch.tsx
+++ b/src/containers/WelcomePage/WelcomePageSearch.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useState, useEffect, FormEvent } from 'react';
+import { useState, useEffect, FormEvent } from 'react';
 import { FrontpageSearch } from '@ndla/ui';
 import { useLazyQuery } from '@apollo/client';
 import debounce from 'lodash.debounce';

--- a/src/iframe/FixDialogPosition.tsx
+++ b/src/iframe/FixDialogPosition.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React from 'react';
+import { Component } from 'react';
 import { Helmet } from 'react-helmet';
 import {
   forEachElement,
@@ -19,7 +19,7 @@ import {
  * our css for align dialogs in the middle of the screen does not work. The
  * solution is to postions the dialogs absolutely.
  */
-class FixDialogPosition extends React.Component {
+class FixDialogPosition extends Component {
   componentDidMount() {
     window.addEventListener('resize', this.updateDialogPositions);
     this.updateDialogPositions();

--- a/src/iframe/IframeArticlePage.tsx
+++ b/src/iframe/IframeArticlePage.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import { Helmet } from 'react-helmet';
 
 import { OneColumn, CreatedBy } from '@ndla/ui';

--- a/src/iframe/IframePage.tsx
+++ b/src/iframe/IframePage.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import { useLocation } from 'react-router';
 import { OneColumn, ErrorMessage } from '@ndla/ui';
 import { useTranslation } from 'react-i18next';

--- a/src/iframe/IframePageContainer.tsx
+++ b/src/iframe/IframePageContainer.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import { I18nextProvider } from 'react-i18next';
 import { i18nInstance } from '@ndla/ui';
 import IframePageWrapper from './IframePageWrapper';

--- a/src/iframe/IframePageWrapper.tsx
+++ b/src/iframe/IframePageWrapper.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 import { Helmet } from 'react-helmet';
 import { PageContainer } from '@ndla/ui';

--- a/src/iframe/IframeTopicPage.tsx
+++ b/src/iframe/IframeTopicPage.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import { Helmet } from 'react-helmet';
 import { withTracker } from '@ndla/tracker';
 import { OneColumn, CreatedBy, constants } from '@ndla/ui';

--- a/src/iframe/PostResizeMessage.tsx
+++ b/src/iframe/PostResizeMessage.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React from 'react';
+import { Component } from 'react';
 
 interface Props {}
 interface State {
@@ -14,7 +14,7 @@ interface State {
   height: number;
 }
 
-class PostResizeMessage extends React.Component<Props, State> {
+class PostResizeMessage extends Component<Props, State> {
   intervalId: ReturnType<typeof setInterval> | undefined;
   constructor(props: Props) {
     super(props);

--- a/src/iframe/__tests__/IframeArticlePage-test.tsx
+++ b/src/iframe/__tests__/IframeArticlePage-test.tsx
@@ -7,7 +7,6 @@
  * @jest-environment jsdom
  */
 
-import React from 'react';
 import renderer from 'react-test-renderer';
 import serializer from 'jest-emotion';
 import { MockedProvider } from '@apollo/client/testing';

--- a/src/iframe/index.tsx
+++ b/src/iframe/index.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import ReactDOM from 'react-dom';
 import { ApolloProvider } from '@apollo/client';
 import { configureTracker } from '@ndla/tracker';

--- a/src/lti/LtiEmbed.tsx
+++ b/src/lti/LtiEmbed.tsx
@@ -4,7 +4,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
 import LtiDefault from './components/LtiDefault';
 import LtiDeepLinking from './components/LtiDeepLinking';
 import LtiBasicLaunch from './components/LtiBasicLaunch';

--- a/src/lti/LtiProvider.tsx
+++ b/src/lti/LtiProvider.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 import { useApolloClient } from '@apollo/client';

--- a/src/lti/components/LtiBasicLaunch.tsx
+++ b/src/lti/components/LtiBasicLaunch.tsx
@@ -4,7 +4,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
 import styled from '@emotion/styled';
 import queryString from 'query-string';
 import { CustomWithTranslation, withTranslation } from 'react-i18next';

--- a/src/lti/components/LtiDeepLinking.tsx
+++ b/src/lti/components/LtiDeepLinking.tsx
@@ -3,7 +3,7 @@
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import Button from '@ndla/button';
 import { useTranslation } from 'react-i18next';
 import config from '../../config';

--- a/src/lti/components/LtiDefault.tsx
+++ b/src/lti/components/LtiDefault.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import Button from '@ndla/button';
 import { useTranslation } from 'react-i18next';
 import LtiEmbedCode from './LtiEmbedCode';

--- a/src/lti/components/LtiEmbedCode.tsx
+++ b/src/lti/components/LtiEmbedCode.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import Modal, { ModalHeader, ModalBody, ModalCloseButton } from '@ndla/modal';
 import { useTranslation } from 'react-i18next';

--- a/src/lti/index.tsx
+++ b/src/lti/index.tsx
@@ -7,7 +7,6 @@
  */
 
 import 'isomorphic-unfetch';
-import React from 'react';
 import ReactDOM from 'react-dom';
 import { I18nextProvider } from 'react-i18next';
 import ErrorReporter from '@ndla/error-reporter';

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React from 'react';
+import { ComponentType } from 'react';
 import { RouteProps } from 'react-router';
 import { ApolloClient } from '@apollo/client';
 import { I18nextProvider } from 'react-i18next';
@@ -61,7 +61,7 @@ export interface RouteType extends RouteProps {
   hideMasthead?: boolean;
   background?: boolean;
   initialSelectMenu?: string;
-  component: React.ComponentType<RootComponentProps>;
+  component: ComponentType<RootComponentProps>;
 }
 
 let routeArray: RouteType[] = [

--- a/src/server/helpers/Document.js
+++ b/src/server/helpers/Document.js
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import PropTypes from 'prop-types';
 import serialize from 'serialize-javascript';
 import ScriptLoader from '@ndla/polyfill/lib/ScriptLoader';

--- a/src/server/helpers/Gtm.js
+++ b/src/server/helpers/Gtm.js
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import config from '../../config';
 
 export const GoogleTagMangerNoScript = () => {

--- a/src/server/helpers/Matomo.tsx
+++ b/src/server/helpers/Matomo.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import { MatomoTracker } from '@ndla/tracker';
 import config from '../../config';
 

--- a/src/server/helpers/__tests__/Document-test.js
+++ b/src/server/helpers/__tests__/Document-test.js
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import renderer from 'react-test-renderer';
 import { Helmet } from 'react-helmet';
 import { PageContainer } from '@ndla/ui';

--- a/src/server/helpers/render.js
+++ b/src/server/helpers/render.js
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import { renderToString, renderToStaticMarkup } from 'react-dom/server';
 import { renderToStringWithData } from '@apollo/client/react/ssr';
 import { resetIdCounter } from '@ndla/tabs';

--- a/src/server/routes/__tests__/iframeArticleRoute-test.js
+++ b/src/server/routes/__tests__/iframeArticleRoute-test.js
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import { iframeArticleRoute } from '../iframeArticleRoute';
 
 jest.mock('../../helpers/Document', () => () => (

--- a/src/server/routes/defaultRoute.js
+++ b/src/server/routes/defaultRoute.js
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import { StaticRouter } from 'react-router';
 import { matchPath } from 'react-router-dom';
 import url from 'url';

--- a/src/server/routes/errorRoute.js
+++ b/src/server/routes/errorRoute.js
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import { MissingRouterContext } from '@ndla/safelink';
 import { INTERNAL_SERVER_ERROR } from '../../statusCodes';
 import ErrorPage from '../../containers/ErrorPage';

--- a/src/server/routes/iframeArticleRoute.tsx
+++ b/src/server/routes/iframeArticleRoute.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React from 'react';
 import url from 'url';
 import { Request } from 'express';
 import { Helmet } from 'react-helmet';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,75 +1,45 @@
 {
   "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig.json to read more about this file */
-
-    /* Basic Options */
-    // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    "lib": ["es2019", "esnext.asynciterable", "dom"],                             /* Specify library files to be included in the compilation. */
-    // "allowJs": true,                       /* Allow javascript files to be compiled. */
-    // "checkJs": true,                       /* Report errors in .js files. */
-    "jsx": "react-jsx",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    "sourceMap": true,                     /* Generates corresponding '.map' file. */
-    // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "build",                        /* Redirect output structure to the directory. */
-    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "composite": true,                     /* Enable project compilation */
-    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
-    // "removeComments": true,                /* Do not emit comments to output. */
-    "noEmit": false,                        /* Do not emit outputs. */
+    "target": "es5",
+    "module": "commonjs",
+    "lib": ["es2019", "esnext.asynciterable", "dom"],
+    "jsx": "react-jsx",
+    "sourceMap": true,
+    "outDir": "build",
+    "noEmit": false,
     "noLib": false,
-    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-    "isolatedModules": false,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+    "isolatedModules": false,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
 
-    /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
-    "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    "strictNullChecks": true,              /* Enable strict null checks. */
-    "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-    "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
-    "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-    "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
 
-    /* Additional Checks */
-    "noUnusedLocals": true,                /* Report errors on unused locals. */
-    "noUnusedParameters": true,            /* Report errors on unused parameters. */
-    "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
-    "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
-    "noUncheckedIndexedAccess": true,      /* Include 'undefined' in index signature results */
-
-    /* Module Resolution Options */
-    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    "baseUrl": "src",                       /* Base directory to resolve non-absolute module names. */
-    "paths": {                                /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    "moduleResolution": "node",
+    "baseUrl": "src",
+    "paths": {
       "*": ["node_modules/*", "src/types/*"]
     },
-    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    "types": ["@emotion/core", "@emotion/styled", "jest", "node", "webpack-env"],                           /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
-
-    /* Source Map Options */
-    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
-    /* Experimental Options */
-    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-
-    /* Advanced Options */
-    "skipLibCheck": true,                     /* Skip type checking of declaration files. */
-    "forceConsistentCasingInFileNames": true,  /* Disallow inconsistently-cased references to the same file. */
+    "types": [
+      "@emotion/core",
+      "@emotion/styled",
+      "jest",
+      "node",
+      "webpack-env"
+    ],
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["src/**/*"],
-  "exclude": ["**/*-test.*"],
+  "exclude": ["**/*-test.*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "lib": ["es2019", "esnext.asynciterable", "dom"],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
-    "jsx": "react",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "jsx": "react-jsx",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     "sourceMap": true,                     /* Generates corresponding '.map' file. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+     /* Full property definition at https://aka.ms/tsconfig.json */
     "target": "es5",
     "module": "commonjs",
     "lib": ["es2019", "esnext.asynciterable", "dom"],


### PR DESCRIPTION
Ser ut som at vi sparer rundt 50kb, sammenlignet med test.ndla.no. React-teamet sier den vil bli mindre, men i verste fall ender vi hvertfall opp med mindre kode. Dette er bare endringer av imports, så skal ikke påvirke noe. Annet enn dette er det bare `jsx`-propertien i `tsconfig` som har endret seg.