### PR TITLE
Fix ul margin overrides on mobile on allsubjects page. Larger H2 font size on mobile subject category

### DIFF
--- a/src/containers/AllSubjectsPage/AllSubjectsPage.tsx
+++ b/src/containers/AllSubjectsPage/AllSubjectsPage.tsx
@@ -80,6 +80,8 @@ const StyledColumn = styled(OneColumn)`
 
 const StyledList = styled.ul`
   list-style: none;
+  margin: 0;
+  padding: 0;
 `;
 
 const StyledHeading = styled.h1`

--- a/src/containers/AllSubjectsPage/LetterNavigation.tsx
+++ b/src/containers/AllSubjectsPage/LetterNavigation.tsx
@@ -22,6 +22,7 @@ const LetterNavigationWrapper = styled.ul`
   ${mq.range({ until: breakpoints.tabletWide })} {
     gap: ${spacing.medium};
   }
+  padding: 0;
 `;
 
 const StyledLi = styled.li`

--- a/src/containers/AllSubjectsPage/SubjectCategory.tsx
+++ b/src/containers/AllSubjectsPage/SubjectCategory.tsx
@@ -69,6 +69,9 @@ const StickyHeading = styled.div<StyledProps>`
 const StyledH2 = styled.h2`
   margin: 0;
   ${fonts.sizes('18px', '24px')};
+  ${mq.range({ until: breakpoints.tabletWide })} {
+    ${fonts.sizes('30px', '36px')};
+  }
 `;
 
 const StyledArrow = styled(Forward)`

--- a/src/containers/Masthead/drawer/BackButton.tsx
+++ b/src/containers/Masthead/drawer/BackButton.tsx
@@ -25,7 +25,7 @@ const StyledButton = styled(ButtonV2)`
   color: ${colors.brand.primary};
   justify-content: flex-start;
   padding: ${spacing.small} ${spacing.normal};
-  ${mq.range({ from: breakpoints.mobileWide })} {
+  ${mq.range({ from: breakpoints.tablet })} {
     display: none;
   }
 `;


### PR DESCRIPTION
Et par feilrettinger som er rapportert inn på alle fag-siden og ny navigasjon.

### Mobil:

Større heading
<img width="271" alt="image" src="https://user-images.githubusercontent.com/17144211/213462008-bb7e4c3b-32a1-411b-8af1-395249c90e5f.png">

--------

Mindre margin rundt bokstavfilter og subjects. Første gir plass til flere bokstaver på små skjermer.
<img width="345" alt="image" src="https://user-images.githubusercontent.com/17144211/213462214-6f47c6ea-93cf-49a6-ab89-6938cf4342cf.png">

<img width="337" alt="image" src="https://user-images.githubusercontent.com/17144211/213462365-77fe8094-4afa-4a05-8cac-16fa9a56034a.png">

-------
Breakpoint mellom mobilWide og tablet hvor denne ikke ble vist
<img width="500" alt="image" src="https://user-images.githubusercontent.com/17144211/213462593-e9fd50f3-151f-4b5f-a1fc-8693f737484d.png">
