### PR TITLE
Only send GQL error messages to loggly if they are not 404s

### DIFF
--- a/src/util/apiHelpers.ts
+++ b/src/util/apiHelpers.ts
@@ -253,7 +253,10 @@ export const createApolloLinks = (lang: string, versionHash?: string) => {
     onError(({ graphQLErrors, networkError }) => {
       if (graphQLErrors) {
         graphQLErrors.forEach(({ message, locations, path, extensions }) => {
-          if (extensions?.status !== 404) {
+          if (
+            process.env.BUILD_TARGET === 'server' ||
+            extensions?.status !== 404
+          ) {
             handleError(
               `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`,
             );

--- a/src/util/apiHelpers.ts
+++ b/src/util/apiHelpers.ts
@@ -252,11 +252,13 @@ export const createApolloLinks = (lang: string, versionHash?: string) => {
   return ApolloLink.from([
     onError(({ graphQLErrors, networkError }) => {
       if (graphQLErrors) {
-        graphQLErrors.map(({ message, locations, path }) =>
-          handleError(
-            `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`,
-          ),
-        );
+        graphQLErrors.forEach(({ message, locations, path, extensions }) => {
+          if (extensions?.status !== 404) {
+            handleError(
+              `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`,
+            );
+          }
+        });
       }
       if (networkError) {
         handleError(`[Network error]: ${networkError}`, {


### PR DESCRIPTION
Filtrerer ut GQL-feilmeldinger som oppstår på grunn av 404. Logger fortsatt server-side. Disse ender ofte opp med å bare være `undefined:undefined` i loggly. 