### PR TITLE
Remove dollar sign that breaks the first css object extracted by emotion

### DIFF
--- a/src/server/helpers/Document.tsx
+++ b/src/server/helpers/Document.tsx
@@ -64,7 +64,7 @@ const Document = ({ helmet, assets, data, css, ids }: Props) => {
         />
         {css && ids && (
           <style data-emotion-css={`${EmotionCacheKey} ${ids.join(' ')}`}>
-            ${css}
+            {css}
           </style>
         )}
         {helmet.script.toComponent()}


### PR DESCRIPTION
Fun fact: Grunnen til at "Hopp til innhold" alltid er synlig er at det er det aller første i emotion-css-strengen.