### PR TITLE
Old sti-url is long gone. No need for embedding anymore.

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -75,10 +75,9 @@ const ndlaMiddleware = [
     frameguard:
       process.env.NODE_ENV === 'development'
         ? {
-            action: 'allow-from',
-            domain: '*://localhost',
+            action: 'sameorigin',
           }
-        : { action: 'allow-from', domain: '*://sti.ndla.no' },
+        : { action: 'deny' },
   }),
 ];
 


### PR DESCRIPTION
Fixes NDLANO/Issues#3179

allow-from ignoreres uansett av frameguard, samt at fleste nettlesere ikkje lenger støtter det. Behovet vi hadde for å godkjenne sti.ndla.no er borte for lengst.