### PR TITLE
Save new folders as refs instead of full objects in order to fix mutations on root folders

### DIFF
--- a/src/containers/MyNdla/folderMutations.ts
+++ b/src/containers/MyNdla/folderMutations.ts
@@ -268,7 +268,9 @@ export const useAddFolderMutation = () => {
         client.cache.modify({
           fields: {
             folders: (existingFolders = []) =>
-              existingFolders.concat(newFolder),
+              existingFolders.concat({
+                __ref: client.cache.identify(newFolder),
+              }),
           },
         });
       } else {


### PR DESCRIPTION
Her har jeg gjort en liten bommert. Dette fikser tre ting:
* Sletting av mapper på rotnivå
* Oppdatering av antall ressurser/submapper på en rotmappe
* Å legge til ressurser på nylig opprettede rotmapper.