### PR TITLE
Send isOembed-param to CompetenceGoalTab

### DIFF
--- a/src/components/Article/Article.tsx
+++ b/src/components/Article/Article.tsx
@@ -40,7 +40,7 @@ function renderCompetenceGoals(
   article: GQLArticle_ArticleFragment,
   isTopicArticle: boolean,
   subjectId?: string,
-  isPlainArticle?: boolean,
+  isOembed?: boolean,
 ):
   | ((inp: {
       Dialog: ComponentType;
@@ -67,7 +67,7 @@ function renderCompetenceGoals(
         supportedLanguages={article.supportedLanguages}
         wrapperComponent={Dialog}
         wrapperComponentProps={dialogProps}
-        isOembed={isPlainArticle}
+        isOembed={isOembed}
       />
     );
   }
@@ -88,6 +88,7 @@ interface Props {
   printUrl?: string;
   subjectId?: string;
   isPlainArticle?: boolean;
+  isOembed?: boolean;
   showFavoriteButton?: boolean;
 }
 
@@ -198,6 +199,7 @@ const Article = ({
   id,
   subjectId,
   isPlainArticle,
+  isOembed = false,
   showFavoriteButton,
   ...rest
 }: Props) => {
@@ -292,7 +294,7 @@ const Article = ({
           article,
           isTopicArticle,
           subjectId,
-          isPlainArticle,
+          isOembed,
         )}
         competenceGoalTypes={competenceGoalTypes}
         notions={

--- a/src/components/Article/Article.tsx
+++ b/src/components/Article/Article.tsx
@@ -40,6 +40,7 @@ function renderCompetenceGoals(
   article: GQLArticle_ArticleFragment,
   isTopicArticle: boolean,
   subjectId?: string,
+  isPlainArticle?: boolean,
 ):
   | ((inp: {
       Dialog: ComponentType;
@@ -66,6 +67,7 @@ function renderCompetenceGoals(
         supportedLanguages={article.supportedLanguages}
         wrapperComponent={Dialog}
         wrapperComponentProps={dialogProps}
+        isOembed={isPlainArticle}
       />
     );
   }
@@ -290,6 +292,7 @@ const Article = ({
           article,
           isTopicArticle,
           subjectId,
+          isPlainArticle,
         )}
         competenceGoalTypes={competenceGoalTypes}
         notions={

--- a/src/components/CompetenceGoals.tsx
+++ b/src/components/CompetenceGoals.tsx
@@ -25,6 +25,7 @@ interface Props {
   nodeId?: string;
   wrapperComponent: ComponentType;
   wrapperComponentProps: any;
+  isOembed?: boolean;
 }
 
 // We swap 'title' for 'name' when we fetch CompetenceGoals from GraphQL
@@ -196,6 +197,7 @@ const CompetenceGoals = ({
   wrapperComponent: Component,
   wrapperComponentProps,
   supportedLanguages,
+  isOembed,
 }: Props) => {
   const { t, i18n } = useTranslation();
   const language =
@@ -260,7 +262,7 @@ const CompetenceGoals = ({
 
   return (
     <Component {...wrapperComponentProps}>
-      <CompetenceGoalTab list={competenceGoalsList} />
+      <CompetenceGoalTab list={competenceGoalsList} isOembed={isOembed} />
     </Component>
   );
 };

--- a/src/iframe/IframeArticlePage.tsx
+++ b/src/iframe/IframeArticlePage.tsx
@@ -71,6 +71,7 @@ const IframeArticlePage = ({
       <Article
         article={article}
         isPlainArticle
+        isOembed
         modifier="clean iframe"
         {...getArticleProps(resource)}>
         <CreatedBy

--- a/src/iframe/IframeTopicPage.tsx
+++ b/src/iframe/IframeTopicPage.tsx
@@ -91,6 +91,7 @@ export const IframeTopicPage = ({
           article={article}
           label={t('topicPage.topic')}
           isPlainArticle
+          isOembed
           contentType={constants.contentTypes.TOPIC}>
           <CreatedBy
             name={t('createdBy.content')}


### PR DESCRIPTION
Fixes NDLANO/Issues#3161

Bruker isOembed for å sette at søk etter kompetansemål skal åpne i ny fane. Brukes kun fra iframe-sidene.