### PR TITLE
Extract userinfo displayed in AuthModal to own, reusable component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,12 +23,14 @@ import LoginProviders from './containers/Login/LoginProviders';
 import LoginSuccess from './containers/Login/LoginSuccess';
 import LogoutProviders from './containers/Logout/LogoutProviders';
 import LogoutSession from './containers/Logout/LogoutSession';
+import MyNdlaPage from './containers/MyNdlaPage/MyNdlaPage';
 import NotFound from './containers/NotFoundPage/NotFoundPage';
 import Layout from './containers/Page/Layout';
 import PlainArticlePage from './containers/PlainArticlePage/PlainArticlePage';
 import PlainLearningpathPage from './containers/PlainLearningpathPage/PlainLearningpathPage';
 import PodcastSeriesListPage from './containers/PodcastPage/PodcastSeriesListPage';
 import PodcastSeriesPage from './containers/PodcastPage/PodcastSeriesPage';
+import PrivateRoute from './containers/PrivateRoute/PrivateRoute';
 import ProgrammePage from './containers/ProgrammePage/ProgrammePage';
 import ResourcePage from './containers/ResourcePage/ResourcePage';
 import SearchPage from './containers/SearchPage/SearchPage';
@@ -109,6 +111,10 @@ const AppRoutes = ({ base, resCookie }: AppProps) => {
                     <Route index element={<LogoutProviders />} />
                     <Route path="session" element={<LogoutSession />} />
                   </Route>
+                  <Route
+                    path="minNDLA"
+                    element={<PrivateRoute element={<MyNdlaPage />} />}
+                  />
                 </>
               )}
               <Route path="subjects" element={<AllSubjectsPage />} />

--- a/src/components/FeideLoginButton/FeideLoginButton.tsx
+++ b/src/components/FeideLoginButton/FeideLoginButton.tsx
@@ -16,6 +16,8 @@ import styled from '@emotion/styled';
 import { StyledButton } from '@ndla/button';
 
 import { AuthContext } from '../AuthenticationContext';
+import Modal, { ModalCloseButton } from '@ndla/modal';
+import { UserInfo } from '../UserInfo';
 
 const FeideButton = styled(StyledButton)`
   background: transparent;
@@ -69,6 +71,14 @@ const FeideLoginButton = ({ footer, children }: Props) => {
     user?.displayName,
     ...(user?.mail ? user.mail : []),
   ]);
+  return (
+    <Modal>
+      {(onClose: () => void) => {
+        if (!user) return null;
+        return <UserInfo user={user} />;
+      }}
+    </Modal>
+  );
 
   return (
     <AuthModal

--- a/src/components/UserInfo.tsx
+++ b/src/components/UserInfo.tsx
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2022-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import styled from '@emotion/styled';
+import { fonts, spacing } from '@ndla/core';
+import { compact } from 'lodash';
+import { useTranslation } from 'react-i18next';
+import { FeideUserWithGroups } from '../util/feideApi';
+
+const InfoList = styled.ul`
+  margin: 0;
+  padding: 0 0 0 ${spacing.normal};
+
+  li {
+    margin: 0;
+    font-weight: ${fonts.weight.semibold};
+  }
+`;
+
+interface Props {
+  user: FeideUserWithGroups;
+}
+
+export const UserInfo = ({ user }: Props) => {
+  const { t } = useTranslation();
+
+  const {
+    mail,
+    displayName,
+    eduPersonPrimaryAffiliation: affiliationRole,
+    primarySchool,
+  } = user;
+
+  const collectedInfo: string[] = compact([
+    primarySchool?.displayName,
+    t(`user.role.${affiliationRole}`) as string,
+    displayName,
+    ...(mail ? mail : []),
+  ]);
+
+  return (
+    <div>
+      {affiliationRole && (
+        <p>
+          {t('user.loggedInAs', {
+            role: affiliationRole,
+          })}
+        </p>
+      )}
+      {collectedInfo && collectedInfo.length > 0 && (
+        <>
+          {t('user.modal.collectedInfo')}
+          <InfoList>
+            {collectedInfo.map(value => (
+              <li key={value}>{value}</li>
+            ))}
+          </InfoList>
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/containers/MyNdlaPage/MyNdlaPage.tsx
+++ b/src/containers/MyNdlaPage/MyNdlaPage.tsx
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2016-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import styled from '@emotion/styled';
+import { useContext } from 'react';
+import { AuthContext } from '../../components/AuthenticationContext';
+import { UserInfo } from '../../components/UserInfo';
+
+const Wrapper = styled.div`
+  padding: 4rem 2rem;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 20;
+`;
+
+const MyNdlaPage = () => {
+  const { user } = useContext(AuthContext);
+  if (!user) return <div>No user...</div>;
+  return (
+    <Wrapper>
+      <UserInfo user={user} />
+    </Wrapper>
+  );
+};
+
+export default MyNdlaPage;


### PR DESCRIPTION
`AuthModal` sin render av en brukers info er nå dratt ut i en egen komponent. 

Closes NDLANO/Issues#3149