### PR TITLE
Add title to text tab in article license box

### DIFF
--- a/src/components/license/LicenseBox.tsx
+++ b/src/components/license/LicenseBox.tsx
@@ -44,6 +44,7 @@ function buildLicenseTabList(
       <TextLicenseList
         texts={[
           {
+            title: article.title,
             copyright: article.copyright,
             updated: article.published,
             copyText: article.metaData?.copyText,

--- a/src/components/license/TextLicenseList.tsx
+++ b/src/components/license/TextLicenseList.tsx
@@ -35,6 +35,13 @@ const TextLicenseInfo = ({ text, locale }: TextLicenseInfoProps) => {
   const { t } = useTranslation();
   const safeCopyright = licenseCopyrightToCopyrightType(text.copyright);
   const items = getGroupedContributorDescriptionList(safeCopyright, locale);
+  if (text.title) {
+    items.unshift({
+      label: t('title'),
+      description: text.title,
+      metaType: metaTypes.other,
+    });
+  }
   items.push({
     label: t('license.text.published'),
     description: text.updated,
@@ -72,6 +79,7 @@ interface TextItem {
   copyright: GQLCopyrightInfoFragment;
   updated: string;
   copyText?: string;
+  title?: string;
 }
 
 interface Props {


### PR DESCRIPTION
Tittel har ikke tidligere blitt vist før i lisensboks for tekst ved klikk på "regler for bruk".

Nå skal tittel vises dersom det finnes.

Hvordan teste:
1. Åpne en artikkel.
2. Trykk på "regler for bruk"
3. Velg fanen "tekst".
4. Tittel på artikkel skal vises øverst i den hvite boksen.