### PR TITLE
Myndla hotfixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "@ndla/safelink": "^3.0.8",
     "@ndla/tabs": "^2.0.7",
     "@ndla/tracker": "^2.0.3",
-    "@ndla/ui": "^30.2.3",
+    "@ndla/ui": "^30.3.1",
     "@ndla/util": "^3.1.7",
     "@ndla/zendesk": "^1.0.8",
     "babel-polyfill": "^6.26.0",

--- a/src/components/MyNdla/AddResourceToFolder.tsx
+++ b/src/components/MyNdla/AddResourceToFolder.tsx
@@ -262,7 +262,6 @@ const AddResourceToFolder = ({
       />
       <ComboboxContainer>
         <TreeStructure
-          maxLevel={5}
           folders={structureFolders}
           label={t('myNdla.myFolders')}
           onSelectFolder={setSelectedFolderId}

--- a/src/components/MyNdla/AddResourceToFolder.tsx
+++ b/src/components/MyNdla/AddResourceToFolder.tsx
@@ -137,12 +137,6 @@ const AddResourceToFolder = ({
   }, [folders, loading, resource.path, storedResource]);
 
   useEffect(() => {
-    if (storedResource) {
-      setSelectedTags(storedResource.tags);
-    }
-  }, [storedResource]);
-
-  useEffect(() => {
     const tagsChanged = !!(
       storedResource && shouldUpdateFolderResource(storedResource, selectedTags)
     );

--- a/src/components/MyNdla/AddResourceToFolder.tsx
+++ b/src/components/MyNdla/AddResourceToFolder.tsx
@@ -126,14 +126,15 @@ const AddResourceToFolder = ({
   const { addSnack } = useSnack();
 
   useEffect(() => {
-    if (!loading && folders) {
+    if (!loading && folders && !storedResource) {
       const _storedResource = getResourceForPath(folders, resource.path);
       setStoredResource(_storedResource ?? undefined);
-      setSelectedTags(uniq(selectedTags.concat(_storedResource?.tags ?? [])));
       setTags(tags => uniq(compact(tags.concat(getAllTags(folders)))));
+      setSelectedTags(prevTags =>
+        uniq(prevTags.concat(_storedResource?.tags ?? [])),
+      );
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loading]);
+  }, [folders, loading, resource.path, storedResource]);
 
   useEffect(() => {
     if (storedResource) {

--- a/src/components/MyNdla/AddResourceToFolder.tsx
+++ b/src/components/MyNdla/AddResourceToFolder.tsx
@@ -129,10 +129,11 @@ const AddResourceToFolder = ({
     if (!loading && folders) {
       const _storedResource = getResourceForPath(folders, resource.path);
       setStoredResource(_storedResource ?? undefined);
-      setSelectedTags(_storedResource?.tags ?? []);
-      setTags(tags => compact(tags.concat(getAllTags(folders))));
+      setSelectedTags(uniq(selectedTags.concat(_storedResource?.tags ?? [])));
+      setTags(tags => uniq(compact(tags.concat(getAllTags(folders)))));
     }
-  }, [loading, folders, resource]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loading]);
 
   useEffect(() => {
     if (storedResource) {
@@ -261,6 +262,7 @@ const AddResourceToFolder = ({
       />
       <ComboboxContainer>
         <TreeStructure
+          maxLevel={5}
           folders={structureFolders}
           label={t('myNdla.myFolders')}
           onSelectFolder={setSelectedFolderId}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4191,10 +4191,10 @@
   resolved "https://registry.yarnpkg.com/@ndla/types-learningpath-api/-/types-learningpath-api-0.0.13.tgz#76adbd73a130b59f922f30be8b5de60f0af7019c"
   integrity sha512-yA3qN+an26HtrBMW5nr6/A+DHSSpq/ohAW49mOsVeYDJBG08csNzVTEO46iDbCqmTO3W/RSBPicDikI68lfBMw==
 
-"@ndla/ui@^30.2.3":
-  version "30.2.3"
-  resolved "https://registry.yarnpkg.com/@ndla/ui/-/ui-30.2.3.tgz#b1000e52a82f546a15d12ce3b648ae71ba2f7a08"
-  integrity sha512-qhaSNH7UbL0Iv0dEofRA3AiBb3KwUmKL1GLV9T1lBUeCjTr/WsdNo5PmPlYMz80X61J7YyE7uMj47GTxUPEuig==
+"@ndla/ui@^30.3.1":
+  version "30.3.1"
+  resolved "https://registry.yarnpkg.com/@ndla/ui/-/ui-30.3.1.tgz#20da149c4332d5b5b3b3a253abf754c622a31a0b"
+  integrity sha512-PvWEdtqicZMndm4qBSdFmF5vGlT/ZCW844e+X8qE/pjFq3ZlVffWW1goNVBiZYxPBgpkhd9PkCUWI12M3H2Nrg==
   dependencies:
     "@ndla/article-scripts" "^3.0.9"
     "@ndla/button" "^5.0.2"


### PR DESCRIPTION
Fikser tre feil.

Det skal ikke lenger dukke opp duplikate tags i tagvelger etter man oppretter mappe i trestruktur.:
https://trello.com/c/lLKLenan/271-duplikater-av-tags-i-tagforslaget-i-tagvelgeren

Forhindrer framtidige feilmeldinger på mappeside pga en liten feil i BlockResource der det ikke ble tatt hensyn til tomme lister.  Kommer fra pakkeoppdatering:
https://trello.com/c/IUi3BC7Q/272-navigering-i-sidemeny-ved-blokkvisning-gir-feilmelding

I trestruktur var det kun mulig å opprette opptil fire mapper i dybden. Dette er nå oppdatert til fem som er riktig. Kommer fra pakkeoppdatering:
https://trello.com/c/23BtFFVi/273-mismatch-mellom-maks-mappedybde-i-mappevisning-og-trestruktur
