### PR TITLE
Set stored language as a cookie instead of in local storage

### DIFF
--- a/src/client.tsx
+++ b/src/client.tsx
@@ -25,6 +25,7 @@ import '@fontsource/source-serif-pro/index.css';
 // @ts-ignore
 import ErrorReporter from '@ndla/error-reporter';
 import { i18nInstance } from '@ndla/ui';
+import { getCookie, setCookie } from '@ndla/util';
 import { createBrowserHistory, createMemoryHistory, History } from 'history';
 // @ts-ignore
 import queryString from 'query-string';
@@ -36,7 +37,7 @@ import { Router } from 'react-router-dom';
 import App from './App';
 import { VersionHashProvider } from './components/VersionHashContext';
 import { getDefaultLocale } from './config';
-import { EmotionCacheKey, STORED_LANGUAGE_KEY } from './constants';
+import { EmotionCacheKey, STORED_LANGUAGE_COOKIE_KEY } from './constants';
 import {
   getLocaleInfoFromPath,
   initializeI18n,
@@ -70,12 +71,18 @@ const locationFromServer = {
   search: serverQueryString ? `?${serverQueryString}` : '',
 };
 
-const maybeStoredLanguage = window.localStorage.getItem(STORED_LANGUAGE_KEY);
+const maybeStoredLanguage = getCookie(
+  STORED_LANGUAGE_COOKIE_KEY,
+  document.cookie,
+);
 // Set storedLanguage to a sane value if non-existent
 if (maybeStoredLanguage === null || maybeStoredLanguage === undefined) {
-  window.localStorage.setItem(STORED_LANGUAGE_KEY, config.defaultLocale);
+  setCookie({
+    cookieName: STORED_LANGUAGE_COOKIE_KEY,
+    cookieValue: config.defaultLocale,
+  });
 }
-const storedLanguage = window.localStorage.getItem(STORED_LANGUAGE_KEY)!;
+const storedLanguage = getCookie(STORED_LANGUAGE_COOKIE_KEY, document.cookie)!;
 const i18n = initializeI18n(i18nInstance, storedLanguage);
 
 window.errorReporter = ErrorReporter.getInstance({
@@ -88,7 +95,7 @@ window.errorReporter = ErrorReporter.getInstance({
 window.hasHydrated = false;
 const renderOrHydrate = config.disableSSR ? ReactDOM.render : ReactDOM.hydrate;
 
-const client = createApolloClient(basename, document.cookie, versionHash);
+const client = createApolloClient(storedLanguage, document.cookie, versionHash);
 const cache = createCache({ key: EmotionCacheKey });
 
 // Use memory router if running under google translate
@@ -188,9 +195,12 @@ const LanguageWrapper = ({ basename }: { basename?: string }) => {
   const windowPath = useReactPath();
 
   i18n.on('languageChanged', lang => {
+    setCookie({
+      cookieName: STORED_LANGUAGE_COOKIE_KEY,
+      cookieValue: lang,
+    });
     client.resetStore();
     client.setLink(createApolloLinks(lang, resCookie, versionHash));
-    window.localStorage.setItem(STORED_LANGUAGE_KEY, lang);
     document.documentElement.lang = lang;
   });
 
@@ -206,7 +216,10 @@ const LanguageWrapper = ({ basename }: { basename?: string }) => {
 
   // handle initial redirect if URL has wrong or missing locale prefix.
   useLayoutEffect(() => {
-    const storedLanguage = window.localStorage.getItem(STORED_LANGUAGE_KEY)!;
+    const storedLanguage = getCookie(
+      STORED_LANGUAGE_COOKIE_KEY,
+      document.cookie,
+    )!;
     if (storedLanguage === getDefaultLocale() && !base) return;
     if (isValidLocale(storedLanguage) && storedLanguage === base) {
       setBase(storedLanguage);

--- a/src/client.tsx
+++ b/src/client.tsx
@@ -53,7 +53,7 @@ declare global {
 }
 
 const {
-  DATA: { config, serverPath, serverQuery, resCookie },
+  DATA: { config, serverPath, serverQuery, resCookie = '' },
 } = window;
 
 const { basepath } = getLocaleInfoFromPath(serverPath ?? '');
@@ -215,6 +215,7 @@ const LanguageWrapper = ({ basename }: { basename?: string }) => {
   }, [i18n.language]);
 
   // handle initial redirect if URL has wrong or missing locale prefix.
+  // only relevant when disableSSR=true
   useLayoutEffect(() => {
     const storedLanguage = getCookie(
       STORED_LANGUAGE_COOKIE_KEY,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,7 +31,7 @@ export const TOOLBOX_STUDENT_SUBJECT_ID =
 
 export const SKIP_TO_CONTENT_ID = 'SkipToContentId';
 export const SUPPORTED_LANGUAGES = ['nb', 'nn', 'en'];
-export const STORED_LANGUAGE_KEY = 'language';
+export const STORED_LANGUAGE_COOKIE_KEY = 'language';
 
 export const PROGRAMME_PATH = '/utdanning';
 

--- a/src/lti/LtiProvider.tsx
+++ b/src/lti/LtiProvider.tsx
@@ -10,6 +10,7 @@ import { useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useApolloClient } from '@apollo/client';
+import { setCookie } from '@ndla/util';
 
 import SearchInnerPage from '../containers/SearchPage/SearchInnerPage';
 import ErrorPage from '../containers/ErrorPage/ErrorPage';
@@ -18,7 +19,10 @@ import { searchPageQuery } from '../queries';
 import ErrorBoundary from '../containers/ErrorPage/ErrorBoundary';
 import { useGraphQuery } from '../util/runQueries';
 import { searchSubjects } from '../util/searchHelpers';
-import { RESOURCE_TYPE_LEARNING_PATH, STORED_LANGUAGE_KEY } from '../constants';
+import {
+  RESOURCE_TYPE_LEARNING_PATH,
+  STORED_LANGUAGE_COOKIE_KEY,
+} from '../constants';
 import { LocaleType, LtiData } from '../interfaces';
 import { GQLSearchPageQuery } from '../graphqlTypes';
 import { createApolloLinks } from '../util/apiHelpers';
@@ -60,7 +64,7 @@ const LtiProvider = ({ locale: propsLocale, ltiData }: Props) => {
   i18n.on('languageChanged', lang => {
     client.resetStore();
     client.setLink(createApolloLinks(lang));
-    window.localStorage.setItem(STORED_LANGUAGE_KEY, lang);
+    setCookie({ cookieName: STORED_LANGUAGE_COOKIE_KEY, cookieValue: lang });
     document.documentElement.lang = lang;
   });
 

--- a/src/lti/index.tsx
+++ b/src/lti/index.tsx
@@ -27,10 +27,11 @@ import '@fontsource/source-code-pro/700.css';
 import '@fontsource/source-serif-pro/index.css';
 import '@fontsource/source-serif-pro/400-italic.css';
 import '@fontsource/source-serif-pro/700.css';
+import { getCookie } from '@ndla/util';
 import { createApolloClient } from '../util/apiHelpers';
 import LtiProvider from './LtiProvider';
 import '../style/index.css';
-import { STORED_LANGUAGE_KEY } from '../constants';
+import { STORED_LANGUAGE_COOKIE_KEY } from '../constants';
 import { initializeI18n, isValidLocale } from '../i18n';
 
 const {
@@ -46,7 +47,7 @@ window.errorReporter = ErrorReporter.getInstance({
   ignoreUrls: [/https:\/\/.*hotjar\.com.*/],
 });
 
-const storedLanguage = window.localStorage.getItem(STORED_LANGUAGE_KEY);
+const storedLanguage = getCookie(STORED_LANGUAGE_COOKIE_KEY, document.cookie);
 const language = isValidLocale(storedLanguage)
   ? storedLanguage
   : config.defaultLocale;

--- a/src/server/routes/defaultRoute.js
+++ b/src/server/routes/defaultRoute.js
@@ -14,6 +14,7 @@ import url from 'url';
 import { ApolloProvider } from '@apollo/client';
 import { CacheProvider } from '@emotion/core';
 import createCache from '@emotion/cache';
+import { getCookie } from '@ndla/util';
 
 import RedirectContext from '../../components/RedirectContext';
 import App from '../../App';
@@ -21,7 +22,7 @@ import config from '../../config';
 import { createApolloClient } from '../../util/apiHelpers';
 import { getLocaleInfoFromPath, initializeI18n } from '../../i18n';
 import { renderHtml, renderPageWithData } from '../helpers/render';
-import { EmotionCacheKey } from '../../constants';
+import { EmotionCacheKey, STORED_LANGUAGE_COOKIE_KEY } from '../../constants';
 import { VersionHashProvider } from '../../components/VersionHashContext';
 
 const assets = require(process.env.RAZZLE_ASSETS_MANIFEST); //eslint-disable-line
@@ -45,7 +46,8 @@ async function doRender(req) {
   global.assets = assets; // used for including mathjax js in pages with math
   const resCookie = req.headers['cookie'];
   const versionHash = req.query.versionHash;
-  const { abbreviation: locale, basename } = getLocaleInfoFromPath(req.path);
+  const { basename } = getLocaleInfoFromPath(req.path);
+  const locale = getCookie(STORED_LANGUAGE_COOKIE_KEY, resCookie);
 
   const client = createApolloClient(locale, resCookie, versionHash);
 


### PR DESCRIPTION
Relatert til https://trello.com/c/IMRsQNDm/1725-bug-bokm%C3%A5l-artikkel-p%C3%A5-nynorsk-url
I prod nå vil det oppstå en mismatch i språket som brukes av server og client dersom man går til /nn/ når det lagrede språket ditt er `nb`. Da blir man automatisk redirectet til `/nb/`, men dette skjer client-side. Siden er allerede returnert fra serveren, og vil derfor være på nynorsk. Det er uheldig.

Løsningen er å flytte det lagrede språket fra localStorage til cookies. Da har vi muligheten til å lese det på server, for deretter å sette riktig språk uavhengig av om `basename` egentlig matcher. Dette kan føre til litt rare situasjoner, som i at `/nn/` kan returnere bokmål, men det er kanskje ikke så viktig? Alternativt kan vi gjøre en redirect til /nb/ på server.