### PR TITLE
Reduce loading time on welcome page by using separate query for fetching subjects

### DIFF
--- a/src/containers/WelcomePage/WelcomePage.tsx
+++ b/src/containers/WelcomePage/WelcomePage.tsx
@@ -19,7 +19,7 @@ import {
 } from '@ndla/ui';
 import { spacing, utils } from '@ndla/core';
 import { useTranslation } from 'react-i18next';
-import { useLazyQuery } from '@apollo/client';
+import { gql, useLazyQuery } from '@apollo/client';
 
 import WelcomePageInfo from './WelcomePageInfo';
 import FrontpageSubjects from './FrontpageSubjects';
@@ -37,8 +37,7 @@ import BlogPosts from './BlogPosts';
 import WelcomePageSearch from './WelcomePageSearch';
 import { toSubject, toTopic } from '../../routeHelpers';
 import { LocaleType, TopicType } from '../../interfaces';
-import { subjectsQuery } from '../../queries';
-import { GQLSubjectsQuery } from '../../graphqlTypes';
+import { GQLWelcomePageQuery } from '../../graphqlTypes';
 import { multidisciplinaryTopics } from '../../data/subjects.ts';
 
 const getMultidisciplinaryTopics = (locale: LocaleType) => {
@@ -59,9 +58,24 @@ const BannerCardWrapper = styled.div`
   padding-bottom: ${spacing.large};
 `;
 
+const welcomePageSubjectsQuery = gql`
+  query welcomePage {
+    subjects(filterVisible: true) {
+      id
+      name
+      path
+      metadata {
+        customFields
+      }
+    }
+  }
+`;
+
 const WelcomePage = () => {
   const { t, i18n } = useTranslation();
-  const [fetchData, { data }] = useLazyQuery<GQLSubjectsQuery>(subjectsQuery);
+  const [fetchData, { data }] = useLazyQuery<GQLWelcomePageQuery>(
+    welcomePageSubjectsQuery,
+  );
 
   useEffect(() => {
     const getData = () => {

--- a/src/graphqlTypes.ts
+++ b/src/graphqlTypes.ts
@@ -2850,6 +2850,19 @@ export type GQLToolboxTopicWrapper_TopicFragment = {
   }>;
 } & GQLResources_TopicFragment;
 
+export type GQLWelcomePageQueryVariables = Exact<{ [key: string]: never }>;
+
+export type GQLWelcomePageQuery = {
+  __typename?: 'Query';
+  subjects?: Array<{
+    __typename?: 'Subject';
+    id: string;
+    name: string;
+    path: string;
+    metadata: { __typename?: 'TaxonomyMetadata'; customFields: any };
+  }>;
+};
+
 export type GQLIframeArticlePage_ArticleFragment = {
   __typename?: 'Article';
   created: string;


### PR DESCRIPTION
Ser ikke ut som at vi faktisk bruker `subjectpage`-dataen som hentes når vi henter fag på WelcomePage. Da kan vi like så godt la være å hente det. Per dags dato kommer dette neppe til å gi noen økning i hastighet, men det vil komme når nye skuffen kommer.