### PR TITLE
Vise rett melding på betafaga

### DIFF
--- a/src/containers/SubjectPage/SubjectContainer.tsx
+++ b/src/containers/SubjectPage/SubjectContainer.tsx
@@ -67,7 +67,7 @@ const getSubjectCategoryMessage = (
   ) {
     return undefined;
   } else if (subjectCategory === constants.subjectCategories.BETA_SUBJECTS) {
-    return t('messageBoxInfo.subjectFuture');
+    return t('messageBoxInfo.subjectBeta');
   } else if (subjectCategory === constants.subjectCategories.ARCHIVE_SUBJECTS) {
     return t('messageBoxInfo.subjectOutdated');
   } else {


### PR DESCRIPTION
Betafaga (sjølv om dei er "kommmende") må vise meldinga for betafag (messageBoxInfo.subjectBeta) inne i faget.

Samtidig skal dei visast under fana "kommende" på /subjects.