### PR TITLE
Viser meny på forsida om feide er skrudd på

### DIFF
--- a/cypress.env.json
+++ b/cypress.env.json
@@ -1,3 +1,0 @@
-{
-    "FEIDE_ENABLED": true
-}

--- a/cypress.env.json
+++ b/cypress.env.json
@@ -1,0 +1,3 @@
+{
+    "FEIDE_ENABLED": true
+}

--- a/cypress.json
+++ b/cypress.json
@@ -11,6 +11,6 @@
   "projectId": "7d39xm",
   "defaultCommandTimeout": 10000,
   "env": {
-    "FEIDE_ENABLED": "true"
+    "FEIDE_ENABLED": true
   }
 }

--- a/cypress.json
+++ b/cypress.json
@@ -9,5 +9,8 @@
   "chromeWebSecurity": false,
   "video": false,
   "projectId": "7d39xm",
-  "defaultCommandTimeout": 10000
+  "defaultCommandTimeout": 10000,
+  "env": {
+    "FEIDE_ENABLED": "true"
+  }
 }

--- a/src/containers/Page/Layout.tsx
+++ b/src/containers/Page/Layout.tsx
@@ -60,7 +60,7 @@ const Layout = () => {
       <Helmet>
         <meta property="fb:app_id" content="115263542481787" />
       </Helmet>
-      <Masthead />
+      {config.feideEnabled && <Masthead />}
       <Content>
         <Outlet />
       </Content>

--- a/src/containers/WelcomePage/WelcomePage.tsx
+++ b/src/containers/WelcomePage/WelcomePage.tsx
@@ -106,14 +106,15 @@ const WelcomePage = () => {
         imageUrl={`${config.ndlaFrontendDomain}/static/logo.png`}>
         <meta name="keywords" content={t('meta.keywords')} />
       </SocialMediaMetadata>
-      {alerts?.map(alert => (
-        <MessageBanner
-          key={alert.number}
-          onClose={() => closeAlert(alert.number)}
-          showCloseButton={alert.closable}>
-          {alert.content}
-        </MessageBanner>
-      ))}
+      {!config.feideEnabled &&
+        alerts?.map(alert => (
+          <MessageBanner
+            key={alert.number}
+            onClose={() => closeAlert(alert.number)}
+            showCloseButton={alert.closable}>
+            {alert.content}
+          </MessageBanner>
+        ))}
       <FrontpageHeader locale={i18n.language} showHeader={true}>
         <WelcomePageSearch />
       </FrontpageHeader>


### PR DESCRIPTION
Fordi masthead også viser alerts, så blir det dobbelt opp på forsida når du feks ser på en taksonomiversjon som ikkje er publisert: https://test.ndla.no/?versionHash=ece0