### PR TITLE
Add version-hash parameter to App

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -153,6 +153,7 @@ interface AppProps extends RouteComponentProps, WithTranslation {
   initialProps: InitialProps;
   locale?: LocaleType;
   client: ApolloClient<object>;
+  versionHash?: string;
 }
 
 interface AppState {
@@ -167,7 +168,12 @@ class App extends Component<AppProps, AppState> {
   constructor(props: AppProps) {
     super(props);
     this.location = null;
-    initializeI18n(props.i18n, props.client, props.initialProps.resCookie);
+    initializeI18n(
+      props.i18n,
+      props.client,
+      props.initialProps.resCookie,
+      props.versionHash,
+    );
     this.state = {
       hasError: false,
       data: props.initialProps,

--- a/src/I18nWrapper.tsx
+++ b/src/I18nWrapper.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
+import { useVersionHash } from './components/VersionHashContext';
 import { getDefaultLocale } from './config';
 import { STORED_LANGUAGE_KEY } from './constants';
 import { appLocales, isValidLocale } from './i18n';
@@ -21,6 +22,7 @@ export const I18nWrapper = ({ locale, initialProps }: Props) => {
   const [lang, setLang] = useState(locale);
   const firstRender = useRef(true);
   const apolloClient = useApolloClient();
+  const versionHash = useVersionHash();
 
   useEffect(() => {
     if (firstRender.current) {
@@ -37,7 +39,9 @@ export const I18nWrapper = ({ locale, initialProps }: Props) => {
           history.replace(
             `/${storedLang}${window.location.pathname}${window.location.search}`,
           );
-          apolloClient.setLink(createApolloLinks(storedLang, document.cookie));
+          apolloClient.setLink(
+            createApolloLinks(storedLang, document.cookie, versionHash),
+          );
           apolloClient.resetStore();
         }
       } else if (locale && !isValidLocale(locale)) {
@@ -75,6 +79,7 @@ export const I18nWrapper = ({ locale, initialProps }: Props) => {
         client={apolloClient}
         locale={lang}
         key={lang}
+        versionHash={versionHash}
       />
     </BrowserRouter>
   );

--- a/src/components/VersionHashContext.tsx
+++ b/src/components/VersionHashContext.tsx
@@ -1,0 +1,28 @@
+import { createContext, ReactNode, useContext } from 'react';
+
+const defaultValue = 'default';
+const VersionHashContext = createContext<string>(defaultValue);
+
+interface Props {
+  children: ReactNode;
+  value?: string;
+}
+
+export const VersionHashProvider = ({
+  children,
+  value = defaultValue,
+}: Props) => {
+  return (
+    <VersionHashContext.Provider value={value}>
+      {children}
+    </VersionHashContext.Provider>
+  );
+};
+
+export const useVersionHash = () => {
+  const context = useContext(VersionHashContext);
+  if (context === undefined) {
+    return defaultValue;
+  }
+  return context;
+};

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -76,6 +76,7 @@ export const initializeI18n = (
   i18n: i18n,
   client?: ApolloClient<object>,
   cookieString?: string,
+  versionHash?: string,
 ): void => {
   i18n.options.supportedLngs = supportedLanguages;
   i18n.addResourceBundle('en', 'translation', en, false, false);
@@ -89,7 +90,7 @@ export const initializeI18n = (
     if (typeof window != 'undefined') {
       if (client) {
         client.resetStore();
-        client.setLink(createApolloLinks(language, cookieString));
+        client.setLink(createApolloLinks(language, cookieString, versionHash));
       }
       window.localStorage.setItem(STORED_LANGUAGE_KEY, language);
     }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -211,6 +211,7 @@ const routesFunc = function(
   client: ApolloClient<object>,
   locale?: LocaleType,
   isClient = false,
+  versionHash?: string,
 ) {
   if (!isClient) {
     i18nInstance.changeLanguage(locale);
@@ -222,6 +223,7 @@ const routesFunc = function(
       client={client}
       locale={locale}
       key={locale}
+      versionHash={versionHash}
     />
   );
 

--- a/src/util/apiHelpers.ts
+++ b/src/util/apiHelpers.ts
@@ -151,7 +151,11 @@ const typePolicies: TypePolicies = {
   },
 };
 
-export const createApolloClient = (language = 'nb', cookieString?: string) => {
+export const createApolloClient = (
+  language = 'nb',
+  cookieString?: string,
+  versionHash?: string,
+) => {
   const cache = __CLIENT__
     ? new InMemoryCache({ possibleTypes, typePolicies }).restore(
         window.DATA.apolloState,
@@ -162,12 +166,16 @@ export const createApolloClient = (language = 'nb', cookieString?: string) => {
 
   return new ApolloClient({
     ssrMode: true,
-    link: createApolloLinks(language, cookie),
+    link: createApolloLinks(language, cookie, versionHash),
     cache,
   });
 };
 
-export const createApolloLinks = (lang: string, cookieString?: string) => {
+export const createApolloLinks = (
+  lang: string,
+  cookieString?: string,
+  versionHash?: string,
+) => {
   const feideCookie = getFeideCookie(cookieString ?? '');
   const accessTokenValid = isAccessTokenValid(feideCookie);
   const accessToken = feideCookie?.access_token;
@@ -177,6 +185,7 @@ export const createApolloLinks = (lang: string, cookieString?: string) => {
       headers: {
         ...headers,
         'Accept-Language': lang,
+        versionHash: versionHash ?? 'default',
         ...(accessToken && accessTokenValid
           ? { FeideAuthorization: `Bearer ${accessToken}` }
           : {}),


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3080
Avhengig av https://github.com/NDLANO/graphql-api/pull/247

Kan testes ved å kjøre mot lokal graphql, og sette `versionHash=ae9f` som queryParam. Da skal du kunne navigere en spesifikk versjon av taksonomi inntil du gjør en full refresh av siden.