### PR TITLE
Handle different language prefix cases for logging in and out

### DIFF
--- a/src/components/FeideLoginButton/FeideLoginButton.tsx
+++ b/src/components/FeideLoginButton/FeideLoginButton.tsx
@@ -19,7 +19,8 @@ import { AuthContext } from '../AuthenticationContext';
 import LoginComponent from '../MyNdla/LoginComponent';
 import IsMobileContext from '../../IsMobileContext';
 import { useIsNdlaFilm } from '../../routeHelpers';
-import { toHref } from '../../util/urlHelper';
+import { constructNewPath, toHref } from '../../util/urlHelper';
+import { useBaseName } from '../BaseNameContext';
 
 const FeideFooterButton = styled(Button)`
   padding: ${spacing.xsmall} ${spacing.small};
@@ -72,6 +73,7 @@ const FeideLoginButton = ({ footer, children, masthead }: Props) => {
   const location = useLocation();
   const { t } = useTranslation();
   const { authenticated, user } = useContext(AuthContext);
+  const basename = useBaseName();
   const ndlaFilm = useIsNdlaFilm();
   const isMobile = useContext(IsMobileContext);
   const destination = isMobile ? '/minndla/meny' : '/minndla';
@@ -132,7 +134,10 @@ const FeideLoginButton = ({ footer, children, masthead }: Props) => {
       user={user}
       onAuthenticateClick={() => {
         const route = authenticated ? 'logout' : 'login';
-        window.location.href = `/${route}?state=${toHref(location)}`;
+        window.location.href = constructNewPath(
+          `/${route}?state=${toHref(location)}`,
+          basename,
+        );
       }}
     />
   );

--- a/src/containers/AccessDeniedPage/AccessDeniedPage.tsx
+++ b/src/containers/AccessDeniedPage/AccessDeniedPage.tsx
@@ -13,11 +13,13 @@ import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import { Status } from '../../components';
 import { AuthContext } from '../../components/AuthenticationContext';
-import { toHref } from '../../util/urlHelper';
+import { constructNewPath, toHref } from '../../util/urlHelper';
+import { useBaseName } from '../../components/BaseNameContext';
 
 const AccessDenied = () => {
   const { t } = useTranslation();
   const location = useLocation();
+  const basename = useBaseName();
   const { authenticated } = useContext(AuthContext);
   const statusCode = authenticated ? 403 : 401;
 
@@ -28,7 +30,10 @@ const AccessDenied = () => {
         <ErrorResourceAccessDenied
           onAuthenticateClick={() => {
             const route = authenticated ? 'logout' : 'login';
-            window.location.href = `/${route}?state=${toHref(location)}`;
+            window.location.href = constructNewPath(
+              `/${route}?state=${toHref(location)}`,
+              basename,
+            );
           }}
         />
       </OneColumn>

--- a/src/containers/MyNdla/MyNdlaPage.tsx
+++ b/src/containers/MyNdla/MyNdlaPage.tsx
@@ -30,7 +30,8 @@ import {
 import MyNdlaBreadcrumb from './components/MyNdlaBreadcrumb';
 import MyNdlaTitle from './components/MyNdlaTitle';
 import TitleWrapper from './components/TitleWrapper';
-import { toHref } from '../../util/urlHelper';
+import { constructNewPath, toHref } from '../../util/urlHelper';
+import { useBaseName } from '../../components/BaseNameContext';
 
 const HeartOutlineIcon = InfoPartIcon.withComponent(HeartOutline);
 const FolderOutlinedIcon = InfoPartIcon.withComponent(FolderOutlined);
@@ -99,6 +100,7 @@ const ButtonContainer = styled.div`
 const MyNdlaPage = () => {
   const { user } = useContext(AuthContext);
   const { t } = useTranslation();
+  const basename = useBaseName();
   const location = useLocation();
   const { deletePersonalData } = useDeletePersonalData();
   const { allFolderResources } = useRecentlyUsedResources();
@@ -115,7 +117,10 @@ const MyNdlaPage = () => {
 
   const onDeleteAccount = async () => {
     await deletePersonalData();
-    window.location.href = `/logout?state=${toHref(location)}`;
+    window.location.href = constructNewPath(
+      `/logout?state=${toHref(location)}`,
+      basename,
+    );
   };
 
   const keyedData = keyBy(metaData ?? [], r => `${r.type}${r.id}`);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -46,6 +46,8 @@ import {
   BAD_REQUEST,
 } from '../statusCodes';
 import { isAccessTokenValid } from '../util/authHelpers';
+import { constructNewPath } from '../util/urlHelper';
+import { getDefaultLocale } from '../config';
 
 // @ts-ignore
 global.fetch = fetch;
@@ -113,16 +115,34 @@ app.get(
   },
 );
 
-app.get('/login', async (req: Request, res: Response) => {
+const getLang = (
+  paramLang?: string,
+  cookieLang?: string | null,
+): string | undefined => {
+  if (paramLang) {
+    return paramLang;
+  }
+  if (!paramLang && cookieLang && cookieLang !== getDefaultLocale()) {
+    return cookieLang;
+  }
+  return undefined;
+};
+
+app.get('/:lang?/login', async (req: Request, res: Response) => {
   const feideCookie = getCookie('feide_auth', req.headers.cookie ?? '') ?? '';
   const feideToken = !!feideCookie ? JSON.parse(feideCookie) : undefined;
-  const state = typeof req.query.state === 'string' ? req.query.state : '/';
+  const state = typeof req.query.state === 'string' ? req.query.state : '';
+  const lang = getLang(
+    req.params.lang,
+    getCookie(STORED_LANGUAGE_COOKIE_KEY, req.headers.cookie ?? ''),
+  );
+  const redirect = constructNewPath(state, lang);
 
   if (feideToken && isAccessTokenValid(feideToken)) {
     return res.redirect(state);
   }
   try {
-    const { verifier, url } = await getRedirectUrl(req, state);
+    const { verifier, url } = await getRedirectUrl(req, redirect);
     res.cookie('PKCE_code', verifier, { httpOnly: true });
     return res.redirect(url);
   } catch (e) {
@@ -148,22 +168,30 @@ app.get('/login/success', async (req: Request, res: Response) => {
       expires: new Date(feideCookie.ndla_expires_at),
       encode: String,
     });
+    //workaround to ensure language cookie is set before redirecting to state path
+    if (
+      getCookie(STORED_LANGUAGE_COOKIE_KEY, req.headers.cookie ?? '') == null
+    ) {
+      const { basename } = getLocaleInfoFromPath(state);
+      res.cookie(STORED_LANGUAGE_COOKIE_KEY, basename ?? getDefaultLocale());
+    }
     return res.redirect(state);
   } catch (e) {
     return await sendInternalServerError(req, res);
   }
 });
 
-app.get('/logout', async (req: Request, res: Response) => {
+app.get('/:lang?/logout', async (req: Request, res: Response) => {
   const feideCookie = getCookie('feide_auth', req.headers.cookie ?? '') ?? '';
   const feideToken = !!feideCookie ? JSON.parse(feideCookie) : undefined;
-  const state = req.query['state'] ?? '/';
+  const state = typeof req.query.state === 'string' ? req.query.state : '/';
+  const redirect = constructNewPath(state, req.params.lang);
 
   if (!feideToken?.['id_token'] || typeof state !== 'string') {
     return sendInternalServerError(req, res);
   }
   try {
-    const logoutUri = await feideLogout(req, state, feideToken['id_token']);
+    const logoutUri = await feideLogout(req, redirect, feideToken['id_token']);
     return res.redirect(logoutUri);
   } catch (_) {
     return await sendInternalServerError(req, res);
@@ -172,9 +200,10 @@ app.get('/logout', async (req: Request, res: Response) => {
 
 app.get('/logout/session', (req: Request, res: Response) => {
   res.clearCookie('feide_auth');
-  const prevPath = typeof req.query.state === 'string' ? req.query.state : '/';
-  const wasPrivateRoute = privateRoutes.some(r => matchPath(r, prevPath));
-  const redirect = wasPrivateRoute ? '/' : prevPath;
+  const state = typeof req.query.state === 'string' ? req.query.state : '/';
+  const { basepath, basename } = getLocaleInfoFromPath(state);
+  const wasPrivateRoute = privateRoutes.some(r => matchPath(r, basepath));
+  const redirect = wasPrivateRoute ? constructNewPath('/', basename) : state;
   return res.redirect(redirect);
 });
 
@@ -329,7 +358,7 @@ app.get(
     if (!route) {
       next('route'); // skip to next route (i.e. proxy)
     } else if (shouldRedirect) {
-      return res.redirect(`/login?state=${route}}`);
+      return res.redirect(`/login?state=${req.path}`);
     } else {
       next();
     }

--- a/src/util/urlHelper.ts
+++ b/src/util/urlHelper.ts
@@ -7,7 +7,7 @@
  */
 
 import { matchPath, Params, PathMatch, Location } from 'react-router-dom';
-import { isValidLocale } from '../i18n';
+import { isValidLocale, supportedLanguages } from '../i18n';
 import { oembedRoutes } from '../routes';
 
 type OembedParams =
@@ -81,4 +81,12 @@ export function parseOembedUrl(url: string, ignoreLocale: boolean = false) {
 
 export const toHref = (location: Location) => {
   return `${location.pathname}${location.search}`;
+};
+
+export const constructNewPath = (pathname: string, newLocale?: string) => {
+  const regex = new RegExp(`\\/(${supportedLanguages.join('|')})($|\\/)`, '');
+  const path = pathname.replace(regex, '');
+  const fullPath = path.startsWith('/') ? path : `/${path}`;
+  const localePrefix = newLocale ? `/${newLocale}` : '';
+  return `${localePrefix}${fullPath}`;
 };


### PR DESCRIPTION
Innlogging feilet når man hadde et basename. Dette tar hensyn til det. Ikke pent, men funksjonelt. Kommer dette til å knekke proxy, @gunnarvelle? Isåfall må vi finne en lur måte å unngå `/nn/{log(in|out)}/`