### PR TITLE
Add h5p script to Helmet if h5p in article

### DIFF
--- a/src/util/getArticleScripts.ts
+++ b/src/util/getArticleScripts.ts
@@ -39,6 +39,14 @@ export function getArticleScripts(
       defer: true,
     });
   }
+  if (article && article.content.indexOf('h5p')) {
+    scripts.push({
+      src: 'https://h5p.org/sites/all/modules/h5p/library/js/h5p-resizer.js',
+      type: 'text/javascript',
+      async: false,
+      defer: true,
+    });
+  }
 
   return scripts;
 }


### PR DESCRIPTION
Fixes NDLANO/Issues#3102

Ved rendering av H5P med klient skal H5p nå resizes. Opprinnelig problem kan sees her: https://ndla.no/en/subject:d1fe9d0a-a54d-49db-a4c2-fd5463a7c9e7/topic:077a5e01-6bb8-4c0b-b1d4-94b683d91803/topic:d9b69de9-9aaa-4058-8caa-99d7a47c48b0/topic:52ce7bcd-0608-4c90-97ed-3f9096284572/resource:7e14ca28-061b-4922-8860-d1898fe491db?disableSSR=true
H5Pen i artikkelen skulle hatt full høyde og uten scroll.

Ser ut som at nettleseren ikke evaluerer `<script>` i koden på klient. Løsningen ble å legge til h5p-resize scriptet i Helmet dersom h5p finnes i artikkelen.

Hvordan teste:
- Åpne /nb/article/31044 (skal ha høy h5p per dags dato) eller annen artikkel med høy h5p. H5p skal få full høyde.
- Trykk deg inn på en annen side og trykk deg tilbake. H5P skal igjen bli høy.
- Åpne siden med `?disableSSR=true`. H5P skal være høy.