### PR TITLE
Fix initial masthead state reset

### DIFF
--- a/src/containers/Masthead/MastheadContainer.tsx
+++ b/src/containers/Masthead/MastheadContainer.tsx
@@ -99,13 +99,14 @@ const MastheadContainer = () => {
   }, [topicIdParam]);
 
   useEffect(() => {
-    if (!topicId && !resourceId && !subjectId) {
+    if (!subjectId) {
       setState(initialState);
       return;
     }
+
     fetchData({
       variables: {
-        subjectId: subjectId ?? '',
+        subjectId,
         topicId: topicId ?? '',
         resourceId: resourceId ?? '',
         skipTopic: !topicId,


### PR DESCRIPTION
Kan testes ved å se at masthead querien ikke gjør et graphql-kall som feiler dersom vi trykker oss tilbake til forsiden fra et emne.