### PR TITLE
Fix html meta language on lti page

### DIFF
--- a/src/server/routes/ltiRoute.tsx
+++ b/src/server/routes/ltiRoute.tsx
@@ -100,7 +100,7 @@ export function ltiRoute(req: Request) {
   }
 
   const lang = getHtmlLang(req.params.lang ?? '');
-  const locale = getLocaleObject(lang);
+  const locale = getLocaleObject(lang).abbreviation;
 
   const { html, docProps, helmetContext } = doRenderPage({
     locale,


### PR DESCRIPTION
En liten mismatch mellom typing av språk mellom skriving og lesing av språk til window.DATA.

html-tag i /lti skal nå vise riktig språk og ikke object: object