### PR TITLE
Fix private route login redirection

### DIFF
--- a/src/containers/PrivateRoute/PrivateRoute.tsx
+++ b/src/containers/PrivateRoute/PrivateRoute.tsx
@@ -6,9 +6,11 @@
  *
  */
 import { ReactElement, useContext } from 'react';
-import { Navigate, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { NoSSR } from '@ndla/util';
 import { AuthContext } from '../../components/AuthenticationContext';
+import { constructNewPath, toHref } from '../../util/urlHelper';
+import { useBaseName } from '../../components/BaseNameContext';
 
 interface Props {
   element: ReactElement;
@@ -17,9 +19,14 @@ interface Props {
 const ClientPrivateRoute = ({ element }: Props) => {
   const { authenticated } = useContext(AuthContext);
   const location = useLocation();
+  const basename = useBaseName();
 
   if (!authenticated) {
-    return <Navigate to={'/login'} state={{ from: location.pathname }} />;
+    window.location.href = constructNewPath(
+      `/login?state=${toHref(location)}`,
+      basename,
+    );
+    return null;
   }
 
   return element;


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3306

Bruk av Navigate fungerer kun i kontekst av react router. Bytter det ut med en hard page reload som tar oss til det faktiske server-endepunktet, som tar seg av resten av innlogginsflyten.