### PR TITLE
Prevent overriding selected folder on saving new folder in treestructure

### DIFF
--- a/src/components/MyNdla/AddResourceToFolder.tsx
+++ b/src/components/MyNdla/AddResourceToFolder.tsx
@@ -232,12 +232,12 @@ const AddResourceToFolder = ({
       : ['folders'];
 
     const last = defaultOpen[defaultOpen.length - 1];
-    if (last !== 'folders') {
+    if (last !== 'folders' && !selectedFolderId) {
       setSelectedFolderId(last);
     }
 
     return defaultOpen;
-  }, [structureFolders, defaultOpenFolder]);
+  }, [structureFolders, defaultOpenFolder, selectedFolderId]);
 
   const noFolderSelected = selectedFolderId === 'folders';
 


### PR DESCRIPTION
Fikser en feil der valgt mappe ble overstyrt dersom man opprettet ny mappe. Se https://trello.com/c/c6ROMy8O/269-feilmelding-etter-oppretting-av-ny-mappe-i-trestruktur.

Hvordan teste:
- Naviger inn i mappene (A) og finn en ressurs. Trykk legg til mappe/emneknagg.
- Opprett umiddelbart en ny mappe (B) i trestruktur.
- Feilmelding tidligere ville vise at ressursen allerede finnes, dette fordi valgt mappe-id ble tilbakestilt til våre A og ikke B. 
- Lagre og se at ressurs ble lagret i mappe B som forventet.