### PR TITLE
Update page title when changing learning step

### DIFF
--- a/src/containers/LearningpathPage/LearningpathPage.tsx
+++ b/src/containers/LearningpathPage/LearningpathPage.tsx
@@ -125,7 +125,7 @@ const LearningpathPage = ({ data, skipToContentId, stepId, t }: Props) => {
   return (
     <div>
       <Helmet>
-        <title>{`${getDocumentTitle(t, data)}`}</title>
+        <title>{`${getDocumentTitle(t, data, stepId)}`}</title>
         {subject?.metadata.customFields?.[
           TAXONOMY_CUSTOM_FIELD_SUBJECT_CATEGORY
         ] === constants.subjectCategories.ARCHIVE_SUBJECTS && (
@@ -204,10 +204,13 @@ const getTitle = (
   ]);
 };
 
-const getDocumentTitle = (t: TFunction, data: PropData) => {
+const getDocumentTitle = (t: TFunction, data: PropData, stepId?: string) => {
   const subject = data.subject;
   const learningpath = data.resource?.learningpath;
-  return htmlTitle(getTitle(subject, learningpath), [
+  const step = stepId
+    ? learningpath?.learningsteps?.[parseInt(stepId) - 1]
+    : undefined;
+  return htmlTitle(getTitle(subject, learningpath, step), [
     t('htmlTitles.titleTemplate'),
   ]);
 };

--- a/src/containers/LearningpathPage/LearningpathPage.tsx
+++ b/src/containers/LearningpathPage/LearningpathPage.tsx
@@ -207,9 +207,10 @@ const getTitle = (
 const getDocumentTitle = (t: TFunction, data: PropData, stepId?: string) => {
   const subject = data.subject;
   const learningpath = data.resource?.learningpath;
-  const step = stepId
-    ? learningpath?.learningsteps?.[parseInt(stepId) - 1]
-    : undefined;
+  const maybeStepId = parseInt(stepId ?? '');
+  const step = learningpath?.learningsteps.find(
+    step => step.id === maybeStepId,
+  );
   return htmlTitle(getTitle(subject, learningpath, step), [
     t('htmlTitles.titleTemplate'),
   ]);


### PR DESCRIPTION
Fixes https://ace.useit.se/ax/accessibility-issues-report.php?show=731&shared=9116698184701048&lang=nb#issue3704
Sidetittel oppdateres ikke når man bytter læringssteg. Dette fører til at fokus ikke resettes, og at sideendring ikke leses opp.