### PR TITLE
Do not use old tree structure way of showing mobile navigation

### DIFF
--- a/src/containers/MyNdla/MyNdlaMobileMenuPage.tsx
+++ b/src/containers/MyNdla/MyNdlaMobileMenuPage.tsx
@@ -21,7 +21,17 @@ const MenuPageContainer = styled.div`
   flex-direction: column;
 `;
 
-const StyledHeading = styled.h2`
+const StyledHeading = styled.h1`
+  margin: 0;
+`;
+
+const StyledNavList = styled.ul`
+  list-style: none;
+  margin: 0px;
+  padding: 0px;
+`;
+
+const StyledLi = styled.li`
   margin: 0;
 `;
 
@@ -37,17 +47,31 @@ const MyNdlaMobileMenuPage = () => {
     <MenuPageContainer>
       <HelmetWithTracker title={t('htmlTitles.myNdlaPage')} />
       <StyledHeading>{t('myNdla.myNDLA')}</StyledHeading>
-      <NavigationLink
-        id=""
-        icon={<Person />}
-        name={t('myNdla.myPage.myPage')}
-      />
-      <NavigationLink
-        id="folders"
-        icon={<FolderOutlined />}
-        name={t('myNdla.myFolders')}
-      />
-      <NavigationLink id="tags" icon={<HashTag />} name={t('myNdla.myTags')} />
+      <nav>
+        <StyledNavList>
+          <StyledLi role="none">
+            <NavigationLink
+              id=""
+              icon={<Person />}
+              name={t('myNdla.myPage.myPage')}
+            />
+          </StyledLi>
+          <StyledLi role="none">
+            <NavigationLink
+              id="folders"
+              icon={<FolderOutlined />}
+              name={t('myNdla.myFolders')}
+            />
+          </StyledLi>
+          <StyledLi role="none">
+            <NavigationLink
+              id="tags"
+              icon={<HashTag />}
+              name={t('myNdla.myTags')}
+            />
+          </StyledLi>
+        </StyledNavList>
+      </nav>
     </MenuPageContainer>
   );
 };

--- a/src/containers/MyNdla/MyNdlaMobileMenuPage.tsx
+++ b/src/containers/MyNdla/MyNdlaMobileMenuPage.tsx
@@ -6,16 +6,15 @@
  *
  */
 
-import { useContext, useMemo } from 'react';
+import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
-import { spacing } from '@ndla/core';
+import { HashTag, Person } from '@ndla/icons/common';
+import { FolderOutlined } from '@ndla/icons/contentType';
 import styled from '@emotion/styled';
 import { HelmetWithTracker } from '@ndla/tracker';
-import { IFolder } from '@ndla/types-learningpath-api';
-import { TreeStructure } from '@ndla/ui';
 import IsMobileContext from '../../IsMobileContext';
 import NotFoundPage from '../NotFoundPage/NotFoundPage';
-import { createStaticStructureElements } from '../../util/folderHelpers';
+import NavigationLink from './components/NavigationLink';
 
 const MenuPageContainer = styled.div`
   display: flex;
@@ -26,18 +25,9 @@ const StyledHeading = styled.h2`
   margin: 0;
 `;
 
-const TreeStructureWrapper = styled.div`
-  margin-left: -${spacing.normal};
-`;
-
 const MyNdlaMobileMenuPage = () => {
   const { t } = useTranslation();
   const isMobile = useContext(IsMobileContext);
-
-  const staticFolderElements: IFolder[] = useMemo(
-    () => createStaticStructureElements([], t),
-    [t],
-  );
 
   if (!isMobile) {
     return <NotFoundPage />;
@@ -47,9 +37,17 @@ const MyNdlaMobileMenuPage = () => {
     <MenuPageContainer>
       <HelmetWithTracker title={t('htmlTitles.myNdlaPage')} />
       <StyledHeading>{t('myNdla.myNDLA')}</StyledHeading>
-      <TreeStructureWrapper>
-        <TreeStructure folders={staticFolderElements} type={'navigation'} />
-      </TreeStructureWrapper>
+      <NavigationLink
+        id=""
+        icon={<Person />}
+        name={t('myNdla.myPage.myPage')}
+      />
+      <NavigationLink
+        id="folders"
+        icon={<FolderOutlined />}
+        name={t('myNdla.myFolders')}
+      />
+      <NavigationLink id="tags" icon={<HashTag />} name={t('myNdla.myTags')} />
     </MenuPageContainer>
   );
 };

--- a/src/util/folderHelpers.tsx
+++ b/src/util/folderHelpers.tsx
@@ -6,10 +6,6 @@
  *
  */
 
-import { HashTag, Person } from '@ndla/icons/common';
-import { FolderOutlined } from '@ndla/icons/contentType';
-import { IFolder } from '@ndla/types-learningpath-api';
-import { TFunction } from 'i18next';
 import uniq from 'lodash/uniq';
 import uniqBy from 'lodash/uniqBy';
 import { GQLFolder, GQLFolderResource } from '../graphqlTypes';
@@ -68,40 +64,4 @@ export const getResourcesForTag = (
       .concat(getResourcesForTag(f.subfolders, tag)),
   );
   return uniqBy(resources, r => r.id);
-};
-
-export const createStaticStructureElements = (
-  folders: GQLFolder[],
-  t: TFunction,
-) => {
-  return [
-    {
-      id: '',
-      isNavigation: true,
-      name: t('myNdla.myPage.myPage'),
-      icon: <Person />,
-      status: 'private',
-      breadcrumbs: [],
-      resources: [],
-    },
-    {
-      id: 'folders',
-      isNavigation: true,
-      icon: <FolderOutlined />,
-      name: t('myNdla.myFolders'),
-      status: 'private',
-      breadcrumbs: [],
-      resources: [],
-    },
-    ...folders,
-    {
-      id: 'tags',
-      isNavigation: true,
-      icon: <HashTag />,
-      name: t('myNdla.myTags'),
-      status: 'private',
-      breadcrumbs: [],
-      resources: [],
-    },
-  ] as IFolder[];
 };


### PR DESCRIPTION
Ser ut som at dette har blitt glemt bort ved overgang til navigasjonslenker på toppnivå. Tror vi kan gjøre dette litt mer uu-vennlig, men fint å få et review på dette med en gang. Kan testes av alle ved å spoofe user-agent som mobil i browser.