### PR TITLE
Implement drag and drop with dnd-kit

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,10 @@
     "react-router-dom": "^6.3.0",
     "remarkable": "^2.0.0",
     "serialize-javascript": "^3.1.0",
-    "source-map-support": "^0.5.9"
+    "source-map-support": "^0.5.9",
+    "@dnd-kit/core": "6.0.5",
+    "@dnd-kit/sortable": "7.0.1",
+    "@dnd-kit/utilities": "^3.2.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -149,7 +149,8 @@
     "source-map-support": "^0.5.9",
     "@dnd-kit/core": "6.0.5",
     "@dnd-kit/sortable": "7.0.1",
-    "@dnd-kit/utilities": "^3.2.0"
+    "@dnd-kit/utilities": "^3.2.0",
+    "@dnd-kit/modifiers": "^6.0.0"
   },
   "repository": {
     "type": "git",

--- a/src/containers/MyNdla/Folders/DragHandle.tsx
+++ b/src/containers/MyNdla/Folders/DragHandle.tsx
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2022-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import { useSortable } from '@dnd-kit/sortable';
+import { IconButtonV2 } from '@ndla/button';
+import { DragVertical } from '@ndla/icons/editor';
+import { useTranslation } from 'react-i18next';
+
+interface Props {
+  sortableId: string;
+}
+
+export const DragHandle = ({ sortableId }: Props) => {
+  const { t } = useTranslation();
+  const { listeners, setActivatorNodeRef } = useSortable({ id: sortableId });
+  return (
+    <div {...listeners} ref={setActivatorNodeRef}>
+      <IconButtonV2
+        aria-label={t('myNdla.dragHandleLabel')}
+        type={'button'}
+        variant={'ghost'}
+        colorTheme={'light'}
+        size={'small'}>
+        <DragVertical />
+      </IconButtonV2>
+    </div>
+  );
+};

--- a/src/containers/MyNdla/Folders/DraggableFolder.tsx
+++ b/src/containers/MyNdla/Folders/DraggableFolder.tsx
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2022-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Folder } from '@ndla/ui';
+import { Pencil } from '@ndla/icons/action';
+import { useTranslation } from 'react-i18next';
+import { DeleteForever } from '@ndla/icons/editor';
+import styled from '@emotion/styled';
+import { colors, spacing } from '@ndla/core';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { css } from '@emotion/core';
+import { GQLFolder } from '../../../graphqlTypes';
+import { FolderTotalCount } from '../../../util/folderHelpers';
+import { FolderAction, ViewType } from './FoldersPage';
+import { DragHandle } from './DragHandle';
+
+interface DraggableFolderProps {
+  id: string;
+  type: ViewType;
+  folder: GQLFolder;
+  foldersCount: Record<string, FolderTotalCount>;
+  setFolderAction: (action: FolderAction | undefined) => void;
+  index: number;
+}
+
+interface LiProps {
+  isDragging: boolean;
+}
+
+export const DraggableListItem = styled.li<LiProps>`
+  list-style: none;
+  margin: 0;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: ${spacing.xsmall};
+  ${p => {
+    if (p.isDragging) {
+      return css`
+        z-index: 10;
+      `;
+    }
+    return '';
+  }}
+`;
+
+export const DragWrapper = styled.div`
+  background-color: ${colors.white};
+  flex-grow: 1;
+`;
+
+const DraggableFolder = ({
+  index,
+  type,
+  foldersCount,
+  setFolderAction,
+  folder,
+}: DraggableFolderProps) => {
+  const { t } = useTranslation();
+  const {
+    attributes,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
+    id: folder.id,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <DraggableListItem
+      key={`folder-${folder.id}`}
+      id={`folder-${folder.id}`}
+      ref={setNodeRef}
+      style={style}
+      isDragging={isDragging}
+      {...attributes}>
+      {type !== 'block' && <DragHandle sortableId={folder.id} />}
+      <DragWrapper>
+        <Folder
+          key={folder.id}
+          id={folder.id}
+          link={`/minndla/folders/${folder.id}`}
+          title={folder.name}
+          type={type === 'block' ? 'block' : 'list'}
+          subFolders={foldersCount[folder.id]?.folders}
+          subResources={foldersCount[folder.id]?.resources}
+          menuItems={[
+            {
+              icon: <Pencil />,
+              text: t('myNdla.folder.edit'),
+              onClick: () => setFolderAction({ action: 'edit', folder, index }),
+            },
+            {
+              icon: <DeleteForever />,
+              text: t('myNdla.folder.delete'),
+              onClick: () =>
+                setFolderAction({ action: 'delete', folder, index }),
+              type: 'danger',
+            },
+          ]}
+        />
+      </DragWrapper>
+    </DraggableListItem>
+  );
+};
+
+export default DraggableFolder;

