### PR TITLE
Add more padding to shared folder meta page

### DIFF
--- a/src/containers/SharedFolderPage/SharedFolderPage.tsx
+++ b/src/containers/SharedFolderPage/SharedFolderPage.tsx
@@ -109,6 +109,10 @@ const DrawerButton = styled(ButtonV2)`
   }
 `;
 
+const DesktopPadding = styled.div`
+  padding-bottom: 80px;
+`;
+
 const InsideDrawerButton = styled(ButtonV2)`
   padding-left: ${spacing.large};
   justify-content: flex-start;
@@ -177,13 +181,13 @@ const SharedFolderPage = () => {
       </Helmet>
       <Sidebar>
         {!isMobile ? (
-          <>
+          <DesktopPadding>
             <InfoBox>
               <HumanMaleBoard />
               <span>{t('myNdla.sharedFolder.info')}</span>
             </InfoBox>
             <FolderNavigation folder={folder} meta={keyedData} />
-          </>
+          </DesktopPadding>
         ) : (
           <StyledDrawer
             position="bottom"

--- a/src/containers/SharedFolderPage/components/FolderMeta.tsx
+++ b/src/containers/SharedFolderPage/components/FolderMeta.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+import styled from '@emotion/styled';
 import { OneColumn } from '@ndla/ui';
 import { useTranslation } from 'react-i18next';
 import { GQLFolder } from '../../../graphqlTypes';
@@ -16,6 +17,10 @@ interface Props {
   folder?: GQLFolder;
 }
 
+const StyledOneColumn = styled(OneColumn)`
+  padding-bottom: 200px;
+`;
+
 const FolderMeta = ({ folder }: Props) => {
   const { t } = useTranslation();
   if (!folder) {
@@ -23,7 +28,7 @@ const FolderMeta = ({ folder }: Props) => {
   }
 
   return (
-    <OneColumn>
+    <StyledOneColumn>
       <h1>{folder.name}</h1>
       <FolderAndResourceCount
         selectedFolder={folder}
@@ -35,7 +40,7 @@ const FolderMeta = ({ folder }: Props) => {
       <p>{t('myNdla.sharedFolder.description.info1')}</p>
       <p>{t('myNdla.sharedFolder.description.info2')}</p>
       <p>{t('myNdla.sharedFolder.description.info3')}</p>
-    </OneColumn>
+    </StyledOneColumn>
   );
 };
 


### PR DESCRIPTION
https://trello.com/c/9ojboioa/316-test-deling-landingsside-delt-mappe-mangler-padding

David lærer har en god mappe å teste dette på. "Jonas sin mappe" legger på ekstra padding basert på sidebar, mens "Undermappe" legger på ekstra padding basert på FolderMeta.