### PR TITLE
Fikse 502-feilmelding ved innlogging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,9 @@ FROM node:16.17-alpine
 RUN apk add py-pip jq && pip install awscli
 COPY run-ndla-frontend.sh /
 
-RUN npm install pm2 -g
 WORKDIR /home/app/ndla-frontend
 COPY --from=builder /home/app/ndla-frontend/build build
 
 ENV NODE_ENV=production
 
-CMD ["/run-ndla-frontend.sh", "pm2-runtime -i max build/server.js '|' bunyan"]
+CMD ["/run-ndla-frontend.sh", "node build/server.js '|' bunyan"]

--- a/src/server/helpers/openidHelper.ts
+++ b/src/server/helpers/openidHelper.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { Issuer, generators } from 'openid-client';
+import { Issuer, generators, Client } from 'openid-client';
 import { Request } from 'express';
 import config, { getEnvironmentVariabel } from '../../config';
 
@@ -26,7 +26,18 @@ const FEIDE_CLIENT_ID = handleConfigTypes(
 const FEIDE_CLIENT_SECRET = handleConfigTypes(
   getEnvironmentVariabel('FEIDE_CLIENT_SECRET'),
 );
-const getIssuer = async () => await Issuer.discover(OPENID_DOMAIN);
+
+let storedIssuer: Issuer<Client>;
+
+const getIssuer = async () => {
+  if (storedIssuer) {
+    return storedIssuer;
+  }
+  console.info('Issuer does not exist. Trying to refetch');
+  storedIssuer = await Issuer.discover(OPENID_DOMAIN);
+  console.info('Issuer refetch:', storedIssuer ? 'Success' : 'Failed');
+  return storedIssuer;
+};
 
 const getClient = (redirect_uri: string) =>
   getIssuer().then(


### PR DESCRIPTION
Ved innlogging ble det ofte logget pm2-problemer der opptil flere av instansene krasjet og ble startet på nytt. Vi vet ikke hvorfor, men det burde uansett ikke være nødvendig med både kubernetes og pm2 for lastbalansering. Har ikke klart å gjenskape noen feilmeldinger etter denne endringen ble gjort. 

Har samtidig skrevet om slik at Issuer bare hentes en gang per ndla-frontend instans. Det burde gjøre både innlogging og utlogging raskere. Det loggføres dersom Issuer ikke finnes og må hentes på nytt.

PRen er manuelt deployed til test slik at det kan verifiseres at det fungerer der.