### PR TITLE
Added colocated fragments to all LicenseBox components

### DIFF
--- a/src/components/license/AudioLicenseList.tsx
+++ b/src/components/license/AudioLicenseList.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+import { gql } from '@apollo/client';
 import { uuid } from '@ndla/util';
 import {
   MediaList,
@@ -23,12 +24,12 @@ import {
 import { useTranslation } from 'react-i18next';
 import CopyTextButton from './CopyTextButton';
 import AnchorButton from './AnchorButton';
-import { GQLAudioLicense } from '../../graphqlTypes';
+import { GQLAudioLicenseList_AudioLicenseFragment } from '../../graphqlTypes';
 import { LocaleType } from '../../interfaces';
 import { licenseCopyrightToCopyrightType } from './licenseHelpers';
 
 interface AudioLicenseInfoProps {
-  audio: GQLAudioLicense;
+  audio: GQLAudioLicenseList_AudioLicenseFragment;
   locale: LocaleType;
 }
 
@@ -88,7 +89,7 @@ const AudioLicenseInfo = ({ audio, locale }: AudioLicenseInfoProps) => {
 };
 
 interface Props {
-  audios: GQLAudioLicense[];
+  audios: GQLAudioLicenseList_AudioLicenseFragment[];
   locale: LocaleType;
 }
 
@@ -105,6 +106,34 @@ const AudioLicenseList = ({ audios, locale }: Props) => {
       </MediaList>
     </div>
   );
+};
+
+AudioLicenseList.fragments = {
+  audio: gql`
+    fragment AudioLicenseList_AudioLicense on AudioLicense {
+      src
+      copyText
+      title
+      copyright {
+        origin
+        license {
+          license
+        }
+        creators {
+          name
+          type
+        }
+        processors {
+          name
+          type
+        }
+        rightsholders {
+          name
+          type
+        }
+      }
+    }
+  `,
 };
 
 export default AudioLicenseList;

--- a/src/components/license/AudioLicenseList.tsx
+++ b/src/components/license/AudioLicenseList.tsx
@@ -27,6 +27,7 @@ import AnchorButton from './AnchorButton';
 import { GQLAudioLicenseList_AudioLicenseFragment } from '../../graphqlTypes';
 import { LocaleType } from '../../interfaces';
 import { licenseCopyrightToCopyrightType } from './licenseHelpers';
+import { licenseListCopyrightFragment } from './licenseFragments';
 
 interface AudioLicenseInfoProps {
   audio: GQLAudioLicenseList_AudioLicenseFragment;
@@ -116,23 +117,10 @@ AudioLicenseList.fragments = {
       title
       copyright {
         origin
-        license {
-          license
-        }
-        creators {
-          name
-          type
-        }
-        processors {
-          name
-          type
-        }
-        rightsholders {
-          name
-          type
-        }
+        ...LicenseListCopyright
       }
     }
+    ${licenseListCopyrightFragment}
   `,
 };
 

--- a/src/components/license/ConceptLicenseList.tsx
+++ b/src/components/license/ConceptLicenseList.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+import { gql } from '@apollo/client';
 import {
   MediaList,
   MediaListItem,
@@ -21,12 +22,12 @@ import {
 import { Concept } from '@ndla/icons/editor';
 import { useTranslation } from 'react-i18next';
 import CopyTextButton from './CopyTextButton';
-import { GQLConceptLicense } from '../../graphqlTypes';
+import { GQLConceptLicenseList_ConceptLicenseFragment } from '../../graphqlTypes';
 import { LocaleType } from '../../interfaces';
 import { licenseCopyrightToCopyrightType } from './licenseHelpers';
 
 interface ConceptLicenseInfoProps {
-  concept: GQLConceptLicense;
+  concept: GQLConceptLicenseList_ConceptLicenseFragment;
   locale: LocaleType;
 }
 
@@ -76,7 +77,7 @@ const ConceptLicenseInfo = ({ concept, locale }: ConceptLicenseInfoProps) => {
 };
 
 interface Props {
-  concepts: GQLConceptLicense[];
+  concepts: GQLConceptLicenseList_ConceptLicenseFragment[];
   locale: LocaleType;
 }
 
@@ -93,6 +94,32 @@ const ConceptLicenseList = ({ concepts, locale }: Props) => {
       </MediaList>
     </div>
   );
+};
+
+ConceptLicenseList.fragments = {
+  concept: gql`
+    fragment ConceptLicenseList_ConceptLicense on ConceptLicense {
+      title
+      src
+      copyright {
+        license {
+          license
+        }
+        creators {
+          name
+          type
+        }
+        processors {
+          name
+          type
+        }
+        rightsholders {
+          name
+          type
+        }
+      }
+    }
+  `,
 };
 
 export default ConceptLicenseList;

--- a/src/components/license/H5pLicenseList.tsx
+++ b/src/components/license/H5pLicenseList.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+import { gql } from '@apollo/client';
 import { uuid } from '@ndla/util';
 import {
   MediaList,
@@ -21,13 +22,13 @@ import {
 } from '@ndla/licenses';
 import { H5PBold } from '@ndla/icons/editor';
 import { useTranslation } from 'react-i18next';
-import { GQLH5pLicense } from '../../graphqlTypes';
+import { GQLH5pLicenseList_H5pLicenseFragment } from '../../graphqlTypes';
 import CopyTextButton from './CopyTextButton';
 import { LocaleType } from '../../interfaces';
 import { licenseCopyrightToCopyrightType } from './licenseHelpers';
 
 interface H5pLicenseInfoProps {
-  h5p: GQLH5pLicense;
+  h5p: GQLH5pLicenseList_H5pLicenseFragment;
   locale: LocaleType;
 }
 
@@ -71,7 +72,7 @@ const H5pLicenseInfo = ({ h5p, locale }: H5pLicenseInfoProps) => {
 };
 
 interface Props {
-  h5ps: GQLH5pLicense[];
+  h5ps: GQLH5pLicenseList_H5pLicenseFragment[];
   locale: LocaleType;
 }
 
@@ -88,6 +89,32 @@ const H5pLicenseList = ({ h5ps, locale }: Props) => {
       </MediaList>
     </div>
   );
+};
+
+H5pLicenseList.fragments = {
+  h5p: gql`
+    fragment H5pLicenseList_H5pLicense on H5pLicense {
+      title
+      src
+      copyright {
+        license {
+          license
+        }
+        creators {
+          name
+          type
+        }
+        processors {
+          name
+          type
+        }
+        rightsholders {
+          name
+          type
+        }
+      }
+    }
+  `,
 };
 
 export default H5pLicenseList;

--- a/src/components/license/H5pLicenseList.tsx
+++ b/src/components/license/H5pLicenseList.tsx
@@ -26,6 +26,7 @@ import { GQLH5pLicenseList_H5pLicenseFragment } from '../../graphqlTypes';
 import CopyTextButton from './CopyTextButton';
 import { LocaleType } from '../../interfaces';
 import { licenseCopyrightToCopyrightType } from './licenseHelpers';
+import { licenseListCopyrightFragment } from './licenseFragments';
 
 interface H5pLicenseInfoProps {
   h5p: GQLH5pLicenseList_H5pLicenseFragment;
@@ -97,23 +98,10 @@ H5pLicenseList.fragments = {
       title
       src
       copyright {
-        license {
-          license
-        }
-        creators {
-          name
-          type
-        }
-        processors {
-          name
-          type
-        }
-        rightsholders {
-          name
-          type
-        }
+        ...LicenseListCopyright
       }
     }
+    ${licenseListCopyrightFragment}
   `,
 };
 

--- a/src/components/license/ImageLicenseList.tsx
+++ b/src/components/license/ImageLicenseList.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+import { gql } from '@apollo/client';
 import { uuid } from '@ndla/util';
 import {
   Image,
@@ -24,7 +25,7 @@ import queryString from 'query-string';
 import { useTranslation } from 'react-i18next';
 import CopyTextButton from './CopyTextButton';
 import AnchorButton from './AnchorButton';
-import { GQLImageLicense } from '../../graphqlTypes';
+import { GQLImageLicenseList_ImageLicenseFragment } from '../../graphqlTypes';
 import { LocaleType } from '../../interfaces';
 import { licenseCopyrightToCopyrightType } from './licenseHelpers';
 
@@ -37,7 +38,7 @@ export const downloadUrl = (imageSrc: string) => {
 };
 
 interface ImageLicenseInfoProps {
-  image: GQLImageLicense;
+  image: GQLImageLicenseList_ImageLicenseFragment;
   locale: LocaleType;
 }
 
@@ -101,7 +102,7 @@ const ImageLicenseInfo = ({ image, locale }: ImageLicenseInfoProps) => {
 };
 
 interface Props {
-  images: GQLImageLicense[];
+  images: GQLImageLicenseList_ImageLicenseFragment[];
   locale: LocaleType;
 }
 
@@ -118,6 +119,35 @@ const ImageLicenseList = ({ images, locale }: Props) => {
       </MediaList>
     </div>
   );
+};
+
+ImageLicenseList.fragments = {
+  image: gql`
+    fragment ImageLicenseList_ImageLicense on ImageLicense {
+      title
+      altText
+      src
+      copyText
+      copyright {
+        origin
+        license {
+          license
+        }
+        creators {
+          name
+          type
+        }
+        processors {
+          name
+          type
+        }
+        rightsholders {
+          name
+          type
+        }
+      }
+    }
+  `,
 };
 
 export default ImageLicenseList;

--- a/src/components/license/ImageLicenseList.tsx
+++ b/src/components/license/ImageLicenseList.tsx
@@ -28,6 +28,7 @@ import AnchorButton from './AnchorButton';
 import { GQLImageLicenseList_ImageLicenseFragment } from '../../graphqlTypes';
 import { LocaleType } from '../../interfaces';
 import { licenseCopyrightToCopyrightType } from './licenseHelpers';
+import { licenseListCopyrightFragment } from './licenseFragments';
 
 export const downloadUrl = (imageSrc: string) => {
   const urlObject = queryString.parseUrl(imageSrc);
@@ -130,23 +131,10 @@ ImageLicenseList.fragments = {
       copyText
       copyright {
         origin
-        license {
-          license
-        }
-        creators {
-          name
-          type
-        }
-        processors {
-          name
-          type
-        }
-        rightsholders {
-          name
-          type
-        }
+        ...LicenseListCopyright
       }
     }
+    ${licenseListCopyrightFragment}
   `,
 };
 

--- a/src/components/license/LicenseBox.tsx
+++ b/src/components/license/LicenseBox.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+import { gql } from '@apollo/client';
 import Tabs from '@ndla/tabs';
 import { useTranslation, TFunction } from 'react-i18next';
 import ImageLicenseList from './ImageLicenseList';
@@ -15,11 +16,11 @@ import VideoLicenseList from './VideoLicenseList';
 import H5pLicenseList from './H5pLicenseList';
 import ConceptLicenseList from './ConceptLicenseList';
 import OembedItem from './OembedItem';
-import { GQLArticleInfoFragment } from '../../graphqlTypes';
+import { GQLLicenseBox_ArticleFragment } from '../../graphqlTypes';
 import { LocaleType } from '../../interfaces';
 
 function buildLicenseTabList(
-  article: GQLArticleInfoFragment,
+  article: GQLLicenseBox_ArticleFragment,
   locale: LocaleType,
   t: TFunction,
 ) {
@@ -93,7 +94,7 @@ function buildLicenseTabList(
 }
 
 interface Props {
-  article: GQLArticleInfoFragment;
+  article: GQLLicenseBox_ArticleFragment;
   locale: LocaleType;
 }
 
@@ -106,6 +107,43 @@ const LicenseBox = ({ article, locale }: Props) => {
       <Tabs tabs={tabs} />
     </div>
   );
+};
+
+LicenseBox.fragments = {
+  article: gql`
+    fragment LicenseBox_Article on Article {
+      title
+      oembed
+      published
+      copyright {
+        ...TextLicenseList_Copyright
+      }
+      metaData {
+        copyText
+        concepts {
+          ...ConceptLicenseList_ConceptLicense
+        }
+        h5ps {
+          ...H5pLicenseList_H5pLicense
+        }
+        brightcoves {
+          ...VideoLicenseList_BrightcoveLicense
+        }
+        audios {
+          ...AudioLicenseList_AudioLicense
+        }
+        images {
+          ...ImageLicenseList_ImageLicense
+        }
+      }
+    }
+    ${ConceptLicenseList.fragments.concept}
+    ${H5pLicenseList.fragments.h5p}
+    ${VideoLicenseList.fragments.video}
+    ${AudioLicenseList.fragments.audio}
+    ${ImageLicenseList.fragments.image}
+    ${TextLicenseList.fragments.copyright}
+  `,
 };
 
 export default LicenseBox;

--- a/src/components/license/TextLicenseList.tsx
+++ b/src/components/license/TextLicenseList.tsx
@@ -26,6 +26,7 @@ import CopyTextButton from './CopyTextButton';
 import { GQLTextLicenseList_CopyrightFragment } from '../../graphqlTypes';
 import { LocaleType } from '../../interfaces';
 import { licenseCopyrightToCopyrightType } from './licenseHelpers';
+import { licenseListCopyrightFragment } from './licenseFragments';
 
 interface TextLicenseInfoProps {
   text: TextItem;
@@ -105,22 +106,9 @@ const TextLicenseList = ({ texts, locale }: Props) => {
 TextLicenseList.fragments = {
   copyright: gql`
     fragment TextLicenseList_Copyright on Copyright {
-      license {
-        license
-      }
-      creators {
-        name
-        type
-      }
-      processors {
-        name
-        type
-      }
-      rightsholders {
-        name
-        type
-      }
+      ...LicenseListCopyright
     }
+    ${licenseListCopyrightFragment}
   `,
 };
 

--- a/src/components/license/TextLicenseList.tsx
+++ b/src/components/license/TextLicenseList.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+import { gql } from '@apollo/client';
 import { uuid } from '@ndla/util';
 import {
   MediaList,
@@ -22,7 +23,7 @@ import {
 import { FileDocumentOutline } from '@ndla/icons/common';
 import { useTranslation } from 'react-i18next';
 import CopyTextButton from './CopyTextButton';
-import { GQLCopyrightInfoFragment } from '../../graphqlTypes';
+import { GQLTextLicenseList_CopyrightFragment } from '../../graphqlTypes';
 import { LocaleType } from '../../interfaces';
 import { licenseCopyrightToCopyrightType } from './licenseHelpers';
 
@@ -75,7 +76,7 @@ const TextLicenseInfo = ({ text, locale }: TextLicenseInfoProps) => {
 };
 
 interface TextItem {
-  copyright: GQLCopyrightInfoFragment;
+  copyright: GQLTextLicenseList_CopyrightFragment;
   updated: string;
   copyText?: string;
   title?: string;
@@ -99,6 +100,28 @@ const TextLicenseList = ({ texts, locale }: Props) => {
       </MediaList>
     </div>
   );
+};
+
+TextLicenseList.fragments = {
+  copyright: gql`
+    fragment TextLicenseList_Copyright on Copyright {
+      license {
+        license
+      }
+      creators {
+        name
+        type
+      }
+      processors {
+        name
+        type
+      }
+      rightsholders {
+        name
+        type
+      }
+    }
+  `,
 };
 
 export default TextLicenseList;

--- a/src/components/license/VideoLicenseList.tsx
+++ b/src/components/license/VideoLicenseList.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+import { gql } from '@apollo/client';
 import { uuid } from '@ndla/util';
 import {
   MediaList,
@@ -22,12 +23,12 @@ import {
 import { useTranslation } from 'react-i18next';
 import CopyTextButton from './CopyTextButton';
 import AnchorButton from './AnchorButton';
-import { GQLBrightcoveLicense } from '../../graphqlTypes';
+import { GQLVideoLicenseList_BrightcoveLicenseFragment } from '../../graphqlTypes';
 import { LocaleType } from '../../interfaces';
 import { licenseCopyrightToCopyrightType } from './licenseHelpers';
 
 interface VideoLicenseInfoProps {
-  video: GQLBrightcoveLicense;
+  video: GQLVideoLicenseList_BrightcoveLicenseFragment;
   locale: LocaleType;
 }
 
@@ -74,7 +75,7 @@ const VideoLicenseInfo = ({ video, locale }: VideoLicenseInfoProps) => {
 };
 
 interface Props {
-  videos: GQLBrightcoveLicense[];
+  videos: GQLVideoLicenseList_BrightcoveLicenseFragment[];
   locale: LocaleType;
 }
 
@@ -91,6 +92,39 @@ const VideoLicenseList = ({ videos, locale }: Props) => {
       </MediaList>
     </div>
   );
+};
+
+VideoLicenseList.fragments = {
+  video: gql`
+    fragment VideoLicenseList_BrightcoveLicense on BrightcoveLicense {
+      title
+      download
+      src
+      cover
+      iframe {
+        width
+        height
+        src
+      }
+      copyright {
+        license {
+          license
+        }
+        creators {
+          name
+          type
+        }
+        processors {
+          name
+          type
+        }
+        rightsholders {
+          name
+          type
+        }
+      }
+    }
+  `,
 };
 
 export default VideoLicenseList;

--- a/src/components/license/VideoLicenseList.tsx
+++ b/src/components/license/VideoLicenseList.tsx
@@ -26,6 +26,7 @@ import AnchorButton from './AnchorButton';
 import { GQLVideoLicenseList_BrightcoveLicenseFragment } from '../../graphqlTypes';
 import { LocaleType } from '../../interfaces';
 import { licenseCopyrightToCopyrightType } from './licenseHelpers';
+import { licenseListCopyrightFragment } from './licenseFragments';
 
 interface VideoLicenseInfoProps {
   video: GQLVideoLicenseList_BrightcoveLicenseFragment;
@@ -107,23 +108,10 @@ VideoLicenseList.fragments = {
         src
       }
       copyright {
-        license {
-          license
-        }
-        creators {
-          name
-          type
-        }
-        processors {
-          name
-          type
-        }
-        rightsholders {
-          name
-          type
-        }
+        ...LicenseListCopyright
       }
     }
+    ${licenseListCopyrightFragment}
   `,
 };
 

--- a/src/components/license/licenseFragments.ts
+++ b/src/components/license/licenseFragments.ts
@@ -1,0 +1,21 @@
+import { gql } from '@apollo/client';
+
+export const licenseListCopyrightFragment = gql`
+  fragment LicenseListCopyright on Copyright {
+    license {
+      license
+    }
+    creators {
+      name
+      type
+    }
+    processors {
+      name
+      type
+    }
+    rightsholders {
+      name
+      type
+    }
+  }
+`;

--- a/src/components/license/licenseHelpers.ts
+++ b/src/components/license/licenseHelpers.ts
@@ -6,10 +6,14 @@
  *
  */
 
-import { GQLConceptCopyright, GQLCopyright } from '../../graphqlTypes';
+import { GQLCopyright } from '../../graphqlTypes';
 
-export const licenseCopyrightToCopyrightType = (
-  copyright: GQLCopyright | GQLConceptCopyright | undefined,
+type BaseCopyright = Pick<
+  GQLCopyright,
+  'creators' | 'processors' | 'rightsholders'
+>;
+export const licenseCopyrightToCopyrightType = <T extends BaseCopyright>(
+  copyright: T | undefined,
 ) => {
   const processors = copyright?.processors ?? [];
   const rightsholders = copyright?.rightsholders ?? [];

--- a/src/graphqlTypes.ts
+++ b/src/graphqlTypes.ts
@@ -1185,6 +1185,183 @@ export type GQLSubjectLinkListSubjectFragment = {
   name: string;
 };
 
+export type GQLAudioLicenseList_AudioLicenseFragment = {
+  __typename?: 'AudioLicense';
+  src: string;
+  copyText?: Maybe<string>;
+  title: string;
+  copyright: {
+    __typename?: 'Copyright';
+    origin?: Maybe<string>;
+    license: { __typename?: 'License'; license: string };
+    creators: Array<{ __typename?: 'Contributor'; name: string; type: string }>;
+    processors: Array<{
+      __typename?: 'Contributor';
+      name: string;
+      type: string;
+    }>;
+    rightsholders: Array<{
+      __typename?: 'Contributor';
+      name: string;
+      type: string;
+    }>;
+  };
+};
+
+export type GQLConceptLicenseList_ConceptLicenseFragment = {
+  __typename?: 'ConceptLicense';
+  title: string;
+  src?: Maybe<string>;
+  copyright?: Maybe<{
+    __typename?: 'ConceptCopyright';
+    license?: Maybe<{ __typename?: 'License'; license: string }>;
+    creators: Array<{ __typename?: 'Contributor'; name: string; type: string }>;
+    processors: Array<{
+      __typename?: 'Contributor';
+      name: string;
+      type: string;
+    }>;
+    rightsholders: Array<{
+      __typename?: 'Contributor';
+      name: string;
+      type: string;
+    }>;
+  }>;
+};
+
+export type GQLH5pLicenseList_H5pLicenseFragment = {
+  __typename?: 'H5pLicense';
+  title: string;
+  src?: Maybe<string>;
+  copyright: {
+    __typename?: 'Copyright';
+    license: { __typename?: 'License'; license: string };
+    creators: Array<{ __typename?: 'Contributor'; name: string; type: string }>;
+    processors: Array<{
+      __typename?: 'Contributor';
+      name: string;
+      type: string;
+    }>;
+    rightsholders: Array<{
+      __typename?: 'Contributor';
+      name: string;
+      type: string;
+    }>;
+  };
+};
+
+export type GQLImageLicenseList_ImageLicenseFragment = {
+  __typename?: 'ImageLicense';
+  title: string;
+  altText: string;
+  src: string;
+  copyText?: Maybe<string>;
+  copyright: {
+    __typename?: 'Copyright';
+    origin?: Maybe<string>;
+    license: { __typename?: 'License'; license: string };
+    creators: Array<{ __typename?: 'Contributor'; name: string; type: string }>;
+    processors: Array<{
+      __typename?: 'Contributor';
+      name: string;
+      type: string;
+    }>;
+    rightsholders: Array<{
+      __typename?: 'Contributor';
+      name: string;
+      type: string;
+    }>;
+  };
+};
+
+export type GQLLicenseBox_ArticleFragment = {
+  __typename?: 'Article';
+  title: string;
+  oembed?: Maybe<string>;
+  published: string;
+  copyright: {
+    __typename?: 'Copyright';
+  } & GQLTextLicenseList_CopyrightFragment;
+  metaData?: Maybe<{
+    __typename?: 'ArticleMetaData';
+    copyText?: Maybe<string>;
+    concepts?: Maybe<
+      Array<
+        {
+          __typename?: 'ConceptLicense';
+        } & GQLConceptLicenseList_ConceptLicenseFragment
+      >
+    >;
+    h5ps?: Maybe<
+      Array<
+        { __typename?: 'H5pLicense' } & GQLH5pLicenseList_H5pLicenseFragment
+      >
+    >;
+    brightcoves?: Maybe<
+      Array<
+        {
+          __typename?: 'BrightcoveLicense';
+        } & GQLVideoLicenseList_BrightcoveLicenseFragment
+      >
+    >;
+    audios?: Maybe<
+      Array<
+        {
+          __typename?: 'AudioLicense';
+        } & GQLAudioLicenseList_AudioLicenseFragment
+      >
+    >;
+    images?: Maybe<
+      Array<
+        {
+          __typename?: 'ImageLicense';
+        } & GQLImageLicenseList_ImageLicenseFragment
+      >
+    >;
+  }>;
+};
+
+export type GQLTextLicenseList_CopyrightFragment = {
+  __typename?: 'Copyright';
+  license: { __typename?: 'License'; license: string };
+  creators: Array<{ __typename?: 'Contributor'; name: string; type: string }>;
+  processors: Array<{ __typename?: 'Contributor'; name: string; type: string }>;
+  rightsholders: Array<{
+    __typename?: 'Contributor';
+    name: string;
+    type: string;
+  }>;
+};
+
+export type GQLVideoLicenseList_BrightcoveLicenseFragment = {
+  __typename?: 'BrightcoveLicense';
+  title: string;
+  download?: Maybe<string>;
+  src?: Maybe<string>;
+  cover?: Maybe<string>;
+  iframe?: Maybe<{
+    __typename?: 'BrightcoveIframe';
+    width: number;
+    height: number;
+    src: string;
+  }>;
+  copyright: {
+    __typename?: 'Copyright';
+    license: { __typename?: 'License'; license: string };
+    creators: Array<{ __typename?: 'Contributor'; name: string; type: string }>;
+    processors: Array<{
+      __typename?: 'Contributor';
+      name: string;
+      type: string;
+    }>;
+    rightsholders: Array<{
+      __typename?: 'Contributor';
+      name: string;
+      type: string;
+    }>;
+  };
+};
+
 export type GQLAllSubjectsQueryVariables = Exact<{ [key: string]: never }>;
 
 export type GQLAllSubjectsQuery = {

--- a/src/graphqlTypes.ts
+++ b/src/graphqlTypes.ts
@@ -1193,19 +1193,7 @@ export type GQLAudioLicenseList_AudioLicenseFragment = {
   copyright: {
     __typename?: 'Copyright';
     origin?: Maybe<string>;
-    license: { __typename?: 'License'; license: string };
-    creators: Array<{ __typename?: 'Contributor'; name: string; type: string }>;
-    processors: Array<{
-      __typename?: 'Contributor';
-      name: string;
-      type: string;
-    }>;
-    rightsholders: Array<{
-      __typename?: 'Contributor';
-      name: string;
-      type: string;
-    }>;
-  };
+  } & GQLLicenseListCopyrightFragment;
 };
 
 export type GQLConceptLicenseList_ConceptLicenseFragment = {
@@ -1233,21 +1221,7 @@ export type GQLH5pLicenseList_H5pLicenseFragment = {
   __typename?: 'H5pLicense';
   title: string;
   src?: Maybe<string>;
-  copyright: {
-    __typename?: 'Copyright';
-    license: { __typename?: 'License'; license: string };
-    creators: Array<{ __typename?: 'Contributor'; name: string; type: string }>;
-    processors: Array<{
-      __typename?: 'Contributor';
-      name: string;
-      type: string;
-    }>;
-    rightsholders: Array<{
-      __typename?: 'Contributor';
-      name: string;
-      type: string;
-    }>;
-  };
+  copyright: { __typename?: 'Copyright' } & GQLLicenseListCopyrightFragment;
 };
 
 export type GQLImageLicenseList_ImageLicenseFragment = {
@@ -1259,19 +1233,7 @@ export type GQLImageLicenseList_ImageLicenseFragment = {
   copyright: {
     __typename?: 'Copyright';
     origin?: Maybe<string>;
-    license: { __typename?: 'License'; license: string };
-    creators: Array<{ __typename?: 'Contributor'; name: string; type: string }>;
-    processors: Array<{
-      __typename?: 'Contributor';
-      name: string;
-      type: string;
-    }>;
-    rightsholders: Array<{
-      __typename?: 'Contributor';
-      name: string;
-      type: string;
-    }>;
-  };
+  } & GQLLicenseListCopyrightFragment;
 };
 
 export type GQLLicenseBox_ArticleFragment = {
@@ -1323,15 +1285,7 @@ export type GQLLicenseBox_ArticleFragment = {
 
 export type GQLTextLicenseList_CopyrightFragment = {
   __typename?: 'Copyright';
-  license: { __typename?: 'License'; license: string };
-  creators: Array<{ __typename?: 'Contributor'; name: string; type: string }>;
-  processors: Array<{ __typename?: 'Contributor'; name: string; type: string }>;
-  rightsholders: Array<{
-    __typename?: 'Contributor';
-    name: string;
-    type: string;
-  }>;
-};
+} & GQLLicenseListCopyrightFragment;
 
 export type GQLVideoLicenseList_BrightcoveLicenseFragment = {
   __typename?: 'BrightcoveLicense';
@@ -1345,21 +1299,19 @@ export type GQLVideoLicenseList_BrightcoveLicenseFragment = {
     height: number;
     src: string;
   }>;
-  copyright: {
-    __typename?: 'Copyright';
-    license: { __typename?: 'License'; license: string };
-    creators: Array<{ __typename?: 'Contributor'; name: string; type: string }>;
-    processors: Array<{
-      __typename?: 'Contributor';
-      name: string;
-      type: string;
-    }>;
-    rightsholders: Array<{
-      __typename?: 'Contributor';
-      name: string;
-      type: string;
-    }>;
-  };
+  copyright: { __typename?: 'Copyright' } & GQLLicenseListCopyrightFragment;
+};
+
+export type GQLLicenseListCopyrightFragment = {
+  __typename?: 'Copyright';
+  license: { __typename?: 'License'; license: string };
+  creators: Array<{ __typename?: 'Contributor'; name: string; type: string }>;
+  processors: Array<{ __typename?: 'Contributor'; name: string; type: string }>;
+  rightsholders: Array<{
+    __typename?: 'Contributor';
+    name: string;
+    type: string;
+  }>;
 };
 
 export type GQLAllSubjectsQueryVariables = Exact<{ [key: string]: never }>;


### PR DESCRIPTION
Prøver å unngå en massiv PR med colocated fragments, så inntil videre har ikke dette noen umiddelbar effekt annet enn at typene endrer seg.

Bør også nevnes at jeg foreslår en navngivningskonvensjon på colocated fragments her: Tanken inntil videre er `$componentName_$schemaType`. Dersom man lager en fragment på `Article` i komponenten `LicenseBox` vil navnet da være `LicenseBox_Article`, mens det genererte typenavnet vil være `GQLLicenseBox_ArticleFragment`. På sikt kunne vi endret autogenererte navn til å være `LicenseBox_Article`, så lenge vi sier at underscore kun skal brukes i GQL-typer.