### PR TITLE
Add additional garbage collection to reduce risk of invalid ui results

### DIFF
--- a/src/containers/MyNdla/Folders/FoldersPage.tsx
+++ b/src/containers/MyNdla/Folders/FoldersPage.tsx
@@ -115,14 +115,14 @@ const FoldersPage = () => {
   }, [folderId]);
 
   const onFolderAdd = async (name: string) => {
+    setFolderAction(undefined);
+    setIsAdding(false);
     await addFolder({
       variables: {
         name,
         parentId: folderId,
       },
     });
-    setFolderAction(undefined);
-    setIsAdding(false);
   };
 
   const showAddButton = (selectedFolder?.breadcrumbs.length || 0) < 5;

--- a/src/containers/MyNdla/MyNdlaPage.tsx
+++ b/src/containers/MyNdla/MyNdlaPage.tsx
@@ -22,12 +22,10 @@ import { HelmetWithTracker } from '@ndla/tracker';
 import Modal, { ModalBody, ModalCloseButton, ModalHeader } from '@ndla/modal';
 import InfoPart, { InfoPartIcon, InfoPartText } from './InfoSection';
 import { AuthContext } from '../../components/AuthenticationContext';
-import { useGraphQuery } from '../../util/runQueries';
-import { GQLRecentlyUsedQuery } from '../../graphqlTypes';
 import {
-  recentlyUsedQuery,
   useDeletePersonalData,
   useFolderResourceMetaSearch,
+  useRecentlyUsedResources,
 } from './folderMutations';
 import TermsOfService from '../../components/MyNdla/TermsOfService';
 import IsMobileContext from '../../IsMobileContext';
@@ -120,9 +118,7 @@ const MyNdlaPage = () => {
   const isMobile = useContext(IsMobileContext);
   const { deletePersonalData } = useDeletePersonalData();
   const navigate = useNavigate();
-  const { data: { allFolderResources = [] } = {} } = useGraphQuery<
-    GQLRecentlyUsedQuery
-  >(recentlyUsedQuery);
+  const { allFolderResources } = useRecentlyUsedResources();
   const { data: metaData, loading } = useFolderResourceMetaSearch(
     allFolderResources.map(r => ({
       id: r.resourceId,


### PR DESCRIPTION
https://trello.com/c/t6C9nLMU/160-har-slettet-alle-mapper-p%C3%A5-min-ndla-f%C3%A5r-da-et-litt-ulogisk-bilde-p%C3%A5-min-side

Jeg klarte aldri å gjenskape problemet, men jeg så at det var flere ressurser som lå igjen i cache etter sletting. Dette kommer mest sannsynligvis av at en/flere queries fortsatt referer til de. Hvis dette ikke holder må vi nesten begynne å slette queries fra cache.

Fikser også https://trello.com/c/xnSAmtRk/159-f%C3%A5r-to-mapper-hvis-jeg-trykker-enter-veldig-raskt-to-ganger-p%C3%A5-rappen på mappe-siden, men ikke i modal.