### PR TITLE
Update graphql types. Remove copyText from multiple figure types in code

### DIFF
--- a/src/components/VisualElement/VisualElementLicenseButtons.tsx
+++ b/src/components/VisualElement/VisualElementLicenseButtons.tsx
@@ -41,10 +41,7 @@ const VisualElementLicenseButtons = ({
   const { t } = useTranslation();
   const Button = StyledButton.withComponent('a');
 
-  const copyText =
-    visualElement.brightcove?.copyText ||
-    visualElement.image?.copyText ||
-    visualElement.h5p?.copyText;
+  const copyText = visualElement.image?.copyText;
 
   return (
     <>

--- a/src/components/license/ConceptLicenseList.tsx
+++ b/src/components/license/ConceptLicenseList.tsx
@@ -63,13 +63,6 @@ const ConceptLicenseInfo = ({ concept, locale }: ConceptLicenseInfoProps) => {
         <MediaListItemActions>
           <div className="c-medialist__ref">
             <MediaListItemMeta items={items} />
-            {concept.copyText && (
-              <CopyTextButton
-                stringToCopy={concept.copyText}
-                copyTitle={t('license.copyTitle')}
-                hasCopiedTitle={t('license.hasCopiedTitle')}
-              />
-            )}
             <CopyTextButton
               stringToCopy={`<iframe title="${concept.title}" aria-label="${concept.title}" height="400" width="500" frameborder="0" src="${src}" allowfullscreen=""></iframe>`}
               copyTitle={t('license.embed')}

--- a/src/components/license/H5pLicenseList.tsx
+++ b/src/components/license/H5pLicenseList.tsx
@@ -58,13 +58,6 @@ const H5pLicenseInfo = ({ h5p, locale }: H5pLicenseInfoProps) => {
         <MediaListItemActions>
           <div className="c-medialist__ref">
             <MediaListItemMeta items={items} />
-            {h5p.copyText && (
-              <CopyTextButton
-                stringToCopy={h5p.copyText}
-                copyTitle={t('license.copyTitle')}
-                hasCopiedTitle={t('license.hasCopiedTitle')}
-              />
-            )}
             <CopyTextButton
               stringToCopy={`<iframe title="${h5p.title}" aria-label="${h5p.src}" height="400" width="500" frameborder="0" src="${h5p.src}" allowfullscreen=""></iframe>`}
               copyTitle={t('license.embed')}

--- a/src/components/license/VideoLicenseList.tsx
+++ b/src/components/license/VideoLicenseList.tsx
@@ -56,13 +56,6 @@ const VideoLicenseInfo = ({ video, locale }: VideoLicenseInfoProps) => {
         <MediaListItemActions>
           <div className="c-medialist__ref">
             <MediaListItemMeta items={items} />
-            {video.copyText && (
-              <CopyTextButton
-                stringToCopy={video.copyText}
-                copyTitle={t('license.copyTitle')}
-                hasCopiedTitle={t('license.hasCopiedTitle')}
-              />
-            )}
             {video.copyright.license?.license !== 'COPYRIGHTED' && (
               <AnchorButton href={video.download} download appearance="outline">
                 {t('license.download')}

--- a/src/gqlSchema.json
+++ b/src/gqlSchema.json
@@ -339,17 +339,13 @@
             "deprecationReason": null
           },
           {
-            "name": "coverPhoto",
+            "name": "image",
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "CoverPhoto",
-                "ofType": null
-              }
+              "kind": "OBJECT",
+              "name": "ImageMetaInformation",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -4353,6 +4349,242 @@
       },
       {
         "kind": "OBJECT",
+        "name": "ImageMetaInformation",
+        "description": null,
+        "specifiedByUrl": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metaUrl",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "altText",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "imageUrl",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "size",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "contentType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "copyright",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Copyright",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tags",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "caption",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "supportedLanguages",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "ImageLicense",
         "description": null,
         "specifiedByUrl": null,
@@ -4692,18 +4924,6 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
-          },
-          {
-            "name": "copyText",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -4769,18 +4989,6 @@
                 "name": "Copyright",
                 "ofType": null
               }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "copyText",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -4940,18 +5148,6 @@
             "type": {
               "kind": "OBJECT",
               "name": "ConceptCopyright",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "copyText",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
               "ofType": null
             },
             "isDeprecated": false,
@@ -8942,18 +9138,6 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
-          },
-          {
-            "name": "copyText",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -8981,18 +9165,6 @@
           },
           {
             "name": "thumbnail",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "copyText",
             "description": null,
             "args": [],
             "type": {
@@ -11771,9 +11943,13 @@
                 "name": "page",
                 "description": null,
                 "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
                 },
                 "defaultValue": null,
                 "isDeprecated": false,
@@ -11783,9 +11959,13 @@
                 "name": "pageSize",
                 "description": null,
                 "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
                 },
                 "defaultValue": null,
                 "isDeprecated": false,
@@ -11837,9 +12017,13 @@
                 "name": "page",
                 "description": null,
                 "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
                 },
                 "defaultValue": null,
                 "isDeprecated": false,
@@ -11849,9 +12033,13 @@
                 "name": "pageSize",
                 "description": null,
                 "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
                 },
                 "defaultValue": null,
                 "isDeprecated": false,

--- a/src/graphqlTypes.ts
+++ b/src/graphqlTypes.ts
@@ -179,7 +179,6 @@ export type GQLBrightcoveElement = {
   __typename?: 'BrightcoveElement';
   account?: Maybe<Scalars['String']>;
   caption?: Maybe<Scalars['String']>;
-  copyText?: Maybe<Scalars['String']>;
   cover?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
   download?: Maybe<Scalars['String']>;
@@ -199,7 +198,6 @@ export type GQLBrightcoveIframe = {
 
 export type GQLBrightcoveLicense = {
   __typename?: 'BrightcoveLicense';
-  copyText?: Maybe<Scalars['String']>;
   copyright: GQLCopyright;
   cover?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
@@ -270,7 +268,6 @@ export type GQLConceptCopyright = {
 
 export type GQLConceptLicense = {
   __typename?: 'ConceptLicense';
-  copyText?: Maybe<Scalars['String']>;
   copyright?: Maybe<GQLConceptCopyright>;
   src?: Maybe<Scalars['String']>;
   title: Scalars['String'];
@@ -418,14 +415,12 @@ export type GQLGroupSearchResult = {
 
 export type GQLH5pElement = {
   __typename?: 'H5pElement';
-  copyText?: Maybe<Scalars['String']>;
   src?: Maybe<Scalars['String']>;
   thumbnail?: Maybe<Scalars['String']>;
 };
 
 export type GQLH5pLicense = {
   __typename?: 'H5pLicense';
-  copyText?: Maybe<Scalars['String']>;
   copyright: GQLCopyright;
   src?: Maybe<Scalars['String']>;
   thumbnail?: Maybe<Scalars['String']>;
@@ -456,6 +451,23 @@ export type GQLImageLicense = {
   copyText?: Maybe<Scalars['String']>;
   copyright: GQLCopyright;
   src: Scalars['String'];
+  title: Scalars['String'];
+};
+
+export type GQLImageMetaInformation = {
+  __typename?: 'ImageMetaInformation';
+  altText: Scalars['String'];
+  caption: Scalars['String'];
+  contentType: Scalars['String'];
+  copyright: GQLCopyright;
+  created: Scalars['String'];
+  createdBy: Scalars['String'];
+  id: Scalars['String'];
+  imageUrl: Scalars['String'];
+  metaUrl: Scalars['String'];
+  size: Scalars['Int'];
+  supportedLanguages: Array<Scalars['String']>;
+  tags: Array<Scalars['String']>;
   title: Scalars['String'];
 };
 
@@ -616,7 +628,7 @@ export type GQLName = {
 
 export type GQLPodcastMeta = {
   __typename?: 'PodcastMeta';
-  coverPhoto: GQLCoverPhoto;
+  image?: Maybe<GQLImageMetaInformation>;
   introduction: Scalars['String'];
   language: Scalars['String'];
 };
@@ -774,8 +786,8 @@ export type GQLQueryPodcastArgs = {
 };
 
 export type GQLQueryPodcastSearchArgs = {
-  page?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
+  page: Scalars['Int'];
+  pageSize: Scalars['Int'];
 };
 
 export type GQLQueryPodcastSeriesArgs = {
@@ -783,8 +795,8 @@ export type GQLQueryPodcastSeriesArgs = {
 };
 
 export type GQLQueryPodcastSeriesSearchArgs = {
-  page?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
+  page: Scalars['Int'];
+  pageSize: Scalars['Int'];
 };
 
 export type GQLQueryResourceArgs = {
@@ -1643,7 +1655,6 @@ export type GQLVisualElementInfoFragment = {
     src?: Maybe<string>;
     download?: Maybe<string>;
     uploadDate?: Maybe<string>;
-    copyText?: Maybe<string>;
     iframe?: Maybe<{
       __typename?: 'BrightcoveIframe';
       src: string;
@@ -1655,7 +1666,6 @@ export type GQLVisualElementInfoFragment = {
     __typename?: 'H5pElement';
     src?: Maybe<string>;
     thumbnail?: Maybe<string>;
-    copyText?: Maybe<string>;
   }>;
   oembed?: Maybe<{
     __typename?: 'VisualElementOembed';
@@ -1738,7 +1748,6 @@ export type GQLArticleInfoFragment = {
         __typename?: 'H5pLicense';
         title: string;
         src?: Maybe<string>;
-        copyText?: Maybe<string>;
         copyright: { __typename?: 'Copyright' } & GQLCopyrightInfoFragment;
       }>
     >;
@@ -1760,7 +1769,6 @@ export type GQLArticleInfoFragment = {
         src?: Maybe<string>;
         download?: Maybe<string>;
         uploadDate?: Maybe<string>;
-        copyText?: Maybe<string>;
         iframe?: Maybe<{
           __typename?: 'BrightcoveIframe';
           height: number;
@@ -1775,7 +1783,6 @@ export type GQLArticleInfoFragment = {
         __typename?: 'ConceptLicense';
         title: string;
         src?: Maybe<string>;
-        copyText?: Maybe<string>;
         copyright?: Maybe<
           { __typename?: 'ConceptCopyright' } & GQLConceptCopyrightInfoFragment
         >;

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -481,12 +481,10 @@ export const visualElementFragment = gql`
         width
       }
       uploadDate
-      copyText
     }
     h5p {
       src
       thumbnail
-      copyText
     }
     oembed {
       title
@@ -565,7 +563,6 @@ export const articleInfoFragment = gql`
         copyright {
           ...CopyrightInfo
         }
-        copyText
       }
       audios {
         title
@@ -590,7 +587,6 @@ export const articleInfoFragment = gql`
           ...CopyrightInfo
         }
         uploadDate
-        copyText
       }
       concepts {
         title
@@ -598,7 +594,6 @@ export const articleInfoFragment = gql`
         copyright {
           ...ConceptCopyrightInfo
         }
-        copyText
       }
     }
     competenceGoals {


### PR DESCRIPTION
Avhengig av og merges samtidig som https://github.com/NDLANO/graphql-api/pull/237

copyText er fjernet for alt bortsett fra tekst, bilde og podcast. Fjerner derfor bruken av dette.