### PR TITLE
Faget naturbruk er endra

### DIFF
--- a/src/data/programmes.ts
+++ b/src/data/programmes.ts
@@ -2388,6 +2388,12 @@ export const programmes: ProgrammeType[] = [
               {
                 id: 'urn:subject:1:c8d6ed8b-d376-4c7b-b73a-3a1d48c3a357',
               },
+              {
+                id: 'urn:subject:e18b8bf0-326b-45f6-8e95-982de8f34264',
+              },
+              {
+                id: 'urn:subject:c0ce0b31-33f6-4f6f-bbe0-caa878f7ab9b',
+              }
             ],
           },
           {

--- a/src/data/programmes.ts
+++ b/src/data/programmes.ts
@@ -2393,7 +2393,7 @@ export const programmes: ProgrammeType[] = [
               },
               {
                 id: 'urn:subject:c0ce0b31-33f6-4f6f-bbe0-caa878f7ab9b',
-              }
+              },
             ],
           },
           {

--- a/src/data/subjects.ts
+++ b/src/data/subjects.ts
@@ -1441,19 +1441,6 @@ export const activeSubjects: SubjectType[] = [
   },
   {
     longName: {
-      en: 'Naturbruk (NA-NAB vg1)',
-      nb: 'Naturbruk (NA-NAB vg1)',
-      nn: 'Naturbruk (NA-NAB vg1)',
-    },
-    name: {
-      en: 'Programfag Naturbruk',
-      nb: 'Programfag Naturbruk',
-      nn: 'Programfag Naturbruk',
-    },
-    id: 'urn:subject:13',
-  },
-  {
-    longName: {
       en: 'Konstruksjons- og styringsteknikk (TP-TIP vg1)',
       nb: 'Konstruksjons- og styringsteknikk (TP-TIP vg1)',
       nn: 'Konstruksjons- og styringsteknikk (TP-TIP vg1)',


### PR DESCRIPTION
Faget vart splitta i ulike programfag i sommar, dette er no tomt.
>Naturbruk (NA-NAB vg1) er jo delt opp i Naturbasert næringsaktivitet (NA-NAB vg1) og Naturbasert produksjon og tjenesteyting (NA-NAB vg1), så da bør Naturbruk (NA-NAB vg1) fjernes fra forsida. Nå ligger den der helt tømt for innhold.