### PR TITLE
Prefer resource name over meta image alttext on search page

### DIFF
--- a/src/containers/SearchPage/searchHelpers.tsx
+++ b/src/containers/SearchPage/searchHelpers.tsx
@@ -255,7 +255,7 @@ export const mapResourcesToItems = (
     ...(resource.metaImage?.url && {
       img: {
         url: `${resource.metaImage.url}?width=${isLti ? '350' : '250'}`,
-        alt: resource.metaImage?.alt ?? '',
+        alt: resource.name ?? resource.metaImage?.alt ?? '',
       },
     }),
     children: isLti ? (


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3045

Faller tilbake til metabilde-alttekst