### PR TITLE
Do a redirect on server instead of on the client to avoid weird logout error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -105,15 +105,6 @@ const AppRoutes = ({ base, resCookie }: AppProps) => {
             <Routes>
               <Route path="/" element={<Layout />}>
                 <Route index element={<WelcomePage />} />
-                <Route path="login" element={<FeideUi />}>
-                  <Route index element={<LoginProviders />} />
-                  <Route path={'success'} element={<LoginSuccess />} />
-                  <Route path={'failure'} element={<LoginFailure />} />
-                </Route>
-                <Route path="logout" element={<FeideUi />}>
-                  <Route index element={<LogoutProviders />} />
-                  <Route path="session" element={<LogoutSession />} />
-                </Route>
                 <Route path="subjects" element={<AllSubjectsPage />} />
                 <Route path="search" element={<SearchPage />} />
                 <Route path="utdanning/:programme" element={<ProgrammePage />}>
@@ -179,6 +170,15 @@ const AppRoutes = ({ base, resCookie }: AppProps) => {
                 <Route path="404" element={<NotFound />} />
                 <Route path="403" element={<AccessDenied />} />
                 <Route path="*" element={<NotFound />} />
+              </Route>
+              <Route path="/login" element={<FeideUi />}>
+                <Route index element={<LoginProviders />} />
+                <Route path={'success'} element={<LoginSuccess />} />
+                <Route path={'failure'} element={<LoginFailure />} />
+              </Route>
+              <Route path="/logout" element={<FeideUi />}>
+                <Route index element={<LogoutProviders />} />
+                <Route path="session" element={<LogoutSession />} />
               </Route>
             </Routes>
           </SnackbarProvider>

--- a/src/containers/Logout/LogoutSession.tsx
+++ b/src/containers/Logout/LogoutSession.tsx
@@ -26,7 +26,7 @@ const LogoutSession = () => {
       lastPath && privateRoutes.some(route => matchPath(route, lastPath));
 
     if (redirect) {
-      redirect.status = 303;
+      redirect.status = 302;
       redirect.url = wasPrivateRoute ? toHome() : lastPath ?? toHome();
     }
   } else if (authenticated && authContextLoaded) {

--- a/src/containers/Logout/LogoutSession.tsx
+++ b/src/containers/Logout/LogoutSession.tsx
@@ -12,7 +12,6 @@ import { matchPath, useLocation } from 'react-router-dom';
 import { AuthContext } from '../../components/AuthenticationContext';
 import RedirectContext from '../../components/RedirectContext';
 import { privateRoutes } from '../../routes';
-import { MOVED_PERMANENTLY } from '../../statusCodes';
 import { feideLogout } from '../../util/authHelpers';
 import { toHome } from '../../util/routeHelpers';
 
@@ -27,7 +26,7 @@ const LogoutSession = () => {
       lastPath && privateRoutes.some(route => matchPath(route, lastPath));
 
     if (redirect) {
-      redirect.status = MOVED_PERMANENTLY;
+      redirect.status = 303;
       redirect.url = wasPrivateRoute ? toHome() : lastPath ?? toHome();
     }
   } else if (authenticated && authContextLoaded) {

--- a/src/containers/Logout/LogoutSession.tsx
+++ b/src/containers/Logout/LogoutSession.tsx
@@ -8,15 +8,18 @@
 
 import queryString from 'query-string';
 import { useContext } from 'react';
-import { matchPath, useLocation, useNavigate } from 'react-router-dom';
+import { matchPath, useLocation } from 'react-router-dom';
 import { AuthContext } from '../../components/AuthenticationContext';
+import RedirectContext, {
+  RedirectInfo,
+} from '../../components/RedirectContext';
 import { privateRoutes } from '../../routes';
 import { feideLogout } from '../../util/authHelpers';
 import { toHome } from '../../util/routeHelpers';
 
 const LogoutSession = () => {
   const { authenticated, logout, authContextLoaded } = useContext(AuthContext);
-  const navigate = useNavigate();
+  const redirect = useContext<RedirectInfo | undefined>(RedirectContext);
   const { search } = useLocation();
   const params = queryString.parse(search) ?? '';
   const lastPath = params.state;
@@ -24,8 +27,10 @@ const LogoutSession = () => {
     const wasPrivateRoute =
       lastPath && privateRoutes.some(route => matchPath(route, lastPath));
 
-    const newPath = wasPrivateRoute ? toHome() : lastPath ?? toHome();
-    navigate(newPath);
+    if (redirect) {
+      redirect.status = 302;
+      redirect.url = wasPrivateRoute ? toHome() : lastPath ?? toHome();
+    }
   } else if (authenticated && authContextLoaded) {
     feideLogout(logout, lastPath);
   }

--- a/src/containers/Logout/LogoutSession.tsx
+++ b/src/containers/Logout/LogoutSession.tsx
@@ -8,16 +8,15 @@
 
 import queryString from 'query-string';
 import { useContext } from 'react';
-import { matchPath, useLocation } from 'react-router-dom';
+import { matchPath, useLocation, useNavigate } from 'react-router-dom';
 import { AuthContext } from '../../components/AuthenticationContext';
-import RedirectContext from '../../components/RedirectContext';
 import { privateRoutes } from '../../routes';
 import { feideLogout } from '../../util/authHelpers';
 import { toHome } from '../../util/routeHelpers';
 
 const LogoutSession = () => {
   const { authenticated, logout, authContextLoaded } = useContext(AuthContext);
-  const redirect = useContext(RedirectContext);
+  const navigate = useNavigate();
   const { search } = useLocation();
   const params = queryString.parse(search) ?? '';
   const lastPath = params.state;
@@ -25,10 +24,8 @@ const LogoutSession = () => {
     const wasPrivateRoute =
       lastPath && privateRoutes.some(route => matchPath(route, lastPath));
 
-    if (redirect) {
-      redirect.status = 302;
-      redirect.url = wasPrivateRoute ? toHome() : lastPath ?? toHome();
-    }
+    const newPath = wasPrivateRoute ? toHome() : lastPath ?? toHome();
+    navigate(newPath);
   } else if (authenticated && authContextLoaded) {
     feideLogout(logout, lastPath);
   }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -41,6 +41,7 @@ import {
   OK,
   INTERNAL_SERVER_ERROR,
   MOVED_PERMANENTLY,
+  FOUND,
   TEMPORARY_REDIRECT,
   BAD_REQUEST,
 } from '../statusCodes';
@@ -154,7 +155,11 @@ export async function sendInternalServerError(req: Request, res: Response) {
 }
 
 function sendResponse(res: Response, data: any, status = OK) {
-  if (status === MOVED_PERMANENTLY || status === TEMPORARY_REDIRECT) {
+  if (
+    status === MOVED_PERMANENTLY ||
+    status === FOUND ||
+    status === TEMPORARY_REDIRECT
+  ) {
     res.writeHead(status, data);
     res.end();
   } else if (res.getHeader('Content-Type') === 'application/json') {

--- a/src/statusCodes.ts
+++ b/src/statusCodes.ts
@@ -1,4 +1,5 @@
 export const MOVED_PERMANENTLY = 301;
+export const FOUND = 302;
 export const OK = 200;
 export const INTERNAL_SERVER_ERROR = 500;
 export const BAD_REQUEST = 400;


### PR DESCRIPTION
Flytter /login- og /logout-routes ut fra felles Layout. Forsøker å redirecte til riktig side på server-side slik at vi faktisk gir beskjed til klient at vi faktisk sender de til en annen rute.