### PR TITLE
Add recursive counting for subfolders and resources on a folder resource

### DIFF
--- a/src/containers/MyNdla/Folders/FoldersPage.tsx
+++ b/src/containers/MyNdla/Folders/FoldersPage.tsx
@@ -105,14 +105,28 @@ const FoldersPage = () => {
     () => (selectedFolder ? selectedFolder.subfolders : folderData ?? []),
     [selectedFolder, folderData],
   );
+
+  const selectedFolderCount = useMemo(
+    () => (selectedFolder ? getTotalCountForFolder(selectedFolder) : undefined),
+    [selectedFolder],
+  );
+
   const foldersCount = useMemo(
     () =>
-      folders.reduce<Record<string, FolderTotalCount>>((acc, curr) => {
+      folders?.reduce<Record<string, FolderTotalCount>>((acc, curr) => {
         acc[curr.id] = getTotalCountForFolder(curr);
         return acc;
       }, {}),
     [folders],
   );
+
+  const allFoldersCount = useMemo(() => {
+    return (
+      folderData?.reduce((acc, curr) => {
+        return acc + getTotalCountForFolder(curr).folders;
+      }, 0) ?? 0
+    );
+  }, [folderData]);
 
   const { updateFolder } = useUpdateFolderMutation();
 
@@ -158,13 +172,19 @@ const FoldersPage = () => {
       {folders && (
         <ResourceCountContainer>
           <FolderOutlined />
-          <span>{t('myNdla.folders', { count: folders.length })}</span>
+          <span>
+            {t('myNdla.folders', {
+              count: selectedFolder
+                ? selectedFolderCount?.folders
+                : allFoldersCount,
+            })}
+          </span>
           {selectedFolder && (
             <>
               <FileDocumentOutline />
               <span>
                 {t('myNdla.resources', {
-                  count: selectedFolder.resources.length,
+                  count: selectedFolderCount?.resources ?? allFoldersCount,
                 })}
               </span>
             </>

--- a/src/util/folderHelpers.tsx
+++ b/src/util/folderHelpers.tsx
@@ -40,20 +40,19 @@ export interface FolderTotalCount {
 }
 
 export const getTotalCountForFolder = (folder: GQLFolder): FolderTotalCount => {
-  const totalCount = folder.subfolders.reduce<FolderTotalCount>(
+  return folder.subfolders.reduce<FolderTotalCount>(
     (acc, curr) => {
+      const subTotal = getTotalCountForFolder(curr);
       return {
-        folders: acc.folders + curr.subfolders.length,
-        resources: acc.resources + curr.resources.length,
+        folders: acc.folders + subTotal.folders,
+        resources: acc.resources + subTotal.resources,
       };
     },
-    { folders: 0, resources: 0 },
+    {
+      folders: folder.subfolders.length,
+      resources: folder.resources.length,
+    },
   );
-
-  return {
-    folders: folder.subfolders.length + totalCount.folders,
-    resources: folder.resources.length + totalCount.resources,
-  };
 };
 
 export const getResourcesForTag = (

--- a/src/util/folderHelpers.tsx
+++ b/src/util/folderHelpers.tsx
@@ -34,6 +34,28 @@ export const getResourceForPath = (
   return getAllResources(allFolders).find(r => r.path === path);
 };
 
+export interface FolderTotalCount {
+  folders: number;
+  resources: number;
+}
+
+export const getTotalCountForFolder = (folder: GQLFolder): FolderTotalCount => {
+  const totalCount = folder.subfolders.reduce<FolderTotalCount>(
+    (acc, curr) => {
+      return {
+        folders: acc.folders + curr.subfolders.length,
+        resources: acc.resources + curr.resources.length,
+      };
+    },
+    { folders: 0, resources: 0 },
+  );
+
+  return {
+    folders: folder.subfolders.length + totalCount.folders,
+    resources: folder.resources.length + totalCount.resources,
+  };
+};
+
 export const getResourcesForTag = (
   allFolders: GQLFolder[],
   tag: string,


### PR DESCRIPTION
https://trello.com/c/JT0Uv2a0/153-antall-undermapper-og-ressurser-viser-ikke-ressurser-i-undermapper

Teller alle mapper og ressurser under en mappe. Kom ikke på noen mer effektiv måte å gjøre det på enn memoization, men kom gjerne med forslag!