### PR TITLE
3037 extended alert functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "@ndla/safelink": "^1.1.4",
     "@ndla/tabs": "^1.1.2",
     "@ndla/tracker": "^0.6.1",
-    "@ndla/ui": "^6.1.3",
+    "@ndla/ui": "^7.0.0",
     "@ndla/util": "^2.0.4",
     "@ndla/zendesk": "^0.3.3",
     "babel-polyfill": "^6.26.0",

--- a/src/components/AlertsContext.tsx
+++ b/src/components/AlertsContext.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@apollo/client';
-import { compact, partition } from 'lodash';
+import { partition, uniq } from 'lodash';
 import {
   createContext,
   ReactNode,
@@ -33,7 +33,7 @@ const getClosedAlerts = (): number[] => {
 const setClosedAlert = (id: number) => {
   try {
     const stored = getClosedAlerts();
-    const updated = compact([...stored, id]);
+    const updated = uniq([...stored, id]);
     localStorage.setItem('closedAlerts', JSON.stringify(updated));
   } catch {
     console.error('Could not save closedAlerts to localStorage.');

--- a/src/components/AlertsContext.tsx
+++ b/src/components/AlertsContext.tsx
@@ -1,7 +1,53 @@
 import { useQuery } from '@apollo/client';
-import { createContext, ReactNode, useContext } from 'react';
-import { GQLAlertsQuery, GQLAlertsQueryVariables } from '../graphqlTypes';
+import { compact, partition } from 'lodash';
+import {
+  createContext,
+  ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+import {
+  GQLAlertsQuery,
+  GQLAlertsQueryVariables,
+  GQLUptimeAlert,
+} from '../graphqlTypes';
 import { alertsQuery } from '../queries';
+
+const getClosedAlerts = (): number[] => {
+  try {
+    const stored = localStorage.getItem('closedAlerts');
+    if (stored) {
+      const ids = JSON.parse(stored);
+      if (Array.isArray(ids)) {
+        return ids;
+      }
+    }
+    return [];
+  } catch {
+    console.error('Could not read closedAlerts from localStorage.');
+    return [];
+  }
+};
+
+const setClosedAlert = (id: number) => {
+  try {
+    const stored = getClosedAlerts();
+    const updated = compact([...stored, id]);
+    localStorage.setItem('closedAlerts', JSON.stringify(updated));
+  } catch {
+    console.error('Could not save closedAlerts to localStorage.');
+  }
+};
+
+const setClosedAlerts = (alerts: GQLUptimeAlert[]) => {
+  try {
+    const ids = alerts.map(alert => alert.number);
+    localStorage.setItem('closedAlerts', JSON.stringify(ids));
+  } catch {
+    console.error('Could not save closedAlerts to localStorage.');
+  }
+};
 
 const AlertsContext = createContext<GQLAlertsQuery['alerts']>([]);
 
@@ -10,13 +56,31 @@ interface Props {
 }
 
 const AlertsProvider = ({ children }: Props) => {
-  const { data } = useQuery<GQLAlertsQuery, GQLAlertsQueryVariables>(
-    alertsQuery,
-    { pollInterval: 5 * 60 * 1000 },
-  );
+  const [openAlerts, setOpenAlerts] = useState<GQLUptimeAlert[]>([]);
+  const { data: { alerts } = {} } = useQuery<
+    GQLAlertsQuery,
+    GQLAlertsQueryVariables
+  >(alertsQuery, { pollInterval: 10 * 60 * 1000 });
+
+  useEffect(() => {
+    if (alerts) {
+      const closedIds = getClosedAlerts();
+      if (closedIds.length > 0) {
+        const [closedAlerts, openAlerts] = partition(
+          alerts,
+          alert => closedIds.includes(alert.number) && alert.closable,
+        );
+        setOpenAlerts(openAlerts);
+        setClosedAlerts(closedAlerts);
+        return;
+      }
+
+      setOpenAlerts(alerts);
+    }
+  }, [alerts]);
 
   return (
-    <AlertsContext.Provider value={data?.alerts || []}>
+    <AlertsContext.Provider value={openAlerts}>
       {children}
     </AlertsContext.Provider>
   );
@@ -30,4 +94,10 @@ const useAlerts = () => {
   return context;
 };
 
-export { useAlerts, AlertsProvider };
+export {
+  useAlerts,
+  AlertsProvider,
+  getClosedAlerts,
+  setClosedAlert,
+  setClosedAlerts,
+};

--- a/src/containers/Masthead/MastheadContainer.tsx
+++ b/src/containers/Masthead/MastheadContainer.tsx
@@ -163,7 +163,10 @@ const MastheadContainer = ({
       />
     );
 
-  const alerts = useAlerts().map(alert => alert.body || alert.title);
+  const alerts = useAlerts().map(alert => ({
+    content: alert.body || alert.title,
+    closable: alert.closable,
+  }));
 
   return (
     <ErrorBoundary>

--- a/src/containers/Masthead/MastheadContainer.tsx
+++ b/src/containers/Masthead/MastheadContainer.tsx
@@ -43,7 +43,7 @@ import {
   GQLTopicInfoFragment,
 } from '../../graphqlTypes';
 import config from '../../config';
-import { useAlerts } from '../../components/AlertsContext';
+import { setClosedAlert, useAlerts } from '../../components/AlertsContext';
 
 interface Props extends RouteComponentProps {
   locale: LocaleType;
@@ -166,6 +166,7 @@ const MastheadContainer = ({
   const alerts = useAlerts().map(alert => ({
     content: alert.body || alert.title,
     closable: alert.closable,
+    number: alert.number,
   }));
 
   return (
@@ -175,6 +176,7 @@ const MastheadContainer = ({
         ndlaFilm={ndlaFilm}
         skipToMainContentId={skipToMainContentId}
         infoContent={infoContent}
+        onCloseAlert={id => setClosedAlert(id)}
         messages={alerts}>
         <MastheadItem left>
           <MastheadMenu

--- a/src/containers/WelcomePage/WelcomePage.tsx
+++ b/src/containers/WelcomePage/WelcomePage.tsx
@@ -31,6 +31,7 @@ import { getSubjectById } from '../../data/subjects';
 import { LocaleType, SubjectType } from '../../interfaces';
 import { alertsQuery } from '../../queries';
 import { GQLAlertsQuery } from '../../graphqlTypes';
+import { setClosedAlert } from '../../components/AlertsContext';
 
 const getUrlFromSubjectId = (subjectId: string) => {
   const subject = getSubjectById(subjectId);
@@ -122,6 +123,9 @@ const WelcomePage = ({ locale, skipToContentId }: Props) => {
       {data?.alerts?.map(alert => (
         <MessageBox
           type={MessageBoxType.fullpage}
+          renderMarkdown={true}
+          onClose={() => setClosedAlert(alert.number)}
+          showCloseButton={alert.closable}
           children={alert.body ?? alert.title}
         />
       ))}

--- a/src/containers/WelcomePage/WelcomePage.tsx
+++ b/src/containers/WelcomePage/WelcomePage.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import { useEffect } from 'react';
 import { HelmetWithTracker } from '@ndla/tracker';
 import {
   FrontpageHeader,
@@ -18,7 +17,6 @@ import {
   MessageBoxType,
 } from '@ndla/ui';
 import { useTranslation } from 'react-i18next';
-import { useLazyQuery } from '@apollo/client';
 import WelcomePageInfo from './WelcomePageInfo';
 import FrontpageSubjects from './FrontpageSubjects';
 import { FILM_PAGE_PATH } from '../../constants';
@@ -29,9 +27,7 @@ import WelcomePageSearch from './WelcomePageSearch';
 import { toSubject, toTopic } from '../../routeHelpers';
 import { getSubjectById } from '../../data/subjects';
 import { LocaleType, SubjectType } from '../../interfaces';
-import { alertsQuery } from '../../queries';
-import { GQLAlertsQuery } from '../../graphqlTypes';
-import { setClosedAlert } from '../../components/AlertsContext';
+import { setClosedAlert, useAlerts } from '../../components/AlertsContext';
 
 const getUrlFromSubjectId = (subjectId: string) => {
   const subject = getSubjectById(subjectId);
@@ -77,16 +73,11 @@ interface Props {
 const WelcomePage = ({ locale, skipToContentId }: Props) => {
   const { t } = useTranslation();
 
-  useEffect(() => {
-    getData();
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const [fetchData, { data }] = useLazyQuery<GQLAlertsQuery>(alertsQuery);
-
-  const getData = () => {
-    fetchData();
-  };
-
+  const alerts = useAlerts().map(alert => ({
+    content: alert.body || alert.title,
+    closable: alert.closable,
+    number: alert.number,
+  }));
   const googleSearchJSONLd = () => {
     const data = {
       '@context': 'https://schema.org',
@@ -120,14 +111,13 @@ const WelcomePage = ({ locale, skipToContentId }: Props) => {
         imageUrl={`${config.ndlaFrontendDomain}/static/logo.png`}>
         <meta name="keywords" content={t('meta.keywords')} />
       </SocialMediaMetadata>
-      {data?.alerts?.map(alert => (
+      {alerts?.map(alert => (
         <MessageBox
           type={MessageBoxType.fullpage}
-          renderMarkdown={true}
           onClose={() => setClosedAlert(alert.number)}
-          showCloseButton={alert.closable}
-          children={alert.body ?? alert.title}
-        />
+          showCloseButton={alert.closable}>
+          {alert.content}
+        </MessageBox>
       ))}
       <FrontpageHeader locale={locale} showHeader={true}>
         <WelcomePageSearch />

--- a/src/graphqlTypes.ts
+++ b/src/graphqlTypes.ts
@@ -3710,6 +3710,7 @@ export type GQLAlertsQuery = {
         title: string;
         body?: Maybe<string>;
         closable: boolean;
+        number: number;
       }>
     >
   >;

--- a/src/graphqlTypes.ts
+++ b/src/graphqlTypes.ts
@@ -1145,6 +1145,8 @@ export type GQLTopicSupplementaryResourcesArgs = {
 export type GQLUptimeAlert = {
   __typename?: 'UptimeAlert';
   body?: Maybe<Scalars['String']>;
+  closable: Scalars['Boolean'];
+  number: Scalars['Int'];
   title: Scalars['String'];
 };
 
@@ -1744,7 +1746,7 @@ export type GQLFilmFrontPageQuery = {
     { __typename?: 'FilmFrontpage' } & GQLFilmFrontpage_FilmFrontpageFragment
   >;
   subject?: Maybe<
-    { __typename?: 'Subject' } & GQLFilmFrontpage_SubjectFragment
+    { __typename?: 'Subject'; id: string } & GQLFilmFrontpage_SubjectFragment
   >;
 };
 
@@ -3703,7 +3705,12 @@ export type GQLAlertsQuery = {
   __typename?: 'Query';
   alerts?: Maybe<
     Array<
-      Maybe<{ __typename?: 'UptimeAlert'; title: string; body?: Maybe<string> }>
+      Maybe<{
+        __typename?: 'UptimeAlert';
+        title: string;
+        body?: Maybe<string>;
+        closable: boolean;
+      }>
     >
   >;
 };

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -1155,6 +1155,7 @@ export const alertsQuery = gql`
       title
       body
       closable
+      number
     }
   }
 `;

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -1154,6 +1154,7 @@ export const alertsQuery = gql`
     alerts {
       title
       body
+      closable
     }
   }
 `;

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -876,6 +876,8 @@ type FrontpageSearch {
 type UptimeAlert {
   title: String!
   body: String
+  number: Int!
+  closable: Boolean!
 }
 
 type Query {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3064,10 +3064,10 @@
   dependencies:
     warning "^4.0.3"
 
-"@ndla/ui@^6.1.3":
-  version "6.1.3"
-  resolved "https://registry.yarnpkg.com/@ndla/ui/-/ui-6.1.3.tgz#e64f558a6553463347f1b102f528ec0e35b79637"
-  integrity sha512-6tjY2w7OgThFzxSLYsYTb8N9k4lsIwtASyZnwhrf9PoKUh8be83d+difby6hC1mCrA2lhaTGY3TcaThua/8HaQ==
+"@ndla/ui@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@ndla/ui/-/ui-7.0.0.tgz#7fca7bdb98f0031022ba3bb1ad6c7b7c1c1170f2"
+  integrity sha512-PCY46b6zhJnzZqi07XyD52qDeE1uXAzGQbKASW5OeAJG8yng+H7I1FbSNVSw/QBSltMm26NxMxDuPBxW6Odi8g==
   dependencies:
     "@ndla/button" "^2.1.3"
     "@ndla/carousel" "^1.2.3"
@@ -3095,6 +3095,7 @@
     react-sticky-el "^2.0.6"
     react-swipeable "^6.2.0"
     react-transition-group "^2.5.3"
+    remarkable "^2.0.1"
     shave "^2.5.10"
 
 "@ndla/util@^2.0.4":


### PR DESCRIPTION
Fixes NDLANO/Issues#3037


Banner utvides med mer funksjonalitet:
- Rendering av markdown og dermed støtte for lenker.
- Bruk av tag "permanent" på https://github.com/NDLANO/oppetid/issues for å gjøre at banner ikke kan lukkes.
- Ved lukking av banner vil det ikke lenger vises for brukeren selv etter refresh.

Bruk gjerne dette issuet til å teste: https://github.com/NDLANO/oppetid/issues/47
1. Sjekk at lenke rendres.
2. Lukk banner og refresh siden. Banner skal ikke dukke opp igjen med mindre localStorage slettes eller "permanent"-tag skrus på.
3. Legg til "permanent"-tag og sjekk at lukk-knapp forsvinner når taggen er satt.

