### PR TITLE
Remove alt text from Feide icon in My NDLA link

### DIFF
--- a/src/containers/Masthead/MastheadContainer.tsx
+++ b/src/containers/Masthead/MastheadContainer.tsx
@@ -188,7 +188,7 @@ const MastheadContainer = () => {
                   <span>{t('myNdla.myNDLA')}</span>
                 )}
               </FeideLoginLabel>
-              <Feide title={t('myNdla.myNDLA')} />
+              <Feide />
             </FeideLoginButton>
           )}
           {renderSearchComponent(true)}


### PR DESCRIPTION
Sammen med aria-hidden vil dette føre til at ikonet ignoreres fullstendig.