### PR TITLE
Removing contentUrl to avoid fastly_token.

### DIFF
--- a/src/util/getStructuredDataFromArticle.ts
+++ b/src/util/getStructuredDataFromArticle.ts
@@ -268,7 +268,6 @@ const createVideoData = (
       embedUrl: video?.src,
       thumbnailUrl: video?.cover,
       description: video?.description,
-      contentUrl: video?.download,
       acquireLicensePage,
       uploadDate: format(video?.uploadDate!, 'YYYY-MM-DD'),
       ...getCopyrightData(video?.copyright!),


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3093
Forces json-ld to be duplicated in ssr and client.

Test:
* Finn en artikkel med video og lim urlen inn i https://validator.schema.org/
* Sjekk at du kun får en article og breadcrumb