### PR TITLE
Always use new article converter for learning path steps

### DIFF
--- a/src/components/Learningpath/LearningpathEmbed.tsx
+++ b/src/components/Learningpath/LearningpathEmbed.tsx
@@ -14,6 +14,7 @@ import { spacing } from '@ndla/core';
 import styled from '@emotion/styled';
 import { useTranslation } from 'react-i18next';
 import { Spinner } from '@ndla/icons';
+import { CreatedBy } from '@ndla/ui';
 import Article from '../Article';
 import { transformArticle } from '../../util/transformArticle';
 import { getArticleScripts } from '../../util/getArticleScripts';
@@ -33,6 +34,7 @@ import {
 import config from '../../config';
 import { useGraphQuery } from '../../util/runQueries';
 import { supportedLanguages } from '../../i18n';
+import { useDisableConverter } from '../ArticleConverterContext';
 
 interface StyledIframeContainerProps {
   oembedWidth: number;
@@ -78,7 +80,6 @@ interface Props {
   breadcrumbItems: Breadcrumb[];
   subjectId?: string;
 }
-const disableConverter = true;
 const LearningpathEmbed = ({
   learningpathStep,
   skipToContentId,
@@ -86,7 +87,8 @@ const LearningpathEmbed = ({
   subjectId,
   breadcrumbItems,
 }: Props) => {
-  const { i18n } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const disableConverter = useDisableConverter();
   const location = useLocation();
   const [taxId, articleId] =
     !learningpathStep.resource && learningpathStep.embedUrl?.url
@@ -104,29 +106,43 @@ const LearningpathEmbed = ({
     GQLLearningpathStepQueryVariables
   >(learningpathStepQuery, {
     variables: {
-      articleId: articleId!,
+      articleId:
+        articleId ?? learningpathStep.resource?.article?.id.toString()!,
       path: location.pathname,
       resourceId: taxId ?? '',
       includeResource: !!taxId,
     },
-    skip: !shouldUseConverter,
+    skip:
+      (disableConverter && !!learningpathStep.resource?.article) ||
+      (!learningpathStep.embedUrl && !learningpathStep.resource),
   });
+
+  const path = !learningpathStep.resource?.path
+    ? data?.resource?.path
+    : undefined;
+  const contentUrl = path ? `${config.ndlaFrontendDomain}${path}` : undefined;
 
   const [article, scripts] = useMemo(() => {
     const article =
-      disableConverter && !learningpathStep.resource
-        ? data?.article
-        : learningpathStep.resource?.article;
+      disableConverter && !!learningpathStep.resource?.article
+        ? learningpathStep.resource.article
+        : data?.article;
     if (!article) return [undefined, undefined];
     return [
       transformArticle(article, i18n.language, {
-        enabled: disableConverter,
+        enabled: true,
         path: `${config.ndlaFrontendDomain}/article/${article.id}`,
         subject: subjectId,
       }),
       getArticleScripts(article, i18n.language),
     ];
-  }, [data?.article, learningpathStep.resource, i18n.language, subjectId]);
+  }, [
+    data?.article,
+    disableConverter,
+    i18n.language,
+    learningpathStep.resource?.article,
+    subjectId,
+  ]);
 
   if (
     !learningpathStep ||
@@ -163,13 +179,13 @@ const LearningpathEmbed = ({
   }
 
   const learningpathStepResource =
-    disableConverter && !learningpathStep.resource
-      ? data
-      : learningpathStep.resource;
+    disableConverter && learningpathStep.resource
+      ? learningpathStep.resource
+      : data;
   const resource =
-    disableConverter && !learningpathStep.resource
-      ? data?.resource
-      : learningpathStep.resource;
+    disableConverter && learningpathStep.resource
+      ? learningpathStep.resource
+      : data?.resource;
   const stepArticle = learningpathStepResource?.article;
 
   if (!stepArticle) {
@@ -203,12 +219,22 @@ const LearningpathEmbed = ({
         </script>
       </Helmet>
       <Article
-        contentTransformed={disableConverter}
+        contentTransformed
         isPlainArticle
         id={skipToContentId}
         article={article}
         {...getArticleProps(resource, topic)}
-      />
+      >
+        {path ? (
+          <CreatedBy
+            name={t('createdBy.content')}
+            description={t('createdBy.text')}
+            url={contentUrl}
+          />
+        ) : (
+          <></>
+        )}
+      </Article>
     </>
   );
 };
@@ -245,6 +271,7 @@ LearningpathEmbed.fragments = {
     fragment LearningpathEmbed_LearningpathStep on LearningpathStep {
       resource {
         id
+        path
         article(convertEmbeds: $convertEmbeds) {
           ...LearningpathEmbed_Article
         }
@@ -277,6 +304,7 @@ const learningpathStepQuery = gql`
     }
     resource(id: $resourceId) @include(if: $includeResource) {
       id
+      path
       resourceTypes {
         id
         name

--- a/src/components/Learningpath/LearningpathEmbed.tsx
+++ b/src/components/Learningpath/LearningpathEmbed.tsx
@@ -31,7 +31,6 @@ import {
   GQLLearningpathStepQueryVariables,
 } from '../../graphqlTypes';
 import config from '../../config';
-import { useDisableConverter } from '../ArticleConverterContext';
 import { useGraphQuery } from '../../util/runQueries';
 import { supportedLanguages } from '../../i18n';
 
@@ -79,6 +78,7 @@ interface Props {
   breadcrumbItems: Breadcrumb[];
   subjectId?: string;
 }
+const disableConverter = true;
 const LearningpathEmbed = ({
   learningpathStep,
   skipToContentId,
@@ -88,7 +88,6 @@ const LearningpathEmbed = ({
 }: Props) => {
   const { i18n } = useTranslation();
   const location = useLocation();
-  const disableConverter = useDisableConverter();
   const [taxId, articleId] =
     !learningpathStep.resource && learningpathStep.embedUrl?.url
       ? getIdFromIframeUrl(learningpathStep.embedUrl.url)
@@ -127,13 +126,7 @@ const LearningpathEmbed = ({
       }),
       getArticleScripts(article, i18n.language),
     ];
-  }, [
-    data?.article,
-    learningpathStep.resource,
-    i18n.language,
-    subjectId,
-    disableConverter,
-  ]);
+  }, [data?.article, learningpathStep.resource, i18n.language, subjectId]);
 
   if (
     !learningpathStep ||

--- a/src/graphqlTypes.ts
+++ b/src/graphqlTypes.ts
@@ -1729,6 +1729,7 @@ export type GQLLearningpathEmbed_LearningpathStepFragment = {
   resource?: {
     __typename?: 'Resource';
     id: string;
+    path: string;
     article?: { __typename?: 'Article' } & GQLLearningpathEmbed_ArticleFragment;
   };
   embedUrl?: {
@@ -1757,6 +1758,7 @@ export type GQLLearningpathStepQuery = {
   resource?: {
     __typename?: 'Resource';
     id: string;
+    path: string;
     resourceTypes?: Array<{
       __typename?: 'ResourceType';
       id: string;


### PR DESCRIPTION
Fikser en feil som fører til at noen læringssteg ikke vises når ny article-converter er skrudd av.

Læringsstier begynner nå å bli ganske så rotete. Her er det jeg har prøvd å få til:
* Dersom vi har en fullverdig artikkel lagret i læringsstien og ny article-converter er _skrudd av_, hent data på nytt med article-converter skrudd på.
* Dersom vi har en fullverdig artikkel lagret i læringsstien og ny article-converter er _skrudd på_, bruk eksisterende data.
* Dersom dataen finnes som en embed, hent ut ID fra embed og hent data med ny article-converter.
* Embeds som ikke er på NDLA.no skal vises som vanlig embed.
* Ingen data skal hentes for introduksjonssteg.

For å teste dette må man kjøre lokalt med article-converter skrudd både på og av.
Kan testes med f.eks http://localhost:3000/subject:1:576cc40f-cc74-4418-9721-9b15ffd29cff/topic:2:002dbe01-f81e-4027-a7fb-b75f4f058bb4/topic:44534bdb-a221-4330-bac5-e52d44712f3c/resource:cb4f4fe6-f299-4a70-b0fa-302d4e9f202b/17085
