### PR TITLE
Bump serialize-javascript dep to match other version in lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "react-i18next": "^11.18.6",
     "react-router-dom": "^6.3.0",
     "remarkable": "^2.0.0",
-    "serialize-javascript": "^3.1.0",
+    "serialize-javascript": "^6.0.0",
     "source-map-support": "^0.5.9"
   },
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11084,13 +11084,6 @@ sentence-case@^3.0.4:
     tslib "^2.0.3"
     upper-case-first "^2.0.2"
 
-serialize-javascript@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-3.1.0.tgz#8bf3a9170712664ef2561b44b691eafe399214ea"
-  integrity sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==
-  dependencies:
-    randombytes "^2.1.0"
-
 serialize-javascript@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz#efae5d88f45d7924141da8b5c3a7a7e663fefeb8"


### PR DESCRIPTION
Vi har allerede en indirekte dep på v6, så bumper like gjerne den direkte dep'en også.