### PR TITLE
Overstyrer en tekst fra frontend-packages for å slippe å bumpe ndla-ui.

### DIFF
--- a/e2e/integration/topic_page.spec.ts
+++ b/e2e/integration/topic_page.spec.ts
@@ -9,12 +9,9 @@
 describe('Topic page', () => {
   beforeEach(() => {
     cy.fixCypressSpec('/cypress/integration/topic_page.spec.ts');
-
+    cy.gqlIntercept({ alias: 'alerts', operations: ['alerts'] });
     cy.visit('/?disableSSR=true');
-    cy.gqlIntercept({
-      alias: 'alerts',
-      operations: ['alerts'],
-    });
+    cy.gqlWait('@alerts');
     cy.gqlIntercept({
       alias: 'medieutrykk',
       operations: ['mastHead', 'subjectPageTest'],
@@ -22,10 +19,11 @@ describe('Topic page', () => {
 
     cy.get('[data-testid="category-list"]  button:contains("Alle fag"):visible')
       .click()
-      .get('a:contains("Medieuttrykk 3")')
+      .get('[data-cy="Alle fag-video-tab"]')
+      .click()
+      .get('a:contains("Medieuttrykk 3 og mediesamfunnet 3")')
       .last()
       .click({ force: true });
-    cy.gqlWait('@alerts');
     cy.gqlWait('@medieutrykk');
   });
 

--- a/e2e/integration/topic_page.spec.ts
+++ b/e2e/integration/topic_page.spec.ts
@@ -22,7 +22,7 @@ describe('Topic page', () => {
 
     cy.get('[data-testid="category-list"]  button:contains("Alle fag"):visible')
       .click()
-      .get('a:contains("Medieuttrykk 3 og mediesamfunnet 3")')
+      .get('a:contains("Medieuttrykk 3")')
       .last()
       .click({ force: true });
     cy.gqlWait('@alerts');

--- a/src/containers/ArticlePage/components/ArticleHero.tsx
+++ b/src/containers/ArticlePage/components/ArticleHero.tsx
@@ -67,7 +67,7 @@ const ArticleHero = ({
         <div className="c-hero__content">
           <section>
             {subject && (
-              <HomeBreadcrumb light={ndlaFilm} items={breadcrumbItems} />
+              <HomeBreadcrumb light={ndlaFilm ? ndlaFilm : undefined} items={breadcrumbItems} />
             )}
           </section>
         </div>

--- a/src/containers/ArticlePage/components/ArticleHero.tsx
+++ b/src/containers/ArticlePage/components/ArticleHero.tsx
@@ -67,7 +67,10 @@ const ArticleHero = ({
         <div className="c-hero__content">
           <section>
             {subject && (
-              <HomeBreadcrumb light={ndlaFilm ? ndlaFilm : undefined} items={breadcrumbItems} />
+              <HomeBreadcrumb
+                light={ndlaFilm ? ndlaFilm : undefined}
+                items={breadcrumbItems}
+              />
             )}
           </section>
         </div>

--- a/src/containers/ArticlePage/components/ArticleHero.tsx
+++ b/src/containers/ArticlePage/components/ArticleHero.tsx
@@ -67,10 +67,7 @@ const ArticleHero = ({
         <div className="c-hero__content">
           <section>
             {subject && (
-              <HomeBreadcrumb
-                light={ndlaFilm ? ndlaFilm : undefined}
-                items={breadcrumbItems}
-              />
+              <HomeBreadcrumb light={ndlaFilm} items={breadcrumbItems} />
             )}
           </section>
         </div>

--- a/src/containers/WelcomePage/FrontpageSubjects.tsx
+++ b/src/containers/WelcomePage/FrontpageSubjects.tsx
@@ -22,6 +22,7 @@ const FrontpageSubjects = ({ locale }: Props) => (
   <FrontpageProgramMenu
     programItems={getProgrammes(locale)}
     subjectCategories={getCategorizedSubjects(locale)}
+    showBetaCursor={true}
   />
 );
 

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -75,8 +75,8 @@ export const initializeI18n = (i18n: i18n, language: string): i18n => {
     lng: language,
     supportedLngs: preferredLanguages,
   });
-  i18n.addResourceBundle('en', 'translation', en, true, false);
-  i18n.addResourceBundle('nb', 'translation', nb, true, false);
-  i18n.addResourceBundle('nn', 'translation', nn, true, false);
+  i18n.addResourceBundle('en', 'translation', en, true, true);
+  i18n.addResourceBundle('nb', 'translation', nb, true, true);
+  i18n.addResourceBundle('nn', 'translation', nn, true, true);
   return instance;
 };

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -75,8 +75,8 @@ export const initializeI18n = (i18n: i18n, language: string): i18n => {
     lng: language,
     supportedLngs: preferredLanguages,
   });
-  i18n.addResourceBundle('en', 'translation', en, false, false);
-  i18n.addResourceBundle('nb', 'translation', nb, false, false);
-  i18n.addResourceBundle('nn', 'translation', nn, false, false);
+  i18n.addResourceBundle('en', 'translation', en, true, false);
+  i18n.addResourceBundle('nb', 'translation', nb, true, false);
+  i18n.addResourceBundle('nn', 'translation', nn, true, false);
   return instance;
 };

--- a/src/messages/messagesEN.ts
+++ b/src/messages/messagesEN.ts
@@ -34,6 +34,9 @@ const messages = {
     pageInfo: 'Page {{page}} of {{lastPage}}',
     noResults: '...No episodes',
   },
+  messageBoxInfo: {
+    subjectBeta: 'This course is in beta. New resources are being added continously.',
+  },
   blogPosts: {
     blog1: {
       imageUrl: '/static/nye-fag.jpg',

--- a/src/messages/messagesEN.ts
+++ b/src/messages/messagesEN.ts
@@ -35,7 +35,8 @@ const messages = {
     noResults: '...No episodes',
   },
   messageBoxInfo: {
-    subjectBeta: 'This course is in beta. New resources are being added continously.',
+    subjectBeta:
+      'This course is in beta. New resources are being added continously.',
   },
   blogPosts: {
     blog1: {

--- a/src/messages/messagesNB.ts
+++ b/src/messages/messagesNB.ts
@@ -34,6 +34,9 @@ const messages = {
     pageInfo: 'Side {{page}} av {{lastPage}}',
     noResults: '...Ingen episoder',
   },
+  messageBoxInfo: {
+    subjectBeta: 'Dette faget er i betaversjon. Vi fyller på med ressurser fortløpende.',
+  },
   blogPosts: {
     blog1: {
       imageUrl: '/static/nye-fag.jpg',

--- a/src/messages/messagesNB.ts
+++ b/src/messages/messagesNB.ts
@@ -35,7 +35,8 @@ const messages = {
     noResults: '...Ingen episoder',
   },
   messageBoxInfo: {
-    subjectBeta: 'Dette faget er i betaversjon. Vi fyller på med ressurser fortløpende.',
+    subjectBeta:
+      'Dette faget er i betaversjon. Vi fyller på med ressurser fortløpende.',
   },
   blogPosts: {
     blog1: {

--- a/src/messages/messagesNN.ts
+++ b/src/messages/messagesNN.ts
@@ -34,6 +34,9 @@ const messages = {
     pageInfo: 'Side {{page}} av {{lastPage}}',
     noResults: '...Ingen episoder',
   },
+  messageBoxInfo: {
+    subjectBeta: 'Dette faget er i betaversjon. Vi fyller på med ressurser fortløpande.',
+  },
   blogPosts: {
     blog1: {
       imageUrl: '/static/nye-fag.jpg',

--- a/src/messages/messagesNN.ts
+++ b/src/messages/messagesNN.ts
@@ -35,7 +35,8 @@ const messages = {
     noResults: '...Ingen episoder',
   },
   messageBoxInfo: {
-    subjectBeta: 'Dette faget er i betaversjon. Vi fyller på med ressurser fortløpande.',
+    subjectBeta:
+      'Dette faget er i betaversjon. Vi fyller på med ressurser fortløpande.',
   },
   blogPosts: {
     blog1: {


### PR DESCRIPTION
Som tittelen forteller. Fikser https://trello.com/c/SxY8ouUe/1731-legge-til-utfyllende-tekst-i-gult-varslingsfelt-p%C3%A5-toppen-av-siden-for-beta