--- a/src/containers/MyNdla/Folders/DraggableFolder.tsx
+++ b/src/containers/MyNdla/Folders/DraggableFolder.tsx
@@ -14,7 +14,7 @@ import styled from '@emotion/styled';
 import { colors, spacing } from '@ndla/core';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { css } from '@emotion/core';
+import { css } from '@emotion/react';
 import { GQLFolder } from '../../../graphqlTypes';
 import { FolderTotalCount } from '../../../util/folderHelpers';
 import { FolderAction, ViewType } from './FoldersPage';

--- a/src/containers/MyNdla/Folders/DraggableResource.tsx
+++ b/src/containers/MyNdla/Folders/DraggableResource.tsx
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2022-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Dictionary } from 'lodash';
+import { useTranslation } from 'react-i18next';
+import { Link } from '@ndla/icons/common';
+import { FolderOutlined } from '@ndla/icons/contentType';
+import { CSS } from '@dnd-kit/utilities';
+import { DeleteForever } from '@ndla/icons/editor';
+import { BlockResource, ListResource, useSnack } from '@ndla/ui';
+import { useSortable } from '@dnd-kit/sortable';
+import config from '../../../config';
+import {
+  GQLFolderResource,
+  GQLFolderResourceMeta,
+} from '../../../graphqlTypes';
+import { ViewType } from './FoldersPage';
+import { ResourceAction } from './ResourceList';
+import { DraggableListItem, DragWrapper } from './DraggableFolder';
+import { DragHandle } from './DragHandle';
+
+interface DraggableResourceProps {
+  id: string;
+  resource: GQLFolderResource;
+  index: number;
+  loading: boolean;
+  viewType: ViewType;
+  setResourceAction: (action: ResourceAction | undefined) => void;
+  keyedData: Dictionary<GQLFolderResourceMeta>;
+}
+
+const DraggableResource = ({
+  resource,
+  index,
+  loading,
+  viewType,
+  setResourceAction,
+  keyedData,
+}: DraggableResourceProps) => {
+  const { t } = useTranslation();
+  const { addSnack } = useSnack();
+  const Resource = viewType === 'block' ? BlockResource : ListResource;
+  const resourceMeta =
+    keyedData[`${resource.resourceType}-${resource.resourceId}`];
+
+  const {
+    attributes,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
+    id: resource.id,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <DraggableListItem
+      key={`resource-${resource.id}`}
+      id={`resource-${resource.id}`}
+      ref={setNodeRef}
+      style={style}
+      isDragging={isDragging}
+      {...attributes}>
+      {viewType !== 'block' && <DragHandle sortableId={resource.id} />}
+      <DragWrapper>
+        <Resource
+          id={resource.id}
+          tagLinkPrefix="/minndla/tags"
+          isLoading={loading}
+          key={resource.id}
+          resourceImage={{
+            src: resourceMeta?.metaImage?.url ?? '',
+            alt: '',
+          }}
+          link={resource.path}
+          tags={resource.tags}
+          resourceTypes={resourceMeta?.resourceTypes ?? []}
+          title={resourceMeta?.title ?? ''}
+          description={
+            viewType !== 'list' ? resourceMeta?.description ?? '' : undefined
+          }
+          menuItems={[
+            {
+              icon: <FolderOutlined />,
+              text: t('myNdla.resource.add'),
+              onClick: () => setResourceAction({ action: 'add', resource }),
+            },
+            {
+              icon: <Link />,
+              text: t('myNdla.resource.copyLink'),
+              onClick: () => {
+                navigator.clipboard.writeText(
+                  `${config.ndlaFrontendDomain}${resource.path}`,
+                );
+                addSnack({
+                  content: t('myNdla.resource.linkCopied'),
+                  id: 'linkCopied',
+                });
+              },
+            },
+            {
+              icon: <DeleteForever />,
+              text: t('myNdla.resource.remove'),
+              onClick: () =>
+                setResourceAction({ action: 'delete', resource, index }),
+              type: 'danger',
+            },
+          ]}
+        />
+      </DragWrapper>
+    </DraggableListItem>
+  );
+};
+
+export default DraggableResource;

