### PR TITLE
Podcast license fixes

### DIFF
--- a/src/containers/PodcastPage/Podcast.tsx
+++ b/src/containers/PodcastPage/Podcast.tsx
@@ -19,6 +19,7 @@ import {
   getLicenseCredits,
   podcastEpisodeApa7CopyString,
   figureApa7CopyString,
+  getGroupedContributorDescriptionList,
 } from '@ndla/licenses';
 import { initArticleScripts } from '@ndla/article-scripts';
 import { gql } from '@apollo/client';
@@ -42,6 +43,21 @@ const getPrioritizedAuthors = (authors: {
   }
   return processors;
 };
+
+const getGroupedAuthors = (
+  authors: {
+    creators: Author[];
+    rightsholders: Author[];
+    processors: Author[];
+  },
+  language: string,
+) => {
+  return getGroupedContributorDescriptionList(authors, language).map(item => ({
+    name: item.description,
+    type: item.label,
+  }));
+};
+
 interface Props {
   podcast: GQLPodcast_AudioFragment;
   seriesId: string;
@@ -50,6 +66,7 @@ interface Props {
 const Podcast = ({ podcast, seriesId }: Props) => {
   const {
     i18n: { language },
+    t,
   } = useTranslation();
 
   const license =
@@ -63,7 +80,6 @@ const Podcast = ({ podcast, seriesId }: Props) => {
     alt: image.altText,
   };
 
-  const { t } = useTranslation();
   useEffect(() => {
     initArticleScripts();
   }, []);
@@ -97,6 +113,14 @@ const Podcast = ({ podcast, seriesId }: Props) => {
   const imageContributors =
     image && getPrioritizedAuthors(getLicenseCredits(image.copyright));
 
+  const podcastGroupedContributors = getGroupedAuthors(
+    licenseCredits,
+    language,
+  );
+
+  const imageGroupedContributors =
+    image && getGroupedAuthors(image.copyright, language);
+
   const imageRights =
     image &&
     getLicenseByAbbreviation(image.copyright.license.license, language).rights;
@@ -125,7 +149,7 @@ const Podcast = ({ podcast, seriesId }: Props) => {
         authors={podcastContributors}>
         <FigureLicenseDialog
           id={id}
-          authors={podcastContributors}
+          authors={podcastGroupedContributors}
           locale={language}
           license={getLicenseByAbbreviation(
             podcast.copyright.license?.license!,
@@ -169,7 +193,7 @@ const Podcast = ({ podcast, seriesId }: Props) => {
             authors={imageContributors}>
             <FigureLicenseDialog
               id={imageId}
-              authors={imageContributors}
+              authors={imageGroupedContributors}
               locale={language}
               license={getLicenseByAbbreviation(
                 image.copyright.license.license!,

--- a/src/containers/PodcastPage/Podcast.tsx
+++ b/src/containers/PodcastPage/Podcast.tsx
@@ -90,12 +90,13 @@ const Podcast = ({ podcast, seriesId }: Props) => {
 
   const imageContributors =
     image &&
-    getGroupedContributorDescriptionList(licenseCredits, language).map(
-      item => ({
-        name: item.description,
-        type: item.label,
-      }),
-    );
+    getGroupedContributorDescriptionList(
+      getLicenseCredits(image.copyright),
+      language,
+    ).map(item => ({
+      name: item.description,
+      type: item.label,
+    }));
 
   const imageRights =
     image &&

--- a/src/containers/PodcastPage/Podcast.tsx
+++ b/src/containers/PodcastPage/Podcast.tsx
@@ -16,7 +16,6 @@ import {
 } from '@ndla/ui';
 import {
   getLicenseByAbbreviation,
-  getGroupedContributorDescriptionList,
   getLicenseCredits,
   podcastEpisodeApa7CopyString,
   figureApa7CopyString,
@@ -29,7 +28,20 @@ import AnchorButton from '../../components/license/AnchorButton';
 import config from '../../config';
 import { GQLPodcast_AudioFragment } from '../../graphqlTypes';
 import { copyrightInfoFragment } from '../../queries';
+import { Author } from '../../interfaces';
 
+const getPrioritizedAuthors = (authors: {
+  creators: Author[];
+  rightsholders: Author[];
+  processors: Author[];
+}): Author[] => {
+  const { creators, rightsholders, processors } = authors;
+
+  if (creators.length || rightsholders.length) {
+    return [...creators, ...rightsholders];
+  }
+  return processors;
+};
 interface Props {
   podcast: GQLPodcast_AudioFragment;
   seriesId: string;
@@ -80,23 +92,10 @@ const Podcast = ({ podcast, seriesId }: Props) => {
 
   const licenseCredits = getLicenseCredits(podcast.copyright);
 
-  const podcastContributors = getGroupedContributorDescriptionList(
-    licenseCredits,
-    language,
-  ).map(item => ({
-    name: item.description,
-    type: item.label,
-  }));
+  const podcastContributors = getPrioritizedAuthors(licenseCredits);
 
   const imageContributors =
-    image &&
-    getGroupedContributorDescriptionList(
-      getLicenseCredits(image.copyright),
-      language,
-    ).map(item => ({
-      name: item.description,
-      type: item.label,
-    }));
+    image && getPrioritizedAuthors(getLicenseCredits(image.copyright));
 
   const imageRights =
     image &&

--- a/src/containers/PodcastPage/Podcast.tsx
+++ b/src/containers/PodcastPage/Podcast.tsx
@@ -104,6 +104,8 @@ const Podcast = ({ podcast, seriesId }: Props) => {
   const id = podcast.id.toString();
   const figureId = `episode-${id}`;
 
+  const imageId = `episode-${id}-image-${image?.id}`;
+
   return (
     <Figure id={figureId} type="full-column">
       <AudioPlayer
@@ -157,16 +159,16 @@ const Podcast = ({ podcast, seriesId }: Props) => {
         </FigureLicenseDialog>
       </FigureCaption>
       {image && (
-        <div id={image.id}>
+        <div id={imageId}>
           <FigureCaption
-            figureId={image.id}
-            id={image.id}
+            figureId={imageId}
+            id={imageId}
             licenseRights={imageRights || []}
             locale={language}
             reuseLabel={t('image.reuse')}
             authors={imageContributors}>
             <FigureLicenseDialog
-              id={image.id}
+              id={imageId}
               authors={imageContributors}
               locale={language}
               license={getLicenseByAbbreviation(


### PR DESCRIPTION
Fikser tre feil i podkaster oppdaget på https://ndla.no/podkast/3:
- Ved klikk på "bruk bildet" på scrolles man alltid til øverste podkast.
- Viser riktige forfattere på caption på bilde. Dette ble tidligere hentet fra podkast og var derfor identisk.
- Viser opphavere OG rettighetshavere, alternativt bearbeidere dersom de andre ikke finnes.

Angående siste vises ikke lenger "Leverandør", "Korrektur" osv foran navn til forfattere. Har ikke sett at dette brukes på figurer andre steder lenger, så fjernet det derfor.

Hvordan teste:
1. Åpne en podkast-serie som har flere episoder med samme bilde.
2. Sjekk at scroll gjøres til den aktuelle episoden ved trykk på bildelisens
3. Forfattere på bilde og podkast skal nå være forskjellig
4. Bearbeidere på bilde og podkast skal kun vises dersom annet ikke finnes.