### PR TITLE
Call yarn format after when calling generate-gql-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "now-build": "npm run build",
     "now-start": "cross-env NODE_ENV=production NOW=true node build/server | bunyan",
     "get-gql-schema-local": "apollo schema:download --endpoint=http://localhost:4000/graphql-api/graphql src/gqlSchema.json",
-    "generate-gql-types": "graphql-codegen --config codegen.yml",
+    "generate-gql-types": "graphql-codegen --config codegen.yml && yarn format",
     "check-translations": "cross-env BABEL_ENV=test NODE_ENV=unittest jest src/messages/__tests__/"
   },
   "jest": {


### PR DESCRIPTION
Litt overkill å formatere hele prosjektet når man genererer typer, men da slipper vi den obligatoriske "fmt"-commiten. 