### PR TITLE
Read ltiData from initialProps variable in window.DATA

### DIFF
--- a/src/lti/index.tsx
+++ b/src/lti/index.tsx
@@ -35,7 +35,7 @@ import { STORED_LANGUAGE_COOKIE_KEY } from '../constants';
 import { initializeI18n, isValidLocale } from '../i18n';
 
 const {
-  DATA: { initialProps, config, ltiData },
+  DATA: { initialProps, config },
 } = window;
 
 const { logglyApiKey, logEnvironment: environment, componentName } = config;
@@ -59,7 +59,7 @@ ReactDOM.render(
     <I18nextProvider i18n={i18n}>
       <ApolloProvider client={client}>
         <MissingRouterContext.Provider value={true}>
-          <LtiProvider {...initialProps} ltiData={ltiData} />
+          <LtiProvider {...initialProps} />
         </MissingRouterContext.Provider>
       </ApolloProvider>
     </I18nextProvider>


### PR DESCRIPTION
Upon inspection it seems like ltiData always is undefined (image1), this is most likely due to ltiData being inserted into the initialProps and not the `DATA` object itself (image2).

image1:
![Skärmavbild 2022-11-03 kl  13 14 28](https://user-images.githubusercontent.com/2635185/199717707-6bfc025f-36bc-4ecf-9c09-e8bacb2b3f4b.png)

image2:
![Skärmavbild 2022-11-03 kl  13 14 49](https://user-images.githubusercontent.com/2635185/199717790-78c6c1c2-c8de-4abf-96d9-722042fd05ba.png)

You need to test this yourselves but I have attached my basic form data that doesnt work for me, (I only get the modal saying "Det fungerte ikke å sette inn innholdet automatisk.")

![Skärmavbild 2022-11-03 kl  13 15 37](https://user-images.githubusercontent.com/2635185/199718277-adba03d9-bd3b-4ee2-867e-f99fff25908f.png)