### PR TITLE
Separate types for foldermeta for articles and learningpath

### DIFF
--- a/src/graphqlTypes.ts
+++ b/src/graphqlTypes.ts
@@ -61,6 +61,16 @@ export type GQLArticleCrossSubjectTopicsArgs = {
   subjectId?: InputMaybe<Scalars['String']>;
 };
 
+export type GQLArticleFolderResourceMeta = GQLFolderResourceMeta & {
+  __typename?: 'ArticleFolderResourceMeta';
+  description: Scalars['String'];
+  id: Scalars['Int'];
+  metaImage?: Maybe<GQLMetaImage>;
+  resourceTypes: Array<GQLFolderResourceResourceType>;
+  title: Scalars['String'];
+  type: Scalars['String'];
+};
+
 export type GQLArticleMetaData = {
   __typename?: 'ArticleMetaData';
   audios?: Maybe<Array<GQLAudioLicense>>;
@@ -380,7 +390,6 @@ export type GQLFolderResource = {
 };
 
 export type GQLFolderResourceMeta = {
-  __typename?: 'FolderResourceMeta';
   description: Scalars['String'];
   id: Scalars['Int'];
   metaImage?: Maybe<GQLMetaImage>;
@@ -556,6 +565,16 @@ export type GQLLearningpathCoverphoto = {
   url: Scalars['String'];
 };
 
+export type GQLLearningpathFolderResourceMeta = GQLFolderResourceMeta & {
+  __typename?: 'LearningpathFolderResourceMeta';
+  description: Scalars['String'];
+  id: Scalars['Int'];
+  metaImage?: Maybe<GQLMetaImage>;
+  resourceTypes: Array<GQLFolderResourceResourceType>;
+  title: Scalars['String'];
+  type: Scalars['String'];
+};
+
 export type GQLLearningpathSearchResult = GQLSearchResult & {
   __typename?: 'LearningpathSearchResult';
   contexts: Array<GQLSearchContext>;
@@ -679,6 +698,8 @@ export type GQLMutation = {
   deleteFolder: Scalars['String'];
   deleteFolderResource: Scalars['String'];
   deletePersonalData: Scalars['Boolean'];
+  sortFolders: GQLSortResult;
+  sortResources: GQLSortResult;
   updateFolder: GQLFolder;
   updateFolderResource: GQLFolderResource;
 };
@@ -704,6 +725,16 @@ export type GQLMutationDeleteFolderArgs = {
 export type GQLMutationDeleteFolderResourceArgs = {
   folderId: Scalars['String'];
   resourceId: Scalars['String'];
+};
+
+export type GQLMutationSortFoldersArgs = {
+  parentId?: InputMaybe<Scalars['String']>;
+  sortedIds: Array<Scalars['String']>;
+};
+
+export type GQLMutationSortResourcesArgs = {
+  parentId: Scalars['String'];
+  sortedIds: Array<Scalars['String']>;
 };
 
 export type GQLMutationUpdateFolderArgs = {
@@ -1132,6 +1163,12 @@ export type GQLSearchSuggestion = {
 export type GQLSearchWithoutPagination = {
   __typename?: 'SearchWithoutPagination';
   results: Array<GQLSearchResult>;
+};
+
+export type GQLSortResult = {
+  __typename?: 'SortResult';
+  parentId?: Maybe<Scalars['String']>;
+  sortedIds: Array<Scalars['String']>;
 };
 
 export type GQLSubject = GQLTaxonomyEntity & {
@@ -2224,8 +2261,8 @@ export type GQLUpdateFolderMutation = {
   updateFolder: { __typename?: 'Folder' } & GQLFoldersPageQueryFragmentFragment;
 };
 
-export type GQLFolderResourceMetaFragment = {
-  __typename: 'FolderResourceMeta';
+type GQLFolderResourceMeta_ArticleFolderResourceMeta_Fragment = {
+  __typename: 'ArticleFolderResourceMeta';
   id: number;
   title: string;
   description: string;
@@ -2238,15 +2275,37 @@ export type GQLFolderResourceMetaFragment = {
   }>;
 };
 
+type GQLFolderResourceMeta_LearningpathFolderResourceMeta_Fragment = {
+  __typename: 'LearningpathFolderResourceMeta';
+  id: number;
+  title: string;
+  description: string;
+  type: string;
+  metaImage?: { __typename?: 'MetaImage'; url: string; alt: string };
+  resourceTypes: Array<{
+    __typename?: 'FolderResourceResourceType';
+    id: string;
+    name: string;
+  }>;
+};
+
+export type GQLFolderResourceMetaFragment =
+  | GQLFolderResourceMeta_ArticleFolderResourceMeta_Fragment
+  | GQLFolderResourceMeta_LearningpathFolderResourceMeta_Fragment;
+
 export type GQLFolderResourceMetaQueryVariables = Exact<{
   resource: GQLFolderResourceMetaSearchInput;
 }>;
 
 export type GQLFolderResourceMetaQuery = {
   __typename?: 'Query';
-  folderResourceMeta?: {
-    __typename?: 'FolderResourceMeta';
-  } & GQLFolderResourceMetaFragment;
+  folderResourceMeta?:
+    | ({
+        __typename?: 'ArticleFolderResourceMeta';
+      } & GQLFolderResourceMeta_ArticleFolderResourceMeta_Fragment)
+    | ({
+        __typename?: 'LearningpathFolderResourceMeta';
+      } & GQLFolderResourceMeta_LearningpathFolderResourceMeta_Fragment);
 };
 
 export type GQLFolderResourceMetaSearchQueryVariables = Exact<{
@@ -2258,7 +2317,12 @@ export type GQLFolderResourceMetaSearchQueryVariables = Exact<{
 export type GQLFolderResourceMetaSearchQuery = {
   __typename?: 'Query';
   folderResourceMetaSearch: Array<
-    { __typename?: 'FolderResourceMeta' } & GQLFolderResourceMetaFragment
+    | ({
+        __typename?: 'ArticleFolderResourceMeta';
+      } & GQLFolderResourceMeta_ArticleFolderResourceMeta_Fragment)
+    | ({
+        __typename?: 'LearningpathFolderResourceMeta';
+      } & GQLFolderResourceMeta_LearningpathFolderResourceMeta_Fragment)
   >;
 };
 

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -36,6 +36,15 @@ type Article {
   visualElement: VisualElement
 }
 
+type ArticleFolderResourceMeta implements FolderResourceMeta {
+  description: String!
+  id: Int!
+  metaImage: MetaImage
+  resourceTypes: [FolderResourceResourceType!]!
+  title: String!
+  type: String!
+}
+
 type ArticleMetaData {
   audios: [AudioLicense!]
   brightcoves: [BrightcoveLicense!]
@@ -323,7 +332,7 @@ type FolderResource {
   tags: [String!]!
 }
 
-type FolderResourceMeta {
+interface FolderResourceMeta {
   description: String!
   id: Int!
   metaImage: MetaImage
@@ -483,6 +492,15 @@ type LearningpathCoverphoto {
   url: String!
 }
 
+type LearningpathFolderResourceMeta implements FolderResourceMeta {
+  description: String!
+  id: Int!
+  metaImage: MetaImage
+  resourceTypes: [FolderResourceResourceType!]!
+  title: String!
+  type: String!
+}
+
 type LearningpathSearchResult implements SearchResult {
   contexts: [SearchContext!]!
   id: Int!
@@ -597,6 +615,8 @@ type Mutation {
   deleteFolder(id: String!): String!
   deleteFolderResource(folderId: String!, resourceId: String!): String!
   deletePersonalData: Boolean!
+  sortFolders(parentId: String, sortedIds: [String!]!): SortResult!
+  sortResources(parentId: String!, sortedIds: [String!]!): SortResult!
   updateFolder(id: String!, name: String, status: String): Folder!
   updateFolderResource(id: String!, tags: [String!]): FolderResource!
 }
@@ -885,6 +905,11 @@ type SearchSuggestion {
 
 type SearchWithoutPagination {
   results: [SearchResult!]!
+}
+
+type SortResult {
+  parentId: String
+  sortedIds: [String!]!
 }
 
 scalar StringRecord

--- a/src/util/apiHelpers.ts
+++ b/src/util/apiHelpers.ts
@@ -134,6 +134,10 @@ const mergeGroupSearch = (
 const possibleTypes = {
   TaxonomyEntity: ['Resource', 'Topic'],
   SearchResult: ['ArticleSearchResult', 'LearningpathSearchResult'],
+  FolderResourceMeta: [
+    'ArticleFolderResourceMeta',
+    'LearningpathFolderResourceMeta',
+  ],
 };
 
 const typePolicies: TypePolicies = {


### PR DESCRIPTION
Skille på typer for artikler og læringssti for foldermeta.

Testes sammen med [NDLANO/graphql-api](https://github.com/NDLANO/graphql-api/pull/278)

Test:
* Hent foldermeta for artikkel og læringssti som deler id:
* Læringssti id 3: /subject:1:01c27030-e8f8-4a7c-a5b3-489fdb8fea30/topic:2:182849/topic:2:175043/resource:1:176514 
* Artikkel id 3: /subject:1:19dae192-699d-488f-8218-d81535ce3ae3/topic:2:179373/topic:2:170165/resource:1:124037 