### PR TITLE
Implement promptless login to feide

### DIFF
--- a/src/components/AuthenticationContext.tsx
+++ b/src/components/AuthenticationContext.tsx
@@ -20,6 +20,8 @@ interface AuthContextType {
   login: () => void;
   logout: () => void;
   user: FeideUserApiType | undefined;
+  needsInteraction: boolean;
+  setNeedsInteraction: (needs: boolean) => void;
 }
 
 export const AuthContext = createContext<AuthContextType>({
@@ -28,6 +30,8 @@ export const AuthContext = createContext<AuthContextType>({
   login: () => {},
   logout: () => {},
   user: undefined,
+  needsInteraction: false,
+  setNeedsInteraction: () => {},
 });
 
 interface Props {
@@ -41,6 +45,7 @@ const AuthenticationContext = ({ children, initialValue }: Props) => {
   );
   const [authContextLoaded, setLoaded] = useState(false);
   const [user, setUser] = useState<FeideUserApiType | undefined>(undefined);
+  const [needsInteraction, setNeedsInteraction] = useState(false);
 
   useEffect(() => {
     const isValid = isAccessTokenValid();
@@ -59,12 +64,23 @@ const AuthenticationContext = ({ children, initialValue }: Props) => {
     }
   }, [authenticated]);
 
-  const login = () => setAuthenticated(true);
+  const login = () => {
+    setNeedsInteraction(false);
+    setAuthenticated(true);
+  };
   const logout = () => setAuthenticated(false);
 
   return (
     <AuthContext.Provider
-      value={{ authenticated, authContextLoaded, login, logout, user }}>
+      value={{
+        authenticated,
+        authContextLoaded,
+        login,
+        logout,
+        user,
+        needsInteraction,
+        setNeedsInteraction,
+      }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/containers/Login/LoginProviders.ts
+++ b/src/containers/Login/LoginProviders.ts
@@ -18,7 +18,9 @@ export type LocationState =
   | undefined;
 
 export const LoginProviders = () => {
-  const { authenticated, authContextLoaded } = useContext(AuthContext);
+  const { authenticated, authContextLoaded, needsInteraction } = useContext(
+    AuthContext,
+  );
   const location = useLocation();
   const locationState = location.state as LocationState;
   const navigate = useNavigate();
@@ -26,9 +28,9 @@ export const LoginProviders = () => {
     if (authenticated && authContextLoaded) {
       navigate(locationState?.from ?? toHome());
     } else if (authContextLoaded && !authenticated) {
-      initializeFeideLogin(locationState?.from).catch(() =>
-        navigate(toLoginFailure()),
-      );
+      initializeFeideLogin(locationState?.from, needsInteraction).catch(() => {
+        navigate(toLoginFailure());
+      });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [authenticated, navigate, authContextLoaded]);

--- a/src/server/helpers/openidHelper.ts
+++ b/src/server/helpers/openidHelper.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { Issuer, generators } from 'openid-client';
+import { generators, Issuer } from 'openid-client';
 import { Request } from 'express';
 import config, { getEnvironmentVariabel } from '../../config';
 
@@ -44,6 +44,7 @@ export const getRedirectUrl = (req: Request) => {
   const code_challenge = generators.codeChallenge(code_verifier);
   const port = req.protocol === 'http' ? `:${config.port}` : '';
   const redirect_uri_login = `${req.protocol}://${req.hostname}${port}/login/success`;
+  const prompt = req.query.prompt === 'none' ? 'none' : undefined;
 
   return getClient(redirect_uri_login)
     .then(client =>
@@ -52,6 +53,7 @@ export const getRedirectUrl = (req: Request) => {
           'email openid userinfo-photo groups-edu userinfo-language userid userinfo-name groups-org userid-feide',
         code_challenge,
         state: req.query.state?.toString(),
+        prompt,
       }),
     )
     .then(feide_url => {


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3270

Legger til default-parameter `prompt: none` til feide-login'en.
Dersom login feiler med `interaction_required` error så setter vi `needsInteraction` i `AuthenticationContext`.

Kan testes ved å se at feidelogin fungerer som før, med mindre du allerede er logget inn (Men ikke har cookie). Da skal login gå uten å trenge å gå innom-feide siden.