### PR TITLE
Stop passing cookie to apollo client on server

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,17 +77,15 @@ class App extends Component<AppProps, State> {
       return <ErrorPage />;
     }
 
-    return (
-      <AppRoutes resCookie={this.props.resCookie} base={this.props.base} />
-    );
+    return <AppRoutes base={this.props.base} />;
   }
 }
 
-const AppRoutes = ({ base, resCookie }: AppProps) => {
+const AppRoutes = ({ base }: AppProps) => {
   return (
     <AlertsProvider>
       <BaseNameProvider value={base}>
-        <AuthenticationContext initialValue={resCookie}>
+        <AuthenticationContext>
           <SnackbarProvider>
             <Routes>
               <Route path="/" element={<Layout />}>
@@ -171,7 +169,6 @@ interface AppProps {
   locale?: LocaleType;
   history?: History;
   isClient?: boolean;
-  resCookie?: string;
 }
 
 export default App;

--- a/src/client.tsx
+++ b/src/client.tsx
@@ -57,8 +57,6 @@ declare global {
 const {
   DATA: { config, serverPath, serverQuery },
 } = window;
-// Only handle cookies on client. Prevents auth-cookies to be serialized and stored in cached pages!
-const resCookie = document.cookie ?? '';
 
 const { basepath, abbreviation } = getLocaleInfoFromPath(serverPath ?? '');
 
@@ -99,7 +97,7 @@ window.errorReporter = ErrorReporter.getInstance({
 window.hasHydrated = false;
 const renderOrHydrate = config.disableSSR ? ReactDOM.render : ReactDOM.hydrate;
 
-const client = createApolloClient(storedLanguage, document.cookie, versionHash);
+const client = createApolloClient(storedLanguage, versionHash);
 const cache = createCache({ key: EmotionCacheKey });
 
 // Use memory router if running under google translate
@@ -204,7 +202,7 @@ const LanguageWrapper = ({ basename }: { basename?: string }) => {
       cookieValue: lang,
     });
     client.resetStore();
-    client.setLink(createApolloLinks(lang, resCookie, versionHash));
+    client.setLink(createApolloLinks(lang, versionHash));
     document.documentElement.lang = lang;
   });
 
@@ -237,13 +235,7 @@ const LanguageWrapper = ({ basename }: { basename?: string }) => {
   return (
     <NDLARouter key={base} base={base}>
       {history => (
-        <App
-          locale={i18n.language}
-          resCookie={resCookie}
-          history={history}
-          isClient
-          base={base}
-        />
+        <App locale={i18n.language} history={history} isClient base={base} />
       )}
     </NDLARouter>
   );

--- a/src/components/AuthenticationContext.tsx
+++ b/src/components/AuthenticationContext.tsx
@@ -7,11 +7,7 @@
 
 import { FeideUserApiType } from '@ndla/ui';
 import { createContext, ReactNode, useEffect, useState } from 'react';
-import {
-  getFeideCookie,
-  isAccessTokenValid,
-  millisUntilExpiration,
-} from '../util/authHelpers';
+import { isAccessTokenValid, millisUntilExpiration } from '../util/authHelpers';
 import { fetchFeideUserWithGroups } from '../util/feideApi';
 
 interface AuthContextType {
@@ -35,10 +31,8 @@ interface Props {
   initialValue?: string;
 }
 
-const AuthenticationContext = ({ children, initialValue }: Props) => {
-  const [authenticated, setAuthenticated] = useState(
-    initialValue ? isAccessTokenValid(getFeideCookie(initialValue)) : false,
-  );
+const AuthenticationContext = ({ children }: Props) => {
+  const [authenticated, setAuthenticated] = useState(false);
   const [authContextLoaded, setLoaded] = useState(false);
   const [user, setUser] = useState<FeideUserApiType | undefined>(undefined);
 

--- a/src/containers/PrivateRoute/PrivateRoute.tsx
+++ b/src/containers/PrivateRoute/PrivateRoute.tsx
@@ -7,13 +7,14 @@
  */
 import { ReactElement, useContext } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
+import { NoSSR } from '@ndla/util';
 import { AuthContext } from '../../components/AuthenticationContext';
 
 interface Props {
   element: ReactElement;
 }
 
-const PrivateRoute = ({ element }: Props) => {
+const ClientPrivateRoute = ({ element }: Props) => {
   const { authenticated } = useContext(AuthContext);
   const location = useLocation();
 
@@ -22,6 +23,14 @@ const PrivateRoute = ({ element }: Props) => {
   }
 
   return element;
+};
+
+const PrivateRoute = (props: Props) => {
+  return (
+    <NoSSR fallback={null}>
+      <ClientPrivateRoute {...props} />
+    </NoSSR>
+  );
 };
 
 export default PrivateRoute;

--- a/src/iframe/index.tsx
+++ b/src/iframe/index.tsx
@@ -63,7 +63,7 @@ const language = initialProps.locale ?? config.defaultLocale;
 
 const cache = createCache({ key: EmotionCacheKey });
 
-const client = createApolloClient(language, initialProps.resCookie);
+const client = createApolloClient(language);
 const i18n = initializeI18n(i18nInstance, language);
 
 const renderOrHydrate = disableSSR ? ReactDOM.render : ReactDOM.hydrate;

--- a/src/lti/index.tsx
+++ b/src/lti/index.tsx
@@ -51,7 +51,7 @@ const storedLanguage = getCookie(STORED_LANGUAGE_COOKIE_KEY, document.cookie);
 const language = isValidLocale(storedLanguage)
   ? storedLanguage
   : config.defaultLocale;
-const client = createApolloClient(language, document.cookie);
+const client = createApolloClient(language);
 const i18n = initializeI18n(i18nInstance, language);
 
 ReactDOM.render(

--- a/src/server/routes/defaultRoute.js
+++ b/src/server/routes/defaultRoute.js
@@ -58,7 +58,7 @@ async function doRender(req) {
   const { basename, abbreviation } = getLocaleInfoFromPath(req.path);
   const locale = getCookieLocaleOrFallback(resCookie, abbreviation);
 
-  const client = createApolloClient(locale, resCookie, versionHash);
+  const client = createApolloClient(locale, versionHash);
 
   const cache = createCache({ key: EmotionCacheKey });
   const context = {};
@@ -80,7 +80,6 @@ async function doRender(req) {
                       client={client}
                       locale={locale}
                       versionHash={versionHash}
-                      resCookie={resCookie}
                       key={locale}
                     />
                   </StaticRouter>

--- a/src/server/routes/iframeArticleRoute.tsx
+++ b/src/server/routes/iframeArticleRoute.tsx
@@ -58,10 +58,7 @@ const disableSSR = (req: Request) => {
 async function doRenderPage(req: Request, initialProps: InitialProps) {
   const context = {};
 
-  const client = createApolloClient(
-    initialProps.locale,
-    initialProps.resCookie,
-  );
+  const client = createApolloClient(initialProps.locale);
 
   const helmetContext = {};
   const cache = createCache({ key: EmotionCacheKey });

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -154,6 +154,7 @@ app.get('/:lang?/login', async (req: Request, res: Response) => {
 app.get('/login/success', async (req: Request, res: Response) => {
   const code = typeof req.query.code === 'string' ? req.query.code : undefined;
   const state = typeof req.query.state === 'string' ? req.query.state : '/';
+  res.setHeader('Cache-Control', 'private');
   const verifier = getCookie('PKCE_code', req.headers.cookie ?? '');
   if (!code || !verifier) {
     return await sendInternalServerError(req, res);
@@ -192,6 +193,7 @@ app.get('/:lang?/logout', async (req: Request, res: Response) => {
   const feideToken = !!feideCookie ? JSON.parse(feideCookie) : undefined;
   const state = typeof req.query.state === 'string' ? req.query.state : '/';
   const redirect = constructNewPath(state, req.params.lang);
+  res.setHeader('Cache-Control', 'private');
 
   if (!feideToken?.['id_token'] || typeof state !== 'string') {
     return sendInternalServerError(req, res);
@@ -210,6 +212,7 @@ app.get('/logout/session', (req: Request, res: Response) => {
   const { basepath, basename } = getLocaleInfoFromPath(state);
   const wasPrivateRoute = privateRoutes.some(r => matchPath(r, basepath));
   const redirect = wasPrivateRoute ? constructNewPath('/', basename) : state;
+  res.setHeader('Cache-Control', 'private');
   return res.redirect(redirect);
 });
 
@@ -318,6 +321,7 @@ app.post('/lti/oauth', ndlaMiddleware, async (req: Request, res: Response) => {
   if (!body || !query.url) {
     res.send(BAD_REQUEST);
   }
+  res.setHeader('Cache-Control', 'private');
   res.send(JSON.stringify(generateOauthData(query.url, body)));
 });
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -132,6 +132,7 @@ app.get('/:lang?/login', async (req: Request, res: Response) => {
   const feideCookie = getCookie('feide_auth', req.headers.cookie ?? '') ?? '';
   const feideToken = !!feideCookie ? JSON.parse(feideCookie) : undefined;
   const state = typeof req.query.state === 'string' ? req.query.state : '';
+  res.setHeader('Cache-Control', 'private');
   const lang = getLang(
     req.params.lang,
     getCookie(STORED_LANGUAGE_COOKIE_KEY, req.headers.cookie ?? ''),

--- a/src/util/apiHelpers.ts
+++ b/src/util/apiHelpers.ts
@@ -220,28 +220,19 @@ function getCache() {
   return cache;
 }
 
-export const createApolloClient = (
-  language = 'nb',
-  cookieString?: string,
-  versionHash?: string,
-) => {
+export const createApolloClient = (language = 'nb', versionHash?: string) => {
   const cache = getCache();
-
-  const cookie = __CLIENT__ ? document.cookie : cookieString;
 
   return new ApolloClient({
     ssrMode: true,
-    link: createApolloLinks(language, cookie, versionHash),
+    link: createApolloLinks(language, versionHash),
     cache,
   });
 };
 
-export const createApolloLinks = (
-  lang: string,
-  cookieString?: string,
-  versionHash?: string,
-) => {
-  const feideCookie = getFeideCookie(cookieString ?? '');
+export const createApolloLinks = (lang: string, versionHash?: string) => {
+  const cookieString = __CLIENT__ ? document.cookie : '';
+  const feideCookie = getFeideCookie(cookieString);
   const accessTokenValid = isAccessTokenValid(feideCookie);
   const accessToken = feideCookie?.access_token;
   const versionHeader = versionHash ? { versionHash: versionHash } : {};


### PR DESCRIPTION
Dette vil kreve at vi tilpasser koden litt de stedene vi ikke kan serverside rendre feide ting (IE penere loading rundtom).

I fremtiden kan vi kanskje velge å skrive oss helt vekk fra cookies sånn at vi er tryggere på at det ikke skjer igjen, men dette vil i alle fall ikke lekke credentials.