### PR TITLE
Implement new breadcrumbs

### DIFF
--- a/e2e/integration/resource_page.spec.ts
+++ b/e2e/integration/resource_page.spec.ts
@@ -21,7 +21,7 @@ describe('Resource page', () => {
     );
     cy.gqlWait('@resourcePage');
     cy.get('.o-content').within(() => {
-      cy.get('.c-breadcrumb__list > li').should($list => {
+      cy.get('[aria-label="Brødsmulesti"] > ol > li').should($list => {
         expect($list).to.have.length(4);
       });
       cy.get('h1').contains('Muntlig eksamen MIK 1');

--- a/e2e/integration/resource_page.spec.ts
+++ b/e2e/integration/resource_page.spec.ts
@@ -21,7 +21,7 @@ describe('Resource page', () => {
     );
     cy.gqlWait('@resourcePage');
     cy.get('.o-content').within(() => {
-      cy.get('[aria-label="Brødsmulesti"] > ol > li').should($list => {
+      cy.get('nav > ol > li').should($list => {
         expect($list).to.have.length(4);
       });
       cy.get('h1').contains('Muntlig eksamen MIK 1');

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "@ndla/safelink": "^2.0.1",
     "@ndla/tabs": "^1.1.6",
     "@ndla/tracker": "^2.0.0",
-    "@ndla/ui": "^13.0.0",
+    "@ndla/ui": "^13.1.0",
     "@ndla/util": "^3.0.0",
     "@ndla/zendesk": "^0.3.7",
     "babel-polyfill": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "@ndla/safelink": "^2.0.1",
     "@ndla/tabs": "^1.1.6",
     "@ndla/tracker": "^2.0.0",
-    "@ndla/ui": "^13.1.0",
+    "@ndla/ui": "^13.1.1",
     "@ndla/util": "^3.0.0",
     "@ndla/zendesk": "^0.3.7",
     "babel-polyfill": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "@ndla/safelink": "^2.0.1",
     "@ndla/tabs": "^1.1.6",
     "@ndla/tracker": "^2.0.0",
-    "@ndla/ui": "^12.0.2",
+    "@ndla/ui": "^13.0.0",
     "@ndla/util": "^3.0.0",
     "@ndla/zendesk": "^0.3.7",
     "babel-polyfill": "^6.26.0",

--- a/src/components/Learningpath/Learningpath.tsx
+++ b/src/components/Learningpath/Learningpath.tsx
@@ -17,10 +17,10 @@ import {
   LearningPathStickySibling,
   LearningPathMobileStepInfo,
   LearningPathStickyPlaceholder,
-  Breadcrumb,
   LearningPathSticky,
   LearningPathMobileHeader,
   constants,
+  HomeBreadcrumb,
 } from '@ndla/ui';
 import { toLearningPath, useIsNdlaFilm } from '../../routeHelpers';
 import LastLearningpathStepInfo from './LastLearningpathStepInfo';
@@ -144,7 +144,7 @@ const Learningpath = ({
     <LearningPathWrapper invertedStyle={ndlaFilm}>
       <div className="c-hero__content">
         <section>
-          <Breadcrumb invertedStyle={ndlaFilm} items={breadcrumbItems} />
+          <HomeBreadcrumb light={ndlaFilm} items={breadcrumbItems} />
         </section>
       </div>
       <LearningPathContent>

--- a/src/containers/ArticlePage/components/ArticleHero.tsx
+++ b/src/containers/ArticlePage/components/ArticleHero.tsx
@@ -66,7 +66,9 @@ const ArticleHero = ({
       <OneColumn>
         <div className="c-hero__content">
           <section>
-            {subject && <HomeBreadcrumb items={breadcrumbItems} />}
+            {subject && (
+              <HomeBreadcrumb light={ndlaFilm} items={breadcrumbItems} />
+            )}
           </section>
         </div>
       </OneColumn>

--- a/src/containers/ArticlePage/components/ArticleHero.tsx
+++ b/src/containers/ArticlePage/components/ArticleHero.tsx
@@ -8,13 +8,7 @@
 
 import { gql } from '@apollo/client';
 import { ReactNode } from 'react';
-import {
-  Hero,
-  OneColumn,
-  Breadcrumb,
-  NdlaFilmHero,
-  HomeBreadcrumb,
-} from '@ndla/ui';
+import { Hero, OneColumn, NdlaFilmHero, HomeBreadcrumb } from '@ndla/ui';
 import { HeroContentType } from '@ndla/ui/lib/Hero';
 import {
   GQLArticleHero_MetaImageFragment,

--- a/src/containers/ArticlePage/components/ArticleHero.tsx
+++ b/src/containers/ArticlePage/components/ArticleHero.tsx
@@ -8,7 +8,13 @@
 
 import { gql } from '@apollo/client';
 import { ReactNode } from 'react';
-import { Hero, OneColumn, Breadcrumb, NdlaFilmHero } from '@ndla/ui';
+import {
+  Hero,
+  OneColumn,
+  Breadcrumb,
+  NdlaFilmHero,
+  HomeBreadcrumb,
+} from '@ndla/ui';
 import { HeroContentType } from '@ndla/ui/lib/Hero';
 import {
   GQLArticleHero_MetaImageFragment,
@@ -66,11 +72,7 @@ const ArticleHero = ({
       <OneColumn>
         <div className="c-hero__content">
           <section>
-            {subject && (
-              <Breadcrumb items={breadcrumbItems} invertedStyle={false}>
-                <></>
-              </Breadcrumb>
-            )}
+            {subject && <HomeBreadcrumb items={breadcrumbItems} />}
           </section>
         </div>
       </OneColumn>

--- a/src/containers/Masthead/MastheadContainer.tsx
+++ b/src/containers/Masthead/MastheadContainer.tsx
@@ -13,8 +13,10 @@ import {
   LanguageSelector,
   Logo,
   DisplayOnPageYOffset,
-  BreadcrumbBlock,
+  HeaderBreadcrumb,
 } from '@ndla/ui';
+import styled from '@emotion/styled';
+import { breakpoints, mq, spacing } from '@ndla/core';
 import { useLocation } from 'react-router-dom';
 import { useLazyQuery } from '@apollo/client';
 
@@ -44,6 +46,12 @@ import { setClosedAlert, useAlerts } from '../../components/AlertsContext';
 import { SKIP_TO_CONTENT_ID } from '../../constants';
 import MastheadMenuModal from './components/MastheadMenuModal';
 
+const BreadcrumbWrapper = styled.div`
+  margin-left: ${spacing.normal};
+  ${mq.range({ until: breakpoints.desktop })} {
+    display: none;
+  }
+`;
 interface State {
   subject?: GQLMastHeadQuery['subject'];
   topicPath: GQLTopicInfoFragment[];
@@ -140,15 +148,17 @@ const MastheadContainer = () => {
           </MastheadMenuModal>
           {!hideBreadcrumb && (
             <DisplayOnPageYOffset yOffsetMin={150}>
-              <BreadcrumbBlock
-                items={
-                  breadcrumbBlockItems.length > 1
-                    ? breadcrumbBlockItems
-                        .slice(1)
-                        .map(uri => ({ name: uri.name!, to: uri.to! }))
-                    : []
-                }
-              />
+              <BreadcrumbWrapper>
+                <HeaderBreadcrumb
+                  items={
+                    breadcrumbBlockItems.length > 1
+                      ? breadcrumbBlockItems
+                          .slice(1)
+                          .map(uri => ({ name: uri.name!, to: uri.to! }))
+                      : []
+                  }
+                />
+              </BreadcrumbWrapper>
             </DisplayOnPageYOffset>
           )}
         </MastheadItem>

--- a/src/containers/Masthead/MastheadContainer.tsx
+++ b/src/containers/Masthead/MastheadContainer.tsx
@@ -150,6 +150,7 @@ const MastheadContainer = () => {
             <DisplayOnPageYOffset yOffsetMin={150}>
               <BreadcrumbWrapper>
                 <HeaderBreadcrumb
+                  light={ndlaFilm}
                   items={
                     breadcrumbBlockItems.length > 1
                       ? breadcrumbBlockItems

--- a/yarn.lock
+++ b/yarn.lock
@@ -3016,16 +3016,16 @@
     "@ndla/icons" "^1.7.1"
     "@reach/dialog" "^0.16.2"
 
-"@ndla/notion@^3.1.7":
-  version "3.1.7"
-  resolved "https://registry.yarnpkg.com/@ndla/notion/-/notion-3.1.7.tgz#fa94058efcd3c9cfc95eea11c19b2df84653466f"
-  integrity sha512-NeijT7GYKViVLDjvOG8f6EFQlfD0eGxoTbdFOiplFFcsC2Im5ydsHew02d1cYBG06Sdp+VW5EXHGJnmYnUOKxQ==
+"@ndla/notion@^3.1.8":
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/@ndla/notion/-/notion-3.1.8.tgz#d183ee6d08187ce5c1d5aa21e4a96c300dfb94d2"
+  integrity sha512-81nXorG6urw9K5Ox/dEdwMsP+6FY7ZENKKNzu833Y5/qGtQAmIweT7OW6Z/mdvH4vYAnOAmYMV5dlxU/B9YFug==
   dependencies:
     "@ndla/core" "^2.1.1"
     "@ndla/icons" "^1.7.1"
     "@ndla/licenses" "^4.1.2"
     "@ndla/modal" "^1.2.8"
-    "@ndla/safelink" "^2.0.1"
+    "@ndla/safelink" "^2.0.2"
 
 "@ndla/pager@^1.1.10":
   version "1.1.10"
@@ -3048,6 +3048,14 @@
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@ndla/safelink/-/safelink-2.0.1.tgz#24aa2b54912156d7dfb29d5d0262f870df754130"
   integrity sha512-+cmwe/GlsiVpoINMIgvpHp4wfyA63ekDb05M9ugPFfcy4XsGHdLhgngWs2FaDTSatlxgHQMNqeIAF2MRZf2Ijg==
+  dependencies:
+    "@ndla/button" "^2.2.1"
+    "@ndla/icons" "^1.7.1"
+
+"@ndla/safelink@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@ndla/safelink/-/safelink-2.0.2.tgz#8b31acc220199053ebb29a1e54b30fcc688c9843"
+  integrity sha512-5Tl7i3lH69NuKmtnkwYkFpqfdiJG2tl9c2hubMSj/O+7gwRbuunYj2+BxHGvI5LjffQqd6LfWCro6uVe6ja0oA==
   dependencies:
     "@ndla/button" "^2.2.1"
     "@ndla/icons" "^1.7.1"
@@ -3094,10 +3102,10 @@
   dependencies:
     warning "^4.0.3"
 
-"@ndla/ui@^12.0.2":
-  version "12.0.2"
-  resolved "https://registry.yarnpkg.com/@ndla/ui/-/ui-12.0.2.tgz#14c6109785bedc2daed0e099421eb7e2f927cc56"
-  integrity sha512-lu45yzWQXltcDwJchDl6kbs9Gwd67fazboRxO6fOLWg37/6SB+Ye0XZLII1CtDObqDhI9xt7y9QTUsBJ2tGUuA==
+"@ndla/ui@^13.0.0":
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/@ndla/ui/-/ui-13.0.0.tgz#81eb4ec7f646c46f1b2c3e674250121d14c430b4"
+  integrity sha512-t8J2XlqTjMPEcPUC7txC8ra50y5rrtsYBbA9d5ZvwXosZ9XY+AKDIbLgPhDZLbosr2kIidW77JofrsxSGVUB5Q==
   dependencies:
     "@ndla/button" "^2.2.1"
     "@ndla/carousel" "^1.2.7"
@@ -3106,8 +3114,8 @@
     "@ndla/icons" "^1.7.1"
     "@ndla/licenses" "^4.1.2"
     "@ndla/modal" "^1.2.8"
-    "@ndla/notion" "^3.1.7"
-    "@ndla/safelink" "^2.0.1"
+    "@ndla/notion" "^3.1.8"
+    "@ndla/safelink" "^2.0.2"
     "@ndla/switch" "^0.1.5"
     "@ndla/tabs" "^1.1.6"
     "@ndla/tooltip" "^0.3.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3102,10 +3102,10 @@
   dependencies:
     warning "^4.0.3"
 
-"@ndla/ui@^13.0.0":
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/@ndla/ui/-/ui-13.0.0.tgz#81eb4ec7f646c46f1b2c3e674250121d14c430b4"
-  integrity sha512-t8J2XlqTjMPEcPUC7txC8ra50y5rrtsYBbA9d5ZvwXosZ9XY+AKDIbLgPhDZLbosr2kIidW77JofrsxSGVUB5Q==
+"@ndla/ui@^13.1.0":
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/@ndla/ui/-/ui-13.1.0.tgz#271d3f77f7876322f11a1eac88f58caca6ec5047"
+  integrity sha512-C2kn01sdC8/z4GwwE+xnlyqiI9Q0f7BkHZw4Ry4L4WAui1VRNEohJo4P9BYG7/0TwGuJZItQBeRRXke6BZnJPw==
   dependencies:
     "@ndla/button" "^2.2.1"
     "@ndla/carousel" "^1.2.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3102,10 +3102,10 @@
   dependencies:
     warning "^4.0.3"
 
-"@ndla/ui@^13.1.0":
-  version "13.1.0"
-  resolved "https://registry.yarnpkg.com/@ndla/ui/-/ui-13.1.0.tgz#271d3f77f7876322f11a1eac88f58caca6ec5047"
-  integrity sha512-C2kn01sdC8/z4GwwE+xnlyqiI9Q0f7BkHZw4Ry4L4WAui1VRNEohJo4P9BYG7/0TwGuJZItQBeRRXke6BZnJPw==
+"@ndla/ui@^13.1.1":
+  version "13.1.1"
+  resolved "https://registry.yarnpkg.com/@ndla/ui/-/ui-13.1.1.tgz#fa4593b168dfdb40682f7a0da5ef1c26813d57a0"
+  integrity sha512-8+qzD8ZbwspEWeAUcTwdMe1Ywv9cJUpgWFrWejhjuV8DzdzhK0ji6sjHbnCY+abW0mPcEXelelpE9QYPa3zZ5w==
   dependencies:
     "@ndla/button" "^2.2.1"
     "@ndla/carousel" "^1.2.7"


### PR DESCRIPTION
Har oppdatert brødsmulestier til siste versjon. Her skal det ikke være noen endringer. Brødsmulestier skal se ut og oppføre seg likt som før. Noen små variasjoner i marginer osv kan det være.

Noen steder brødsmulestier finnes
- Masthead i ndla-film. Dukker opp ved scroll
- Masthead i artikler, emner. Trykk feks inn på tverrfaglige emner. Dukker opp ved scroll.
- Toppen av læringsressurs
- Toppen av læringsressurs i ndla film