### PR TITLE
Prevent saving duplicate resource when already in folder

### DIFF
--- a/src/components/MyNdla/AddResourceToFolder.tsx
+++ b/src/components/MyNdla/AddResourceToFolder.tsx
@@ -190,8 +190,12 @@ const AddResourceToFolder = ({
     loading: addResourceLoading,
   } = useAddResourceToFolderMutation(selectedFolder?.id ?? '');
 
+  const alreadyAdded = selectedFolder?.resources.some(
+    resource => resource.id === storedResource?.id,
+  );
+
   const onSave = async () => {
-    if (selectedFolder) {
+    if (selectedFolder && !alreadyAdded) {
       await addResourceToFolder({
         variables: {
           resourceId: resource.id,
@@ -240,10 +244,6 @@ const AddResourceToFolder = ({
   }, [structureFolders, defaultOpenFolder]);
 
   const noFolderSelected = selectedFolderId === 'folders';
-
-  const alreadyAdded = selectedFolder?.resources.some(
-    resource => resource.id === storedResource?.id,
-  );
 
   return (
     <AddResourceContainer>


### PR DESCRIPTION
Ved lagring av ressurs med nye tags i en mappe der ressursen allerede eksisterte førte til duplikat i cachen. Bruker en eksisterende sjekk til å droppe lagring i mappe dersom den allerede finnes. Se https://trello.com/c/YTp9329I/270-duplikate-ressurser-i-test

Kan framprovoseres i test ved å oppdatere tags og lagre ressursen i en mappe der den allerede finnes. Tilsvarende teste PR lokalt.