--- a/src/containers/MyNdla/Folders/FolderList.tsx
+++ b/src/containers/MyNdla/Folders/FolderList.tsx
@@ -21,6 +21,10 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { useEffect, useState } from 'react';
+import {
+  restrictToParentElement,
+  restrictToVerticalAxis,
+} from '@dnd-kit/modifiers';
 import { GQLFolder } from '../../../graphqlTypes';
 import { FolderTotalCount } from '../../../util/folderHelpers';
 import { FolderAction, ViewType } from './FoldersPage';
@@ -93,7 +97,8 @@ const FolderList = ({
     <DndContext
       sensors={sensors}
       collisionDetection={closestCenter}
-      onDragEnd={sortFolderIds}>
+      onDragEnd={sortFolderIds}
+      modifiers={[restrictToVerticalAxis, restrictToParentElement]}>
       <SortableContext
         items={sortedFolders}
         strategy={verticalListSortingStrategy}>

--- a/src/containers/MyNdla/Folders/FolderList.tsx
+++ b/src/containers/MyNdla/Folders/FolderList.tsx
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2022-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { useApolloClient } from '@apollo/client';
+import {
+  closestCenter,
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { useEffect, useState } from 'react';
+import { GQLFolder } from '../../../graphqlTypes';
+import { FolderTotalCount } from '../../../util/folderHelpers';
+import { FolderAction, ViewType } from './FoldersPage';
+import { useSortFoldersMutation } from '../folderMutations';
+import DraggableFolder from './DraggableFolder';
+import { makeDndSortFunction } from './util';
+
+interface Props {
+  currentFolderId: string | undefined;
+  type: ViewType;
+  folders: GQLFolder[];
+  foldersCount: Record<string, FolderTotalCount>;
+  setFolderAction: (action: FolderAction | undefined) => void;
+}
+
+const FolderList = ({
+  currentFolderId,
+  type,
+  folders,
+  foldersCount,
+  setFolderAction,
+}: Props) => {
+  const { sortFolders } = useSortFoldersMutation();
+  const client = useApolloClient();
+
+  const updateCache = (newOrder: string[]) => {
+    const sortCacheModifierFunction = (
+      existing: (GQLFolder & { __ref: string })[],
+    ) => {
+      return newOrder.map(id =>
+        existing.find(ef => ef.__ref === `Folder:${id}`),
+      );
+    };
+
+    if (currentFolderId) {
+      client.cache.modify({
+        id: client.cache.identify({
+          __ref: `Folder:${currentFolderId}`,
+        }),
+        fields: { subfolders: sortCacheModifierFunction },
+      });
+    } else {
+      client.cache.modify({
+        fields: { folders: sortCacheModifierFunction },
+      });
+    }
+  };
+  const [sortedFolders, setSortedFolders] = useState(folders);
+
+  useEffect(() => {
+    setSortedFolders(folders);
+  }, [folders]);
+
+  const sortFolderIds = makeDndSortFunction(
+    currentFolderId,
+    folders,
+    sortFolders,
+    updateCache,
+    setSortedFolders,
+  );
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={sortFolderIds}>
+      <SortableContext
+        items={sortedFolders}
+        strategy={verticalListSortingStrategy}>
+        {sortedFolders.map((folder, index) => (
+          <DraggableFolder
+            id={folder.id}
+            key={folder.id}
+            index={index}
+            folder={folder}
+            foldersCount={foldersCount}
+            setFolderAction={setFolderAction}
+            type={type}
+          />
+        ))}
+      </SortableContext>
+    </DndContext>
+  );
+};
+
+export default FolderList;

--- a/src/containers/MyNdla/Folders/FoldersPage.tsx
+++ b/src/containers/MyNdla/Folders/FoldersPage.tsx
@@ -13,12 +13,10 @@ import { AddButton } from '@ndla/button';
 import { colors, spacing } from '@ndla/core';
 import { FolderOutlined } from '@ndla/icons/contentType';
 import { FileDocumentOutline } from '@ndla/icons/common';
-import { Folder, useSnack } from '@ndla/ui';
-import { Pencil } from '@ndla/icons/action';
+import { useSnack } from '@ndla/ui';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
-import { DeleteForever } from '@ndla/icons/editor';
 import { HelmetWithTracker } from '@ndla/tracker';
 import { GQLFolder, GQLFoldersPageQuery } from '../../../graphqlTypes';
 import { useGraphQuery } from '../../../util/runQueries';
@@ -31,7 +29,6 @@ import {
   useDeleteFolderMutation,
   useUpdateFolderMutation,
 } from '../folderMutations';
-import ResourceList from './ResourceList';
 import {
   FolderTotalCount,
   getTotalCountForFolder,
@@ -41,6 +38,8 @@ import NewFolder from '../../../components/MyNdla/NewFolder';
 import MyNdlaTitle from '../components/MyNdlaTitle';
 import TitleWrapper from '../components/TitleWrapper';
 import FolderActions from './FolderActions';
+import FolderList from './FolderList';
+import ResourceList from './ResourceList';
 
 interface BlockWrapperProps {
   type?: string;
@@ -62,7 +61,7 @@ const StyledFolderIcon = styled.span`
   }
 `;
 
-export const BlockWrapper = styled.ul<BlockWrapperProps>`
+export const BlockWrapper = styled.div<BlockWrapperProps>`
   display: flex;
   flex-direction: column;
   gap: ${spacing.xsmall};
@@ -314,37 +313,13 @@ const FoldersPage = () => {
               onCreate={onFolderAdd}
             />
           )}
-          {folders.map((folder, index) => (
-            <ListItem
-              key={`folder-${index}`}
-              id={`folder-${folder.id}`}
-              tabIndex={-1}>
-              <Folder
-                key={folder.id}
-                id={folder.id}
-                link={`/minndla/folders/${folder.id}`}
-                title={folder.name}
-                type={type === 'block' ? 'block' : 'list'}
-                subFolders={foldersCount[folder.id]?.folders}
-                subResources={foldersCount[folder.id]?.resources}
-                menuItems={[
-                  {
-                    icon: <Pencil />,
-                    text: t('myNdla.folder.edit'),
-                    onClick: () =>
-                      setFolderAction({ action: 'edit', folder, index }),
-                  },
-                  {
-                    icon: <DeleteForever />,
-                    text: t('myNdla.folder.delete'),
-                    onClick: () =>
-                      setFolderAction({ action: 'delete', folder, index }),
-                    type: 'danger',
-                  },
-                ]}
-              />
-            </ListItem>
-          ))}
+          <FolderList
+            currentFolderId={folderId}
+            folders={folders}
+            foldersCount={foldersCount}
+            setFolderAction={setFolderAction}
+            type={type}
+          />
         </BlockWrapper>
       )}
       {selectedFolder && (

--- a/src/containers/MyNdla/Folders/ResourceList.tsx
+++ b/src/containers/MyNdla/Folders/ResourceList.tsx
@@ -24,6 +24,10 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
+import {
+  restrictToParentElement,
+  restrictToVerticalAxis,
+} from '@dnd-kit/modifiers';
 import AddResourceToFolderModal from '../../../components/MyNdla/AddResourceToFolderModal';
 import { GQLFolder, GQLFolderResource } from '../../../graphqlTypes';
 import DeleteModal from '../components/DeleteModal';
@@ -160,7 +164,8 @@ const ResourceList = ({ selectedFolder, viewType, folderId }: Props) => {
       <DndContext
         sensors={sensors}
         collisionDetection={closestCenter}
-        onDragEnd={sortResourceIds}>
+        onDragEnd={sortResourceIds}
+        modifiers={[restrictToVerticalAxis, restrictToParentElement]}>
         <SortableContext
           items={sortedResources}
           strategy={verticalListSortingStrategy}>

--- a/src/containers/MyNdla/Folders/util.ts
+++ b/src/containers/MyNdla/Folders/util.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2022-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { DragEndEvent } from '@dnd-kit/core';
+import { arrayMove } from '@dnd-kit/sortable';
+
+export const makeDndSortFunction = <PID, RES, T extends { id: string }>(
+  parentId: PID,
+  sortables: T[],
+  sortFunction: (options: {
+    variables: { sortedIds: string[]; parentId: PID };
+  }) => Promise<RES>,
+  updateCache: (newOrder: string[]) => void,
+  setSortedFoldersState: (setNew: T[]) => void,
+) => {
+  return async (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (over === null) return;
+
+    const originalIds = sortables.map(f => f.id);
+    const oldIndex = originalIds.indexOf(active.id as string);
+    const newIndex = originalIds.indexOf(over.id as string);
+
+    if (newIndex === undefined || newIndex === oldIndex) return;
+
+    const newSorted = arrayMove(sortables, oldIndex, newIndex);
+    setSortedFoldersState(newSorted);
+
+    const sortedIds = newSorted.map(f => f.id);
+
+    // Update cache before sorting happens to make GUI feel snappy
+    updateCache(sortedIds);
+
+    return sortFunction({
+      variables: {
+        sortedIds,
+        parentId,
+      },
+    }).catch(() => updateCache(originalIds));
+  };
+};

--- a/src/containers/MyNdla/folderMutations.ts
+++ b/src/containers/MyNdla/folderMutations.ts
@@ -28,9 +28,12 @@ import {
   GQLMutationAddFolderResourceArgs,
   GQLMutationDeleteFolderArgs,
   GQLMutationDeleteFolderResourceArgs,
+  GQLMutationSortFoldersArgs,
+  GQLMutationSortResourcesArgs,
   GQLMutationUpdateFolderArgs,
   GQLMutationUpdateFolderResourceArgs,
   GQLRecentlyUsedQuery,
+  GQLSortFoldersMutation,
   GQLUpdateFolderMutation,
   GQLUpdateFolderResourceMutation,
 } from '../../graphqlTypes';
@@ -144,6 +147,24 @@ const updateFolderMutation = gql`
     }
   }
   ${foldersPageQueryFragment}
+`;
+
+const sortFoldersMutation = gql`
+  mutation sortFolders($parentId: String, $sortedIds: [String!]!) {
+    sortFolders(parentId: $parentId, sortedIds: $sortedIds) {
+      parentId
+      sortedIds
+    }
+  }
+`;
+
+const sortResourcesMutation = gql`
+  mutation sortResources($parentId: String!, $sortedIds: [String!]!) {
+    sortResources(parentId: $parentId, sortedIds: $sortedIds) {
+      parentId
+      sortedIds
+    }
+  }
 `;
 
 const folderResourceMetaFragment = gql`
@@ -363,6 +384,23 @@ export const useUpdateFolderMutation = () => {
   >(updateFolderMutation);
 
   return { updateFolder, loading };
+};
+
+export const useSortFoldersMutation = () => {
+  const [sortFolders] = useMutation<
+    GQLSortFoldersMutation,
+    GQLMutationSortFoldersArgs
+  >(sortFoldersMutation);
+
+  return { sortFolders };
+};
+
+export const useSortResourcesMutation = () => {
+  const [sortResources] = useMutation<boolean, GQLMutationSortResourcesArgs>(
+    sortResourcesMutation,
+  );
+
+  return { sortResources };
 };
 
 const addResourceToFolderQuery = gql`

--- a/src/graphqlTypes.ts
+++ b/src/graphqlTypes.ts
@@ -679,6 +679,8 @@ export type GQLMutation = {
   deleteFolder: Scalars['String'];
   deleteFolderResource: Scalars['String'];
   deletePersonalData: Scalars['Boolean'];
+  sortFolders: GQLSortResult;
+  sortResources: GQLSortResult;
   updateFolder: GQLFolder;
   updateFolderResource: GQLFolderResource;
 };
@@ -704,6 +706,16 @@ export type GQLMutationDeleteFolderArgs = {
 export type GQLMutationDeleteFolderResourceArgs = {
   folderId: Scalars['String'];
   resourceId: Scalars['String'];
+};
+
+export type GQLMutationSortFoldersArgs = {
+  parentId?: InputMaybe<Scalars['String']>;
+  sortedIds: Array<Scalars['String']>;
+};
+
+export type GQLMutationSortResourcesArgs = {
+  parentId: Scalars['String'];
+  sortedIds: Array<Scalars['String']>;
 };
 
 export type GQLMutationUpdateFolderArgs = {
@@ -1132,6 +1144,12 @@ export type GQLSearchSuggestion = {
 export type GQLSearchWithoutPagination = {
   __typename?: 'SearchWithoutPagination';
   results: Array<GQLSearchResult>;
+};
+
+export type GQLSortResult = {
+  __typename?: 'SortResult';
+  parentId?: Maybe<Scalars['String']>;
+  sortedIds: Array<Scalars['String']>;
 };
 
 export type GQLSubject = GQLTaxonomyEntity & {
@@ -2222,6 +2240,34 @@ export type GQLUpdateFolderMutationVariables = Exact<{
 export type GQLUpdateFolderMutation = {
   __typename?: 'Mutation';
   updateFolder: { __typename?: 'Folder' } & GQLFoldersPageQueryFragmentFragment;
+};
+
+export type GQLSortFoldersMutationVariables = Exact<{
+  parentId?: InputMaybe<Scalars['String']>;
+  sortedIds: Array<Scalars['String']> | Scalars['String'];
+}>;
+
+export type GQLSortFoldersMutation = {
+  __typename?: 'Mutation';
+  sortFolders: {
+    __typename?: 'SortResult';
+    parentId?: string;
+    sortedIds: Array<string>;
+  };
+};
+
+export type GQLSortResourcesMutationVariables = Exact<{
+  parentId: Scalars['String'];
+  sortedIds: Array<Scalars['String']> | Scalars['String'];
+}>;
+
+export type GQLSortResourcesMutation = {
+  __typename?: 'Mutation';
+  sortResources: {
+    __typename?: 'SortResult';
+    parentId?: string;
+    sortedIds: Array<string>;
+  };
 };
 
 export type GQLFolderResourceMetaFragment = {

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -597,6 +597,8 @@ type Mutation {
   deleteFolder(id: String!): String!
   deleteFolderResource(folderId: String!, resourceId: String!): String!
   deletePersonalData: Boolean!
+  sortFolders(parentId: String, sortedIds: [String!]!): SortResult!
+  sortResources(parentId: String!, sortedIds: [String!]!): SortResult!
   updateFolder(id: String!, name: String, status: String): Folder!
   updateFolderResource(id: String!, tags: [String!]): FolderResource!
 }
@@ -885,6 +887,11 @@ type SearchSuggestion {
 
 type SearchWithoutPagination {
   results: [SearchResult!]!
+}
+
+type SortResult {
+  parentId: String
+  sortedIds: [String!]!
 }
 
 scalar StringRecord

--- a/src/types/react-i18next.ts
+++ b/src/types/react-i18next.ts
@@ -27,14 +27,10 @@ declare module 'react-i18next' {
     options?: UseTranslationOptions,
   ): CustomUseTranslationResponse<N>;
 
-  function withTranslation<
-    N extends Namespace = DefaultNamespace,
-    TKPrefix extends KeyPrefix<N> = undefined
-  >(
+  function withTranslation<N extends Namespace = DefaultNamespace>(
     ns?: N,
     options?: {
       withRef?: boolean;
-      keyPrefix?: TKPrefix;
     },
   ): <
     C extends ComponentType<ComponentProps<any> & WithTranslationProps>,

--- a/src/util/apiHelpers.ts
+++ b/src/util/apiHelpers.ts
@@ -33,7 +33,7 @@ import {
 
 export const fetch = createFetch;
 
-const __SERVER__ = process.env.BUILD_TARGET === 'server'; //eslint-disable-line
+export const __SERVER__ = process.env.BUILD_TARGET === 'server'; //eslint-disable-line
 const __CLIENT__ = process.env.BUILD_TARGET === 'client'; //eslint-disable-line
 
 const apiBaseUrl = (() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3017,6 +3017,37 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
+"@dnd-kit/accessibility@^3.0.0":
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.0.1.tgz#3ccbefdfca595b0a23a5dc57d3de96bc6935641c"
+  integrity sha512-HXRrwS9YUYQO9lFRc/49uO/VICbM+O+ZRpFDe9Pd1rwVv2PCNkRiTZRdxrDgng/UkvdC3Re9r2vwPpXXrWeFzg==
+  dependencies:
+    tslib "^2.0.0"
+
+"@dnd-kit/core@6.0.5":
+  version "6.0.5"
+  resolved "https://registry.npmjs.org/@dnd-kit/core/-/core-6.0.5.tgz#5670ad0dcc83cd51dbf2fa8c6a5c8af4ac0c1989"
+  integrity sha512-3nL+Zy5cT+1XwsWdlXIvGIFvbuocMyB4NBxTN74DeBaBqeWdH9JsnKwQv7buZQgAHmAH+eIENfS1ginkvW6bCw==
+  dependencies:
+    "@dnd-kit/accessibility" "^3.0.0"
+    "@dnd-kit/utilities" "^3.2.0"
+    tslib "^2.0.0"
+
+"@dnd-kit/sortable@7.0.1":
+  version "7.0.1"
+  resolved "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-7.0.1.tgz#99c6012bbab4d8bb726c0eef7b921a338c404fdb"
+  integrity sha512-n77qAzJQtMMywu25sJzhz3gsHnDOUlEjTtnRl8A87rWIhnu32zuP+7zmFjwGgvqfXmRufqiHOSlH7JPC/tnJ8Q==
+  dependencies:
+    "@dnd-kit/utilities" "^3.2.0"
+    tslib "^2.0.0"
+
+"@dnd-kit/utilities@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.0.tgz#b3e956ea63a1347c9d0e1316b037ddcc6140acda"
+  integrity sha512-h65/pn2IPCCIWwdlR2BMLqRkDxpTEONA+HQW3n765HBijLYGyrnTCLa2YQt8VVjjSQD6EfFlTE6aS2Q/b6nb2g==
+  dependencies:
+    tslib "^2.0.0"
+
 "@edge-runtime/format@^1.1.0-beta.23":
   version "1.1.0-beta.26"
   resolved "https://registry.yarnpkg.com/@edge-runtime/format/-/format-1.1.0-beta.26.tgz#99e3f8dfe4ed5dd36376a2c4167ac67ed0259820"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3033,6 +3033,14 @@
     "@dnd-kit/utilities" "^3.2.0"
     tslib "^2.0.0"
 
+"@dnd-kit/modifiers@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-6.0.0.tgz#61d8834132f791a68e9e93be5426becbcd45c078"
+  integrity sha512-V3+JSo6/BTcgPRHiNUTSKgqVv/doKXg+T4Z0QvKiiXp+uIyJTUtPkQOBRQApUWi3ApBhnoWljyt/3xxY4fTd0Q==
+  dependencies:
+    "@dnd-kit/utilities" "^3.2.0"
+    tslib "^2.0.0"
+
 "@dnd-kit/sortable@7.0.1":
   version "7.0.1"
   resolved "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-7.0.1.tgz#99c6012bbab4d8bb726c0eef7b921a338c404fdb"


### PR DESCRIPTION
Depends on https://github.com/NDLANO/ndla-frontend/pull/1145
Depends on https://github.com/NDLANO/graphql-api/pull/273

Prøver ut [dnd-kit](https://dndkit.com).
Er teknisk sett _mulig_ å isolere noen props ved å dra de ut i et bibliotek, men personlig så syns jeg dette var såpass enkelt å bruke at vi like greit kan bruke det direkte.

Er ikke _heeelt_ overbevist om designet, men fikk høre av @haattis og @Jonas-C at det var iiiish sånn det så ut.

Mangler en oversettelse for aria-label'en på drag handle'n. Vet ikke om jeg fortsatt kan bruke filene i ndla-frontend eller om jeg må lage en PR til frontend-packages? Er uansett ikke så flink på samisk :^)

Kan testes ut ved å se at sortering av mapper og ressurser fungerer på min-ndla siden.
