### PR TITLE
Simple programme sitemap generation.

### DIFF
--- a/src/server/programmeSitemap.ts
+++ b/src/server/programmeSitemap.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2022-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import config from '../config';
+import { PROGRAMME_PATH } from '../constants';
+import { programmes } from '../data/programmes';
+
+const programmeSitemap = (): string => {
+  const baseUrl = `${config?.ndlaFrontendDomain}${PROGRAMME_PATH}/`;
+  const slugs = programmes.map(p => `${baseUrl}${p.url['nb']}\n`);
+  return slugs.join('');
+};
+
+export default programmeSitemap;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -32,6 +32,7 @@ import {
   feideLogout,
 } from './helpers/openidHelper';
 import { podcastFeedRoute } from './routes/podcastFeedRoute';
+import programmeSitemap from './programmeSitemap';
 import config from '../config';
 import {
   OK,
@@ -206,6 +207,15 @@ app.get(
     res.removeHeader('X-Frame-Options');
     res.setHeader('Content-Type', 'application/xml');
     res.send(ltiConfig());
+  },
+);
+
+app.get(
+  '/sitemap-utdanningsprogram.txt',
+  ndlaMiddleware,
+  async (_req: Request, res: Response) => {
+    res.setHeader('Content-Type', 'application/txt');
+    res.send(programmeSitemap());
   },
 );
 


### PR DESCRIPTION
Veldig enkel generering av sitemap for programområder.

Test
* Sjekk path /sitemap-utdanningsprogram.txt og sjå at du får ut lista med områder.