### PR TITLE
Remove show translation in favor of having the folder link as the link name

### DIFF
--- a/src/components/MyNdla/AddResourceToFolder.tsx
+++ b/src/components/MyNdla/AddResourceToFolder.tsx
@@ -77,13 +77,11 @@ const ResourceAddedSnack = ({ folder }: ResourceAddedSnackProps) => {
   return (
     <StyledResourceAddedSnack>
       <StyledResource>
-        {t('myNdla.resource.addedToFolder', {
-          folderName: folder.name,
-        })}
+        {t('myNdla.resource.addedToFolder')}
+        <StyledSafeLink to={`/minndla/folders/${folder.id}`}>
+          "{folder.name}"
+        </StyledSafeLink>
       </StyledResource>
-      <StyledSafeLink to={`/minndla/folders/${folder.id}`}>
-        {t('myNdla.resource.show')}
-      </StyledSafeLink>
     </StyledResourceAddedSnack>
   );
 };


### PR DESCRIPTION
https://trello.com/c/cLKZmc1R/147-lenke-b%C3%B8r-ligge-p%C3%A5-mappenavn-ikke-vis-ord
Avhengig av https://github.com/NDLANO/frontend-packages/pull/1263