### PR TITLE
Bruker korrekte verdier for kjerne-element

### DIFF
--- a/src/graphqlTypes.ts
+++ b/src/graphqlTypes.ts
@@ -3601,8 +3601,8 @@ export type GQLStructuredArticleDataFragment = {
   }>;
   coreElements?: Array<{
     __typename?: 'CoreElement';
-    curriculumCode?: string;
-    curriculum?: { __typename?: 'Reference'; code?: string };
+    id: string;
+    title: string;
   }>;
   metaData?: {
     __typename?: 'ArticleMetaData';

--- a/src/util/getStructuredDataFromArticle.ts
+++ b/src/util/getStructuredDataFromArticle.ts
@@ -155,9 +155,9 @@ const getAllignments = (
           '@type': 'AlignmentObject',
           alignmentType: 'assesses',
           educationalFramework: 'LK20',
-          targetDescription: '',
-          targetName: ce.curriculumCode,
-          targetUrl: `http://psi.udir.no/kl06/${ce.curriculumCode}`,
+          targetDescription: ce.title,
+          targetName: ce.id,
+          targetUrl: `http://psi.udir.no/kl06/${ce.id}`,
         };
       })
     : [];
@@ -263,10 +263,8 @@ export const structuredArticleDataFragment = gql`
       type
     }
     coreElements {
-      curriculum {
-        code
-      }
-      curriculumCode
+      id
+      title
     }
     metaData {
       images {


### PR DESCRIPTION
Fant en feil i generert json-ld for kjerneelement der verdier fra læreplanen var brukt. 

Kan testes på /subject:1:09410bfa-5b0d-470b-8727-5006e711bc1f/topic:1:25d7645a-b089-4418-b79c-59ad819aa515/resource:1:4045

