### PR TITLE
Include h5p scripts in head if h5p is present in article

### DIFF
--- a/src/containers/MultidisciplinarySubject/components/MultidisciplinarySubjectArticle.tsx
+++ b/src/containers/MultidisciplinarySubject/components/MultidisciplinarySubjectArticle.tsx
@@ -8,6 +8,7 @@
 
 import { gql } from '@apollo/client';
 import { useRef, MouseEvent, useMemo } from 'react';
+import { Helmet } from 'react-helmet-async';
 import {
   ArticleSideBar,
   Breadcrumblist,
@@ -30,6 +31,7 @@ import {
 import { transformArticle } from '../../../util/transformArticle';
 import config from '../../../config';
 import { useDisableConverter } from '../../../components/ArticleConverterContext';
+import { getArticleScripts } from '../../../util/getArticleScripts';
 
 const filterCodes: Record<string, 'publicHealth' | 'democracy' | 'climate'> = {
   TT1: 'publicHealth',
@@ -59,14 +61,17 @@ const MultidisciplinarySubjectArticle = ({
     scrollToRef(resourcesRef, 0);
   };
 
-  const article = useMemo(() => {
-    if (!topic.article) return undefined;
-    return transformArticle(topic.article, i18n.language, {
-      enabled: disableConverter,
-      path: `${config.ndlaFrontendDomain}/article/${topic.article.id}`,
-      subject: subject.id,
-    });
-  }, [subject.id, topic.article, i18n.language, disableConverter]);
+  const [article, scripts] = useMemo(() => {
+    if (!topic.article) return [undefined, undefined];
+    return [
+      transformArticle(topic.article, i18n.language, {
+        enabled: disableConverter,
+        path: `${config.ndlaFrontendDomain}/article/${topic.article.id}`,
+        subject: subject.id,
+      }),
+      getArticleScripts(topic.article, i18n.language),
+    ];
+  }, [topic.article, i18n.language, subject.id, disableConverter]);
 
   if (!topic.article || !article) {
     return null;
@@ -84,6 +89,17 @@ const MultidisciplinarySubjectArticle = ({
 
   return (
     <main>
+      <Helmet>
+        {scripts?.map(script => (
+          <script
+            key={script.src}
+            src={script.src}
+            type={script.type}
+            async={script.async}
+            defer={script.defer}
+          />
+        ))}
+      </Helmet>
       <Breadcrumblist hideOnNarrow items={[]} startOffset={268}>
         <ArticleSideBar
           onLinkToResourcesClick={onLinkToResourcesClick}

--- a/src/util/getArticleScripts.ts
+++ b/src/util/getArticleScripts.ts
@@ -46,5 +46,14 @@ export function getArticleScripts(
     });
   }
 
+  if (article && article.content.indexOf('data-resource="h5p"') > -1) {
+    scripts.push({
+      src: 'https://ca.h5p.ndla.no/h5p-php-library/js/h5p-resizer.js',
+      type: 'text/javascript',
+      async: false,
+      defer: true,
+    });
+  }
+
   return scripts;
 }


### PR DESCRIPTION
Hverken `ArticleContents` eller `MultidisciplinarySubjectArticle` inkluderer scripts når de rendrer en artikkel. Er dette noe vi trenger å legge til støtte for?