### PR TITLE
Legger på parameter for å forsikre at korrekt path velges.

### DIFF
--- a/src/components/Learningpath/LearningpathEmbed.tsx
+++ b/src/components/Learningpath/LearningpathEmbed.tsx
@@ -124,7 +124,7 @@ const LearningpathEmbed = ({
 LearningpathEmbed.fragments = {
   topic: gql`
     fragment LearningpathEmbed_Topic on Topic {
-      supplementaryResources {
+      supplementaryResources(subjectId: $subjectId) {
         id
       }
     }

--- a/src/containers/Resources/Resources.tsx
+++ b/src/containers/Resources/Resources.tsx
@@ -204,10 +204,10 @@ Resources.fragments = {
   topic: gql`
     fragment Resources_Topic on Topic {
       name
-      coreResources {
+      coreResources(subjectId: $subjectId) {
         ...Resources_Resource
       }
-      supplementaryResources {
+      supplementaryResources(subjectId: $subjectId) {
         ...Resources_Resource
       }
       metadata {


### PR DESCRIPTION
Vi trenger å sende med subjectid til disse endepunkta for at korrekt path skal plukkes ut.

Test:
* Må kjøres lokalt med NDLA_ENVIRONMENT=prod
* Åpne artikkelen http://localhost:3000/nb/subject:7509b507-548d-48e1-bef3-a06758e4820c/topic:109b4977-b2d1-4895-b24c-9ec1ba911bec/resource:bd019e72-a6a6-4644-beda-6161574cc405
* Neste må gjøres uten å laste sida på nytt for å unngå å ødelegge cache:
* I menyen velg Alle fag -> Norsk (SF vg3) 2022/2023 - BETA -> Tekst i kontekst -> Sammensatte tekster
* I launchpad til emnet skal artikkelen du først gikk til ligge, men med korrekt path fra emnet.

Alternativt, bruk pr-installasjon og finn en artikkel som brukes i fleire emner og gjør tilsvarende.