### PR TITLE
Show both creators and rightsholders in visualelement if exists

### DIFF
--- a/src/components/VisualElement/VisualElementWrapper.tsx
+++ b/src/components/VisualElement/VisualElementWrapper.tsx
@@ -59,9 +59,8 @@ const VisualElementWrapper = ({ visualElement, locale }: Props) => {
   }));
 
   const possibleAuthors = [
-    copyright?.creators,
+    [...(copyright?.creators || []), ...(copyright?.rightsholders || [])],
     copyright?.processors,
-    copyright?.rightsholders,
   ];
   const authors =
     possibleAuthors.find(grouping => grouping && grouping.length > 0) ?? [];


### PR DESCRIPTION
Fikser forespørsel fra Trello. Denne er klar for review, men avventer merge til jeg har fått tommel opp på Trello også.

Rettighetshaver og opphaver skal vises samtidig om begge deler eksisterer.