### PR TITLE
Do not redeclare params every time an article is rendered

### DIFF
--- a/public/static/mathjax-config.js
+++ b/public/static/mathjax-config.js
@@ -6,27 +6,28 @@
  *
  */
 
-const params = new URLSearchParams(new URL(document.currentScript.src).search);
-
 window.MathJax = {
   chtml: {
     mathmlSpacing: false,
   },
-  options:{
-      enableMenu: true,
-      menuOptions:{
-          settings:{
-              assistiveMml: false,
-              collapsible: false,
-              explorer: true
-          }
+  options: {
+    enableMenu: true,
+    menuOptions: {
+      settings: {
+        assistiveMml: false,
+        collapsible: false,
+        explorer: true,
       },
-      sre: {
-        domain: 'mathspeak',
-        style: 'sbrief',
-        speech: 'shallow',
-        locale: params.get('locale') || 'nb',
-        structure: false,
-      }
-  }
+    },
+    sre: {
+      domain: 'mathspeak',
+      style: 'sbrief',
+      speech: 'shallow',
+      locale:
+        new URLSearchParams(new URL(document.currentScript.src).search).get(
+          'locale',
+        ) || 'nb',
+      structure: false,
+    },
+  },
 };


### PR DESCRIPTION
Hvordan teste:
* Åpne en artikkel med matte, f.eks test.ndla.no/subject:1:793027a5-0b4c-42c1-a2aa-840aaf9f8083/topic:1:afe62c93-41c4-4071-82a5-b80ec4386a46/topic:1:31653ddd-cf4b-432c-8e5a-2f491fceadf4/resource:898d798d-29a8-4f3d-afd8-e0dbb8f39d32
* Trykk på "Kommunikasjon og Samhandling" i brødsmulestien. 
* Bruk tilbakeknappen på f.eks musen for å komme tilbake til artikkelen, og se at det etter hvert dukker opp en feilmelding om redeklarering av const i terminalen.

Dersom man gjennomfører de samme stegene på PR-instansen vil man ikke lenger få feilmelding. Lurer på om en del av disse dukker opp i loggly.