### PR TITLE
Dont show alt text in resource image

### DIFF
--- a/src/containers/MyNdla/Folders/ResourceList.tsx
+++ b/src/containers/MyNdla/Folders/ResourceList.tsx
@@ -75,7 +75,7 @@ const ResourceList = ({ selectedFolder, viewType, folderId }: Props) => {
               key={resource.id}
               resourceImage={{
                 src: resourceMeta?.metaImage?.url ?? '',
-                alt: resourceMeta?.metaImage?.url ?? '',
+                alt: '',
               }}
               link={resource.path}
               tags={resource.tags}

--- a/src/containers/MyNdla/MyNdlaPage.tsx
+++ b/src/containers/MyNdla/MyNdlaPage.tsx
@@ -172,7 +172,7 @@ const MyNdlaPage = () => {
                 title={meta?.title ?? ''}
                 resourceImage={{
                   src: meta?.metaImage?.url ?? '',
-                  alt: meta?.metaImage?.alt ?? '',
+                  alt: '',
                 }}
                 tags={res.tags}
                 topics={meta?.resourceTypes.map(rt => rt.name) ?? []}

--- a/src/containers/MyNdla/Tags/TagsPage.tsx
+++ b/src/containers/MyNdla/Tags/TagsPage.tsx
@@ -130,7 +130,7 @@ const Resources = ({ resources }: ResourcesProps) => {
               topics={meta?.resourceTypes.map(rt => rt.name) ?? []}
               resourceImage={{
                 src: meta?.metaImage?.url ?? '',
-                alt: meta?.metaImage?.url ?? '',
+                alt: '',
               }}
               menuItems={[
                 {


### PR DESCRIPTION
Fixes https://trello.com/c/nlxTDuuO/129-metabilder-i-lenker-skal-ha-tomt-alt-attributt

Bilder i ressurser skal ha tom alt-tekst siden dette er inni en lenke. Dette skal nå gjelde på alle tre undersider på min ndla.