### PR TITLE
Use originalUrl for redirect to preserve params

### DIFF
--- a/src/server/routes/defaultRoute.js
+++ b/src/server/routes/defaultRoute.js
@@ -119,7 +119,7 @@ async function doRender(req) {
 
 export async function defaultRoute(req) {
   const resCookie = req.headers['cookie'] ?? '';
-  const { basename, basepath } = getLocaleInfoFromPath(req.path);
+  const { basename, basepath } = getLocaleInfoFromPath(req.originalUrl);
   const cookieLocale = getCookie(STORED_LANGUAGE_COOKIE_KEY, resCookie) ?? '';
   const locale =
     cookieLocale.length && isValidLocale(cookieLocale) ? cookieLocale : 'nb';


### PR DESCRIPTION
Fixes NDLANO/Issues#3263

Tar med originale parametre i redirect på grunn av språk.

Test:
* Gå inn på pr.-installasjon og endre språk til nn
* Lim inn url /search?subjects=urn:subject:1:19dae192-699d-488f-8218-d81535ce3ae3&grepCodes=KM2688
* Du skal tas til nn-versjonen av sida med parametrene beholdt. I test blir parametre strippa bort.