### PR TITLE
Added dynamic scroll padding to ensure focusable elements do not end behind the masthead

### DIFF
--- a/src/containers/Page/Layout.tsx
+++ b/src/containers/Page/Layout.tsx
@@ -7,11 +7,12 @@
  */
 
 import { useEffect } from 'react';
-import { Content, PageContainer } from '@ndla/ui';
+import { Content, PageContainer, useMastheadHeight } from '@ndla/ui';
 import ZendeskButton from '@ndla/zendesk';
 import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import styled from '@emotion/styled';
+import { css, Global } from '@emotion/core';
 import { matchPath, Outlet, useLocation } from 'react-router-dom';
 import Masthead from '../Masthead';
 import config from '../../config';
@@ -27,6 +28,7 @@ const ZendeskWrapper = styled.div`
 const Layout = () => {
   const { t, i18n } = useTranslation();
   const { pathname } = useLocation();
+  const { height } = useMastheadHeight();
   const prevPathname = usePrevious(pathname);
   const params = useUrnIds();
   const zendeskLanguage =
@@ -57,6 +59,13 @@ const Layout = () => {
 
   return (
     <PageContainer backgroundWide={backgroundWide} ndlaFilm={ndlaFilm}>
+      <Global
+        styles={css`
+          html {
+            scroll-padding-top: ${height ? `${height}px` : undefined};
+          }
+        `}
+      />
       <Helmet
         htmlAttributes={{ lang: i18n.language }}
         title="NDLA"


### PR DESCRIPTION
Sammenlign tab-navigering med nåværende frontend. Merk at tab-navigering bakover alltid vil sørge for at det fokuserte elementet er synlig i denne løsningen, mens det ofte vil være skjult i den gamle.

Fixes https://github.com/NDLANO/Issues/issues/3217