### PR TITLE
Fikser manglende bilde-id i kildehenvisning

### DIFF
--- a/src/components/license/ImageLicenseList.tsx
+++ b/src/components/license/ImageLicenseList.tsx
@@ -42,7 +42,7 @@ export const downloadUrl = (imageSrc: string) => {
 
 interface ImageLicenseInfoProps {
   image: GQLImageLicenseList_ImageLicenseFragment;
-  articleId?: string;
+  articleId?: number;
 }
 
 const ImageLicenseInfo = ({ image, articleId }: ImageLicenseInfoProps) => {
@@ -126,9 +126,10 @@ const ImageLicenseInfo = ({ image, articleId }: ImageLicenseInfoProps) => {
 
 interface Props {
   images: GQLImageLicenseList_ImageLicenseFragment[];
+  articleId?: number;
 }
 
-const ImageLicenseList = ({ images }: Props) => {
+const ImageLicenseList = ({ images, articleId }: Props) => {
   const { t } = useTranslation();
   return (
     <div>
@@ -136,7 +137,7 @@ const ImageLicenseList = ({ images }: Props) => {
       <p>{t('license.images.description')}</p>
       <MediaList>
         {images.map((image) => (
-          <ImageLicenseInfo image={image} key={uuid()} />
+          <ImageLicenseInfo image={image} articleId={articleId} key={uuid()} />
         ))}
       </MediaList>
     </div>

--- a/src/components/license/LicenseBox.tsx
+++ b/src/components/license/LicenseBox.tsx
@@ -37,7 +37,7 @@ function buildLicenseTabList(
   if (images.length > 0) {
     tabs.push({
       title: t('license.tabs.images'),
-      content: <ImageLicenseList images={images} />,
+      content: <ImageLicenseList images={images} articleId={article.id} />,
     });
   }
   tabs.push({


### PR DESCRIPTION
Test: Åpne en artikkel og klikk på Regler for bruk. Sjekk at kildehenvisning til bilde inneheld lenke til artikkelsida uten undefined der artikkelid skal være.