### PR TITLE
Check for article-converter flag before removing portal

### DIFF
--- a/src/client.tsx
+++ b/src/client.tsx
@@ -95,6 +95,9 @@ function canUseDOM() {
 function removeUniversalPortals() {
   if (canUseDOM()) {
     document.querySelectorAll('[data-react-universal-portal]').forEach(node => {
+      if (node.hasAttribute('data-from-article-converter')) {
+        return;
+      }
       node.remove();
     });
   }


### PR DESCRIPTION
Avhengig av https://github.com/NDLANO/article-converter/pull/314
Portaler som rendres likt på både klient og server er avhengig av `removeUniversalPortal`, mens de som går gjennom `article-converter` først krasjer. Dette sørger for at vi ikke fjerner portaler fra `article-converter`.

Kan testes ved å spinne opp article-converter, graphql og ndla-frontend lokalt, for deretter å sjekke at http://localhost:3000/nn/subject:1:f18b0daa-6507-4025-8998-b8a11c8ccc70/topic:5:dbc23651-7216-4610-bc38-dde58f013724/topic:3:fe851509-1f3c-4fef-9922-ae05ff1a4fba/resource:5edb583f-b7a9-4d04-8f3b-58100188e8ce ikke krasjer.