### PR TITLE
Do not share cache between regular folders and shared folders to avoid cache mismatches

### DIFF
--- a/src/containers/MyNdla/folderMutations.ts
+++ b/src/containers/MyNdla/folderMutations.ts
@@ -77,6 +77,27 @@ export const folderFragment = gql`
   ${folderResourceFragment}
 `;
 
+export const sharedFolderFragment = gql`
+  fragment SharedFolderFragment on SharedFolder {
+    __typename
+    id
+    name
+    status
+    parentId
+    created
+    updated
+    breadcrumbs {
+      __typename
+      id
+      name
+    }
+    resources {
+      ...FolderResourceFragment
+    }
+  }
+  ${folderResourceFragment}
+`;
+
 const deleteFolderMutation = gql`
   mutation deleteFolder($id: String!) {
     deleteFolder(id: $id)
@@ -118,6 +139,40 @@ export const foldersPageQueryFragment = gql`
     }
   }
   ${folderFragment}
+`;
+
+export const sharedFoldersPageQueryFragment = gql`
+  fragment SharedFoldersPageQueryFragment on SharedFolder {
+    ...SharedFolderFragment
+    subfolders {
+      ...SharedFolderFragment
+      subfolders {
+        ...SharedFolderFragment
+        subfolders {
+          ...SharedFolderFragment
+          subfolders {
+            ...SharedFolderFragment
+            subfolders {
+              ...SharedFolderFragment
+              subfolders {
+                ...SharedFolderFragment
+                subfolders {
+                  ...SharedFolderFragment
+                  subfolders {
+                    ...SharedFolderFragment
+                    subfolders {
+                      ...SharedFolderFragment
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  ${sharedFolderFragment}
 `;
 
 export const foldersPageQuery = gql`
@@ -209,10 +264,10 @@ export const sharedFolderQuery = gql`
       includeSubfolders: $includeSubfolders
       includeResources: $includeResources
     ) {
-      ...FoldersPageQueryFragment
+      ...SharedFoldersPageQueryFragment
     }
   }
-  ${foldersPageQueryFragment}
+  ${sharedFoldersPageQueryFragment}
 `;
 
 const folderResourceMetaQuery = gql`
@@ -326,7 +381,6 @@ export const useSharedFolder = ({
     GQLSharedFolderQueryVariables
   >(sharedFolderQuery, {
     variables: { id, includeResources, includeSubfolders },
-    fetchPolicy: 'no-cache',
   });
 
   const folder = data?.sharedFolder as GQLFolder | undefined;

--- a/src/containers/MyNdla/folderMutations.ts
+++ b/src/containers/MyNdla/folderMutations.ts
@@ -326,6 +326,7 @@ export const useSharedFolder = ({
     GQLSharedFolderQueryVariables
   >(sharedFolderQuery, {
     variables: { id, includeResources, includeSubfolders },
+    fetchPolicy: 'no-cache',
   });
 
   const folder = data?.sharedFolder as GQLFolder | undefined;

--- a/src/graphqlTypes.ts
+++ b/src/graphqlTypes.ts
@@ -952,7 +952,7 @@ export type GQLQuery = {
   resourceTypes?: Maybe<Array<GQLResourceTypeDefinition>>;
   search?: Maybe<GQLSearch>;
   searchWithoutPagination?: Maybe<GQLSearchWithoutPagination>;
-  sharedFolder: GQLFolder;
+  sharedFolder: GQLSharedFolder;
   subject?: Maybe<GQLSubject>;
   subjectpage?: Maybe<GQLSubjectPage>;
   subjects?: Maybe<Array<GQLSubject>>;
@@ -1274,6 +1274,19 @@ export type GQLSearchSuggestion = {
 export type GQLSearchWithoutPagination = {
   __typename?: 'SearchWithoutPagination';
   results: Array<GQLSearchResult>;
+};
+
+export type GQLSharedFolder = {
+  __typename?: 'SharedFolder';
+  breadcrumbs: Array<GQLBreadcrumb>;
+  created: Scalars['String'];
+  id: Scalars['String'];
+  name: Scalars['String'];
+  parentId?: Maybe<Scalars['String']>;
+  resources: Array<GQLFolderResource>;
+  status: Scalars['String'];
+  subfolders: Array<GQLSharedFolder>;
+  updated: Scalars['String'];
 };
 
 export type GQLSortResult = {
@@ -2454,6 +2467,20 @@ export type GQLFolderFragmentFragment = {
   >;
 };
 
+export type GQLSharedFolderFragmentFragment = {
+  __typename: 'SharedFolder';
+  id: string;
+  name: string;
+  status: string;
+  parentId?: string;
+  created: string;
+  updated: string;
+  breadcrumbs: Array<{ __typename: 'Breadcrumb'; id: string; name: string }>;
+  resources: Array<
+    { __typename?: 'FolderResource' } & GQLFolderResourceFragmentFragment
+  >;
+};
+
 export type GQLDeleteFolderMutationVariables = Exact<{
   id: Scalars['String'];
 }>;
@@ -2511,6 +2538,55 @@ export type GQLFoldersPageQueryFragmentFragment = {
     } & GQLFolderFragmentFragment
   >;
 } & GQLFolderFragmentFragment;
+
+export type GQLSharedFoldersPageQueryFragmentFragment = {
+  __typename?: 'SharedFolder';
+  subfolders: Array<
+    {
+      __typename?: 'SharedFolder';
+      subfolders: Array<
+        {
+          __typename?: 'SharedFolder';
+          subfolders: Array<
+            {
+              __typename?: 'SharedFolder';
+              subfolders: Array<
+                {
+                  __typename?: 'SharedFolder';
+                  subfolders: Array<
+                    {
+                      __typename?: 'SharedFolder';
+                      subfolders: Array<
+                        {
+                          __typename?: 'SharedFolder';
+                          subfolders: Array<
+                            {
+                              __typename?: 'SharedFolder';
+                              subfolders: Array<
+                                {
+                                  __typename?: 'SharedFolder';
+                                  subfolders: Array<
+                                    {
+                                      __typename?: 'SharedFolder';
+                                    } & GQLSharedFolderFragmentFragment
+                                  >;
+                                } & GQLSharedFolderFragmentFragment
+                              >;
+                            } & GQLSharedFolderFragmentFragment
+                          >;
+                        } & GQLSharedFolderFragmentFragment
+                      >;
+                    } & GQLSharedFolderFragmentFragment
+                  >;
+                } & GQLSharedFolderFragmentFragment
+              >;
+            } & GQLSharedFolderFragmentFragment
+          >;
+        } & GQLSharedFolderFragmentFragment
+      >;
+    } & GQLSharedFolderFragmentFragment
+  >;
+} & GQLSharedFolderFragmentFragment;
 
 export type GQLFoldersPageQueryVariables = Exact<{ [key: string]: never }>;
 
@@ -2693,7 +2769,9 @@ export type GQLSharedFolderQueryVariables = Exact<{
 
 export type GQLSharedFolderQuery = {
   __typename?: 'Query';
-  sharedFolder: { __typename?: 'Folder' } & GQLFoldersPageQueryFragmentFragment;
+  sharedFolder: {
+    __typename?: 'SharedFolder';
+  } & GQLSharedFoldersPageQueryFragmentFragment;
 };
 
 export type GQLFolderResourceMetaQueryVariables = Exact<{

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -869,7 +869,7 @@ type Query {
     id: String!
     includeResources: Boolean
     includeSubfolders: Boolean
-  ): Folder!
+  ): SharedFolder!
   subject(id: String!): Subject
   subjectpage(id: Int!): SubjectPage
   subjects(
@@ -979,6 +979,18 @@ type SearchSuggestion {
 
 type SearchWithoutPagination {
   results: [SearchResult!]!
+}
+
+type SharedFolder {
+  breadcrumbs: [Breadcrumb!]!
+  created: String!
+  id: String!
+  name: String!
+  parentId: String
+  resources: [FolderResource!]!
+  status: String!
+  subfolders: [SharedFolder!]!
+  updated: String!
 }
 
 type SortResult {


### PR DESCRIPTION
Avhengig av https://github.com/NDLANO/graphql-api/pull/321
Fikser en feil som Angelica fant. Dette kan testes på David-brukeren under "Angelica sin hovedmappe". Feilen er som følger:
Dersom du starter på Min NDLA og går til forhåndsvis mappe gjennom knapp vil du se alle undermappene til den delte mappen, uavhengig av om de er delt eller ikke. Dersom du starter på forhåndsvis mappe og går til Min NDLA ser du bare delte mapper, og ikke private mapper.

Det finnes nok bedre løsninger som ikke krever nytt kall til serveren, men dette er bra nok.