### PR TITLE
Only load competence goals on client

### DIFF
--- a/src/components/CompetenceGoals.tsx
+++ b/src/components/CompetenceGoals.tsx
@@ -208,6 +208,7 @@ const CompetenceGoals = ({
     competenceGoalsQuery,
     {
       variables: { codes, language },
+      skip: typeof window === 'undefined',
     },
   );
 


### PR DESCRIPTION
Har inntrykk av at dette har en tendens til å være et ganske treigt kall. Vil tro at kompetansemål ikke brukes nok til at det må være klart når siden nettopp har lastet inn. Vi burde nok skrive om måten vi rendrer kompetansemål-knappen, slik at vi har mulighet til å vise frem en slags loading-state.

Dette kommer til å brekke en del cypress-tester, men kan ta den når vi er enige om dette er noe vi vil gjøre eller ei.