### PR TITLE
Reset initial state in masthead if empty params

### DIFF
--- a/src/containers/Masthead/MastheadContainer.tsx
+++ b/src/containers/Masthead/MastheadContainer.tsx
@@ -67,8 +67,10 @@ interface State {
   resource?: GQLMastHeadQuery['resource'];
 }
 
+const initialState: State = { topicPath: [] };
+
 const MastheadContainer = () => {
-  const [state, setState] = useState<State>({ topicPath: [] });
+  const [state, setState] = useState<State>(initialState);
   const { t, i18n } = useTranslation();
   const locale = i18n.language;
   const {
@@ -97,7 +99,10 @@ const MastheadContainer = () => {
   }, [topicIdParam]);
 
   useEffect(() => {
-    if (!topicId && !resourceId && !subjectId) return;
+    if (!topicId && !resourceId && !subjectId) {
+      setState(initialState);
+      return;
+    }
     fetchData({
       variables: {
         subjectId: subjectId ?? '',


### PR DESCRIPTION
Var et problem med at masthead breadcrumb'en ikke ble oppdatert om man navigerte til forsiden.

Kan testes ved å navigere til en side som har breadcrumb (Feks `/subject:e18b8bf0-326b-45f6-8e95-982de8f34264/`), for så å navigere til forsiden igjen og scrolle ned og se at breadcrumben i mastheaden er tom.