### PR TITLE
Load tags after importing folders

### DIFF
--- a/src/components/MyNdla/AddResourceToFolder.tsx
+++ b/src/components/MyNdla/AddResourceToFolder.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import { isEqual, sortBy, uniq } from 'lodash';
+import { compact, isEqual, sortBy, uniq } from 'lodash';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from '@emotion/styled';
@@ -93,9 +93,7 @@ const AddResourceToFolder = ({ onClose, resource }: Props) => {
   const [storedResource, setStoredResource] = useState<
     GQLFolderResource | undefined
   >(undefined);
-  const [tags, setTags] = useState<{ id: string; name: string }[]>(
-    getAllTags(folders).map(t => ({ id: t, name: t })),
-  );
+  const [tags, setTags] = useState<{ id: string; name: string }[]>([]);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [canSave, setCanSave] = useState<boolean>(false);
   const [alreadyAdded, setAlreadyAdded] = useState(false);
@@ -110,6 +108,11 @@ const AddResourceToFolder = ({ onClose, resource }: Props) => {
       const _storedResource = getResourceForPath(folders, resource.path);
       setStoredResource(_storedResource ?? undefined);
       setSelectedTags(_storedResource?.tags ?? []);
+      setTags(tags =>
+        compact(
+          tags.concat(getAllTags(folders).map(t => ({ id: t, name: t }))),
+        ),
+      );
     }
   }, [loading, folders, resource]);
 


### PR DESCRIPTION
Tags skal nå loades ved førte åpning av modal for å legge til en ressurs i min ndla.

Hvordan teste:
- Start lokalt
- Åpne feks /subject:1:8bfd0a97-d456-448d-8b5f-3bc49e445b37/topic:5:1:165344/topic:4:1:165378/resource:1:100791
- Klikk på hjerte øverst til høyre, legg til noen tags og lagre i en mappe.
- Refresh siden og klikk på hjertet igjen. Tags skal lastes inn med en gang. (På test vises tags som tomt ved første åpning)