### PR TITLE
Load stylesheets on server

### DIFF
--- a/src/containers/WelcomePage/WelcomePage.tsx
+++ b/src/containers/WelcomePage/WelcomePage.tsx
@@ -123,7 +123,7 @@ const WelcomePage = () => {
           />
           <BlogPosts locale={i18n.language} />
           <FrontpageFilm
-            imageUrl="/static/film_illustrasjon.svg"
+            imageUrl="http://localhost:3000/static/film_illustrasjon.svg"
             url={FILM_PAGE_PATH}
           />
           <WelcomePageInfo />

--- a/src/server/helpers/Document.tsx
+++ b/src/server/helpers/Document.tsx
@@ -64,7 +64,7 @@ const Document = ({ helmet, assets, data, css, ids }: Props) => {
         />
         {css && ids && (
           <style data-emotion-css={`${EmotionCacheKey} ${ids.join(' ')}`}>
-            ${css}
+            {css}
           </style>
         )}
         {helmet.script.toComponent()}

--- a/src/server/helpers/Document.tsx
+++ b/src/server/helpers/Document.tsx
@@ -56,7 +56,9 @@ const Document = ({ helmet, assets, data, css, ids }: Props) => {
         {helmet.title.toComponent()}
         {helmet.meta.toComponent()}
         {helmet.link.toComponent()}
-        {assets.css && <link rel="stylesheet" href={assets.css} />}
+        {assets.css && (
+          <link rel="stylesheet" href={`http://localhost:3000${assets.css}`} />
+        )}
         <link
           rel="shortcut icon"
           href="/static/ndla-favicon.png"


### PR DESCRIPTION
Eksperimenterte litt med side-styling i helgen, og kom fram til noe ganske stilig når jeg tittet på SSR-responsen til NRK. Jeg så at de brukte absolutte pather som inkludrerte domenenavnet for lasting av statisk innhold, og tenkte det var verdt et forsøk hos oss også. Surprise, surprise, det funker!

Dette er som sagt bare et POC, jeg vet ikke om man vil få noe performance gains ut av det. Man kan teste det ut ved å bygge et prod-build fra denne branchen, og deretter sammenligne server-responsen med test. Inntil videre har jeg lastet NDLA Film-bildet og scss'en vår. 