### PR TITLE
Move new folder input outside of block wrapper to avoid overflow issues

### DIFF
--- a/src/containers/MyNdla/Folders/FolderList.tsx
+++ b/src/containers/MyNdla/Folders/FolderList.tsx
@@ -67,20 +67,20 @@ const FolderList = ({
 
   return (
     <WhileLoading isLoading={loading} fallback={<Spinner />}>
+      {isAdding && (
+        <NewFolder
+          icon={
+            <StyledFolderIcon>
+              <FolderOutlined />
+            </StyledFolderIcon>
+          }
+          parentId={folderId ?? 'folders'}
+          onClose={() => setIsAdding(false)}
+          onCreate={onFolderAdd}
+        />
+      )}
       {folders && (
         <BlockWrapper type={type}>
-          {isAdding && (
-            <NewFolder
-              icon={
-                <StyledFolderIcon>
-                  <FolderOutlined />
-                </StyledFolderIcon>
-              }
-              parentId={folderId ?? 'folders'}
-              onClose={() => setIsAdding(false)}
-              onCreate={onFolderAdd}
-            />
-          )}
           {folders.map((folder, index) => (
             <ListItem
               key={`folder-${index}`}


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3315

Kan også fikse selve input-komponenten, men med dårligere brukeropplevelse. Input er såpass liten at placeholder-teksten kuttes tidlig.