### PR TITLE
Add catch for mathjax error

### DIFF
--- a/public/static/mathjax-config.js
+++ b/public/static/mathjax-config.js
@@ -16,7 +16,7 @@ window.MathJax = {
       enableMenu: true,
       menuOptions:{
           settings:{
-              assistiveMml: true,
+              assistiveMml: false,
               collapsible: false,
               explorer: true
           }

--- a/src/containers/ArticlePage/ArticlePage.tsx
+++ b/src/containers/ArticlePage/ArticlePage.tsx
@@ -83,7 +83,7 @@ const ArticlePage = ({
 
   useEffect(() => {
     if (window.MathJax && typeof window.MathJax.typeset === 'function') {
-      try  {
+      try {
         window.MathJax.typeset();
       } catch (err) {
         // do nothing

--- a/src/containers/ArticlePage/ArticlePage.tsx
+++ b/src/containers/ArticlePage/ArticlePage.tsx
@@ -83,7 +83,11 @@ const ArticlePage = ({
 
   useEffect(() => {
     if (window.MathJax && typeof window.MathJax.typeset === 'function') {
-      window.MathJax.typeset();
+      try  {
+        window.MathJax.typeset();
+      } catch (err) {
+        // do nothing
+      }
     }
   });
 

--- a/src/containers/LearningpathPage/LearningpathPage.tsx
+++ b/src/containers/LearningpathPage/LearningpathPage.tsx
@@ -62,8 +62,12 @@ const LearningpathPage = ({
 }: Props) => {
   const navigate = useNavigate();
   useEffect(() => {
-    if (window.MathJax) {
-      window.MathJax.typeset();
+    if (window.MathJax && typeof window.MathJax.typeset === 'function') {
+      try  {
+        window.MathJax.typeset();
+      } catch (err) {
+        // do nothing
+      }
     }
   });
 

--- a/src/containers/LearningpathPage/LearningpathPage.tsx
+++ b/src/containers/LearningpathPage/LearningpathPage.tsx
@@ -63,7 +63,7 @@ const LearningpathPage = ({
   const navigate = useNavigate();
   useEffect(() => {
     if (window.MathJax && typeof window.MathJax.typeset === 'function') {
-      try  {
+      try {
         window.MathJax.typeset();
       } catch (err) {
         // do nothing

--- a/src/containers/PlainArticlePage/PlainArticleContainer.tsx
+++ b/src/containers/PlainArticlePage/PlainArticleContainer.tsx
@@ -43,7 +43,11 @@ const PlainArticleContainer = ({
 }: Props) => {
   useEffect(() => {
     if (window.MathJax && typeof window.MathJax.typeset === 'function') {
-      window?.MathJax?.typeset();
+      try  {
+        window.MathJax.typeset();
+      } catch (err) {
+        // do nothing
+      }
     }
   });
 

--- a/src/containers/PlainArticlePage/PlainArticleContainer.tsx
+++ b/src/containers/PlainArticlePage/PlainArticleContainer.tsx
@@ -43,7 +43,7 @@ const PlainArticleContainer = ({
 }: Props) => {
   useEffect(() => {
     if (window.MathJax && typeof window.MathJax.typeset === 'function') {
-      try  {
+      try {
         window.MathJax.typeset();
       } catch (err) {
         // do nothing

--- a/src/containers/PlainLearningpathPage/PlainLearningpathContainer.tsx
+++ b/src/containers/PlainLearningpathPage/PlainLearningpathContainer.tsx
@@ -43,8 +43,12 @@ const PlainLearningpathContainer = ({
   const steps = learningpath.learningsteps;
 
   useEffect(() => {
-    if (window.MathJax) {
-      window.MathJax.typeset();
+    if (window.MathJax && typeof window.MathJax.typeset === 'function') {
+      try  {
+        window.MathJax.typeset();
+      } catch (err) {
+        // do nothing
+      }
     }
   });
 

--- a/src/containers/PlainLearningpathPage/PlainLearningpathContainer.tsx
+++ b/src/containers/PlainLearningpathPage/PlainLearningpathContainer.tsx
@@ -44,7 +44,7 @@ const PlainLearningpathContainer = ({
 
   useEffect(() => {
     if (window.MathJax && typeof window.MathJax.typeset === 'function') {
-      try  {
+      try {
         window.MathJax.typeset();
       } catch (err) {
         // do nothing

--- a/src/util/getArticleScripts.ts
+++ b/src/util/getArticleScripts.ts
@@ -28,7 +28,7 @@ export function getArticleScripts(
   if (article && article.content.indexOf('<math') > -1) {
     // Increment number for each change in config.
     scripts.push({
-      src: `/static/mathjax-config.js?locale=${locale}&ts=${1}`,
+      src: `/static/mathjax-config.js?locale=${locale}&ts=${2}`,
       type: 'text/javascript',
       async: false,
       defer: true,


### PR DESCRIPTION
Generering av aria-label kan av og til føre til at typeset feiler ved rerender. Dette forhindrer at sida krasher på grunn av en error som ikkje plukkes opp. Ser ikkje ut som om det har praktisk betydning.

Test:
Denne sida har eg opplevd har feila ved hypping lasting: https://test.ndla.no/nb/subject:1:3ae2c40f-4661-4863-9987-4944ff534974/topic:2:165540/topic:2:165558/resource:1:95726

Tilsvarende url i pr bør rendres uten feil.