### PR TITLE
Fix podcastpage page number translation

### DIFF
--- a/src/messages/messagesNB.ts
+++ b/src/messages/messagesNB.ts
@@ -18,7 +18,7 @@ const messages = {
     notFound: `Siden finnes ikke - ${titleTemplate}`,
     accessDenied: `Ingen tilgang - ${titleTemplate}`,
     subject: 'Fag',
-    podcast: `Podkast - Side {{pageNumber}} - ${titleTemplate}`,
+    podcast: `Podkast - Side {{page}} - ${titleTemplate}`,
     lti: `LTI - ${titleTemplate}`,
     movedResourcePage: `Siden har flyttet - ${titleTemplate}`,
     myNdlaPage: `Min NDLA - ${titleTemplate}`,

--- a/src/messages/messagesNN.ts
+++ b/src/messages/messagesNN.ts
@@ -18,7 +18,7 @@ const messages = {
     notFound: `Sida finst ikkje - ${titleTemplate}`,
     accessDenied: `Ingen tilgang - ${titleTemplate}`,
     subject: 'Fag',
-    podcast: `Podkast - Side {{pageNumber}} - ${titleTemplate}`,
+    podcast: `Podkast - Side {{page}} - ${titleTemplate}`,
     lti: `LTI - ${titleTemplate}`,
     movedResourcePage: `Sida har flytta - ${titleTemplate}`,
     myNdlaPage: `Min NDLA - ${titleTemplate}`,


### PR DESCRIPTION
Fant en liten feil på nynorsk og bokmål visning av podkast.

<img width="184" alt="image" src="https://user-images.githubusercontent.com/17144211/214308194-1512b37b-cb37-4b32-87f3-21743a6e9233.png">

Oppdaterer translations slik at disse nå bruker `page` og ikke `pageNumber`.

Hvordan teste:
Åpne /podkast
Sjekk at sidetall vises i tittel på alle språk