### PR TITLE
Handle case where languageCookie is empty properly

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -168,12 +168,17 @@ app.get('/login/success', async (req: Request, res: Response) => {
       expires: new Date(feideCookie.ndla_expires_at),
       encode: String,
     });
+    const languageCookie = getCookie(
+      STORED_LANGUAGE_COOKIE_KEY,
+      req.headers.cookie ?? '',
+    );
     //workaround to ensure language cookie is set before redirecting to state path
-    if (
-      getCookie(STORED_LANGUAGE_COOKIE_KEY, req.headers.cookie ?? '') == null
-    ) {
+    if (!languageCookie) {
       const { basename } = getLocaleInfoFromPath(state);
-      res.cookie(STORED_LANGUAGE_COOKIE_KEY, basename ?? getDefaultLocale());
+      res.cookie(
+        STORED_LANGUAGE_COOKIE_KEY,
+        basename.length ? basename : getDefaultLocale(),
+      );
     }
     return res.redirect(state);
   } catch (e) {


### PR DESCRIPTION
`"" ?? "fallback"` returnerer visst `""`, og ikke `"fallback"`. Dette fikser det, slik at vi ikke lenger får en tom language-cookie.