### PR TITLE
Prevent folders and resources from overflowing container

### DIFF
--- a/src/containers/MyNdla/Folders/DraggableFolder.tsx
+++ b/src/containers/MyNdla/Folders/DraggableFolder.tsx
@@ -44,6 +44,7 @@ export const DraggableListItem = styled.li<DraggableListItemProps>`
 `;
 
 export const DragWrapper = styled.div`
+  max-width: 100%;
   background-color: ${colors.white};
   flex-grow: 1;
 `;


### PR DESCRIPTION
Fixes NDLANO/Issues#3316

Fikser en feil der mapper og ressurser med lang tekst overflyter containeren sin.

Se nærmere beskrivelse i issue. Må testes lokalt