### PR TITLE
Topic colocation

### DIFF
--- a/src/components/Article/ArticleContents.tsx
+++ b/src/components/Article/ArticleContents.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+import { gql } from '@apollo/client';
 import { useMemo } from 'react';
 import { Remarkable } from 'remarkable';
 import {
@@ -20,11 +21,11 @@ import {
 
 import LicenseBox from '../license/LicenseBox';
 import { transformArticle } from '../../util/transformArticle';
-import { GQLTopicQueryTopicFragment } from '../../graphqlTypes';
+import { GQLArticleContents_TopicFragment } from '../../graphqlTypes';
 import { LocaleType } from '../../interfaces';
 
 interface Props {
-  topic: GQLTopicQueryTopicFragment;
+  topic: GQLArticleContents_TopicFragment;
   copyPageUrlLink: string;
   locale: LocaleType;
   modifier: 'clean' | 'in-topic';
@@ -85,6 +86,33 @@ const ArticleContents = ({
       </LayoutItem>
     </ArticleWrapper>
   );
+};
+
+ArticleContents.fragments = {
+  topic: gql`
+    fragment ArticleContents_Topic on Topic {
+      article {
+        id
+        content
+        created
+        updated
+        introduction
+        metaData {
+          footnotes {
+            ref
+            authors
+            edition
+            publisher
+            year
+            url
+            title
+          }
+        }
+        ...LicenseBox_Article
+      }
+    }
+    ${LicenseBox.fragments.article}
+  `,
 };
 
 export default ArticleContents;

--- a/src/containers/Resources/Resources.tsx
+++ b/src/containers/Resources/Resources.tsx
@@ -9,7 +9,7 @@
 import { gql } from '@apollo/client';
 import { useEffect, useState } from 'react';
 import { ResourcesWrapper, ResourcesTopicTitle, ResourceGroup } from '@ndla/ui';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { useRouteMatch } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { contentTypeMapping } from '../../util/getContentType';
 import { getResourceGroups, sortResourceTypes } from './getResourceGroups';
@@ -29,17 +29,13 @@ interface MatchProps {
   resourceId?: string;
 }
 
-interface Props extends RouteComponentProps<MatchProps> {
+interface Props {
   topic: GQLResources_TopicFragment;
   resourceTypes?: GQLResources_ResourceTypeDefinitionFragment[];
   ndlaFilm?: boolean;
 }
-const Resources = ({
-  match: { params },
-  topic,
-  resourceTypes,
-  ndlaFilm,
-}: Props) => {
+const Resources = ({ topic, resourceTypes, ndlaFilm }: Props) => {
+  const { params } = useRouteMatch<MatchProps>();
   const [showAdditionalResources, setShowAdditionalResources] = useState(false);
   const { t } = useTranslation();
 
@@ -183,25 +179,26 @@ const Resources = ({
   );
 };
 
+const resourceFragment = gql`
+  fragment Resources_Resource on Resource {
+    id
+    name
+    contentUri
+    path
+    paths
+    rank
+    resourceTypes {
+      id
+      name
+    }
+  }
+`;
+
 Resources.fragments = {
   resourceType: gql`
     fragment Resources_ResourceTypeDefinition on ResourceTypeDefinition {
       id
       name
-    }
-  `,
-  resource: gql`
-    fragment Resources_Resource on Resource {
-      id
-      name
-      contentUri
-      path
-      paths
-      rank
-      resourceTypes {
-        id
-        name
-      }
     }
   `,
   topic: gql`
@@ -217,7 +214,8 @@ Resources.fragments = {
         customFields
       }
     }
+    ${resourceFragment}
   `,
 };
 
-export default withRouter(Resources);
+export default Resources;

--- a/src/containers/SubjectPage/components/Topic.tsx
+++ b/src/containers/SubjectPage/components/Topic.tsx
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+
+import { gql } from '@apollo/client';
 import { useEffect, useMemo, useState, MouseEvent } from 'react';
 import { Remarkable } from 'remarkable';
 import { TFunction, withTranslation, WithTranslation } from 'react-i18next';
@@ -25,15 +27,15 @@ import {
 } from '../../../util/imageHelpers';
 import { getSubjectLongName } from '../../../data/subjects';
 import {
-  GQLResourceTypeDefinition,
-  GQLTopicQueryTopicFragment,
+  GQLTopic_ResourceTypeDefinitionFragment,
+  GQLTopic_SubjectFragment,
+  GQLTopic_TopicFragment,
 } from '../../../graphqlTypes';
 import { LocaleType } from '../../../interfaces';
 import VisualElementWrapper, {
   getResourceType,
 } from '../../../components/VisualElement/VisualElementWrapper';
 import { FeideUserWithGroups } from '../../../util/feideApi';
-import { GQLSubjectContainerType } from '../SubjectContainer';
 
 const getDocumentTitle = ({
   t,
@@ -54,10 +56,10 @@ type Props = {
   onClickTopics: (e: MouseEvent<HTMLAnchorElement>) => void;
   index?: number;
   showResources?: boolean;
-  subject?: GQLSubjectContainerType;
+  subject?: GQLTopic_SubjectFragment;
   loading?: boolean;
-  topic: GQLTopicQueryTopicFragment;
-  resourceTypes?: Array<GQLResourceTypeDefinition>;
+  topic: GQLTopic_TopicFragment;
+  resourceTypes?: GQLTopic_ResourceTypeDefinitionFragment[];
   user?: FeideUserWithGroups;
 } & WithTranslation;
 
@@ -208,6 +210,51 @@ Topic.getDimensions = ({ topic, locale, subject, user }: Props) => {
     undefined,
     true,
   );
+};
+
+export const topicFragments = {
+  subject: gql`
+    fragment Topic_Subject on Subject {
+      id
+      name
+      allTopics {
+        id
+        name
+      }
+    }
+  `,
+  topic: gql`
+    fragment Topic_Topic on Topic {
+      path
+      name
+      relevanceId
+      subtopics {
+        id
+        name
+        relevanceId
+      }
+      article {
+        metaImage {
+          url
+          alt
+        }
+        visualElement {
+          ...VisualElementWrapper_VisualElement
+        }
+      }
+      ...ArticleContents_Topic
+      ...Resources_Topic
+    }
+    ${VisualElementWrapper.fragments.visualElement}
+    ${ArticleContents.fragments.topic}
+    ${Resources.fragments.topic}
+  `,
+  resourceType: gql`
+    fragment Topic_ResourceTypeDefinition on ResourceTypeDefinition {
+      ...Resources_ResourceTypeDefinition
+    }
+    ${Resources.fragments.resourceType}
+  `,
 };
 
 export default withTranslation()(withTracker(Topic));

--- a/src/containers/SubjectPage/components/TopicWrapper.tsx
+++ b/src/containers/SubjectPage/components/TopicWrapper.tsx
@@ -1,14 +1,17 @@
+import { gql } from '@apollo/client';
 import { useContext, useEffect, MouseEvent } from 'react';
 import { useHistory, useLocation } from 'react-router';
 import { withTranslation, WithTranslation } from 'react-i18next';
 import Spinner from '@ndla/ui/lib/Spinner';
 import { AuthContext } from '../../../components/AuthenticationContext';
-import Topic from './Topic';
-import { topicQuery } from '../../../queries';
+import Topic, { topicFragments } from './Topic';
 import { useGraphQuery } from '../../../util/runQueries';
 import handleError, { isAccessDeniedError } from '../../../util/handleError';
 import { BreadcrumbItem, LocaleType } from '../../../interfaces';
-import { GQLTopicQuery, GQLTopicQueryVariables } from '../../../graphqlTypes';
+import {
+  GQLTopicWrapperQuery,
+  GQLTopicWrapperQueryVariables,
+} from '../../../graphqlTypes';
 import { GQLSubjectContainerType } from '../SubjectContainer';
 
 type Props = {
@@ -23,6 +26,20 @@ type Props = {
   showResources: boolean;
   subject: GQLSubjectContainerType;
 } & WithTranslation;
+
+const topicWrapperQuery = gql`
+  query topicWrapper($topicId: String!, $subjectId: String) {
+    topic(id: $topicId, subjectId: $subjectId) {
+      id
+      ...Topic_Topic
+    }
+    resourceTypes {
+      ...Topic_ResourceTypeDefinition
+    }
+  }
+  ${topicFragments.topic}
+  ${topicFragments.resourceType}
+`;
 
 const TopicWrapper = ({
   subTopicId,
@@ -40,9 +57,9 @@ const TopicWrapper = ({
   const history = useHistory();
   const { user } = useContext(AuthContext);
   const { data, loading, error } = useGraphQuery<
-    GQLTopicQuery,
-    GQLTopicQueryVariables
-  >(topicQuery, {
+    GQLTopicWrapperQuery,
+    GQLTopicWrapperQueryVariables
+  >(topicWrapperQuery, {
     variables: { topicId, subjectId },
     onCompleted: data => {
       if (data.topic) {

--- a/src/graphqlTypes.ts
+++ b/src/graphqlTypes.ts
@@ -1179,6 +1179,35 @@ export type GQLEmbedVisualelement = {
   visualElement?: Maybe<GQLVisualElement>;
 };
 
+export type GQLArticleContents_TopicFragment = {
+  __typename?: 'Topic';
+  article?: Maybe<
+    {
+      __typename?: 'Article';
+      id: number;
+      content: string;
+      created: string;
+      updated: string;
+      introduction?: Maybe<string>;
+      metaData?: Maybe<{
+        __typename?: 'ArticleMetaData';
+        footnotes?: Maybe<
+          Array<{
+            __typename?: 'FootNote';
+            ref: number;
+            authors: Array<string>;
+            edition?: Maybe<string>;
+            publisher?: Maybe<string>;
+            year: string;
+            url?: Maybe<string>;
+            title: string;
+          }>
+        >;
+      }>;
+    } & GQLLicenseBox_ArticleFragment
+  >;
+};
+
 export type GQLSubjectLinkListSubjectFragment = {
   __typename?: 'Subject';
   id: string;

--- a/src/graphqlTypes.ts
+++ b/src/graphqlTypes.ts
@@ -1435,12 +1435,6 @@ export type GQLAllSubjectsQuery = {
   >;
 };
 
-export type GQLResources_ResourceTypeDefinitionFragment = {
-  __typename?: 'ResourceTypeDefinition';
-  id: string;
-  name: string;
-};
-
 export type GQLResources_ResourceFragment = {
   __typename?: 'Resource';
   id: string;
@@ -1454,6 +1448,12 @@ export type GQLResources_ResourceFragment = {
   >;
 };
 
+export type GQLResources_ResourceTypeDefinitionFragment = {
+  __typename?: 'ResourceTypeDefinition';
+  id: string;
+  name: string;
+};
+
 export type GQLResources_TopicFragment = {
   __typename?: 'Topic';
   name: string;
@@ -1464,6 +1464,59 @@ export type GQLResources_TopicFragment = {
     Array<{ __typename?: 'Resource' } & GQLResources_ResourceFragment>
   >;
   metadata: { __typename?: 'TaxonomyMetadata'; customFields: any };
+};
+
+export type GQLTopic_SubjectFragment = {
+  __typename?: 'Subject';
+  id: string;
+  name: string;
+  allTopics?: Maybe<Array<{ __typename?: 'Topic'; id: string; name: string }>>;
+};
+
+export type GQLTopic_TopicFragment = {
+  __typename?: 'Topic';
+  path: string;
+  name: string;
+  relevanceId?: Maybe<string>;
+  subtopics?: Maybe<
+    Array<{
+      __typename?: 'Topic';
+      id: string;
+      name: string;
+      relevanceId?: Maybe<string>;
+    }>
+  >;
+  article?: Maybe<{
+    __typename?: 'Article';
+    metaImage?: Maybe<{ __typename?: 'MetaImage'; url: string; alt: string }>;
+    visualElement?: Maybe<
+      {
+        __typename?: 'VisualElement';
+      } & GQLVisualElementWrapper_VisualElementFragment
+    >;
+  }>;
+} & GQLArticleContents_TopicFragment &
+  GQLResources_TopicFragment;
+
+export type GQLTopic_ResourceTypeDefinitionFragment = {
+  __typename?: 'ResourceTypeDefinition';
+} & GQLResources_ResourceTypeDefinitionFragment;
+
+export type GQLTopicWrapperQueryVariables = Exact<{
+  topicId: Scalars['String'];
+  subjectId?: Maybe<Scalars['String']>;
+}>;
+
+export type GQLTopicWrapperQuery = {
+  __typename?: 'Query';
+  topic?: Maybe<{ __typename?: 'Topic'; id: string } & GQLTopic_TopicFragment>;
+  resourceTypes?: Maybe<
+    Array<
+      {
+        __typename?: 'ResourceTypeDefinition';
+      } & GQLTopic_ResourceTypeDefinitionFragment
+    >
+  >;
 };
 
 export type GQLContributorInfoFragment = {

--- a/src/util/transformArticle.ts
+++ b/src/util/transformArticle.ts
@@ -6,11 +6,11 @@
  *
  */
 
-import { GQLArticleInfoFragment } from '../graphqlTypes';
+import { GQLArticle } from '../graphqlTypes';
 import { LocaleType } from '../interfaces';
 import formatDate from './formatDate';
 
-function getContent(article: GQLArticleInfoFragment) {
+function getContent(content: string) {
   /**
    * We call extractCSS on the whole page server side. This removes/hoists
    * all style tags. The data (article) object is serialized with the style
@@ -22,16 +22,25 @@ function getContent(article: GQLArticleInfoFragment) {
    * styles will not be included.
    */
   if (process.env.BUILD_TARGET === 'client' && !window.hasHydrated) {
-    return article.content.replace(/<style.+?>.+?<\/style>/g, '');
+    return content.replace(/<style.+?>.+?<\/style>/g, '');
   }
-  return article.content;
+  return content;
 }
 
-export const transformArticle = (
-  article: GQLArticleInfoFragment,
+type BaseArticle = Pick<
+  GQLArticle,
+  | 'content'
+  | 'metaData'
+  | 'created'
+  | 'updated'
+  | 'published'
+  | 'requiredLibraries'
+>;
+export const transformArticle = <T extends BaseArticle>(
+  article: T,
   locale: LocaleType,
-) => {
-  const content = getContent(article);
+): T => {
+  const content = getContent(article.content);
   const footNotes = article?.metaData?.footnotes ?? [];
   return {
     ...article,


### PR DESCRIPTION
Dette kommer også med en positiv side-effekt: lasting av topics blir veldig raskt (for det meste).

En ulempe vi begynner å støte på her er at wrapping av exporten fører til at `.fragments` ikke lenger finnes. Man kan fjerne HOC der det er mulig, men der det ikke kan gjøres må vi eksportere fragments separat.