### PR TITLE
Removing gaTrackinId from ndla-frontend.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,7 +64,7 @@ class App extends Component<AppProps, State> {
     if (props.isClient && props.history) {
       configureTracker({
         listen: props.history.listen,
-        gaTrackingId: window.location.host ? config?.gaTrackingId : '',
+        gaTrackingId: undefined,
         googleTagManagerId: config?.googleTagManagerId,
       });
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -81,23 +81,6 @@ export const feideDomain = (): string => {
   }
 };
 
-const gaTrackingId = (): string => {
-  if (process.env.NODE_ENV !== 'production') {
-    return '';
-  }
-
-  switch (ndlaEnvironment) {
-    case 'local':
-      return '';
-    case 'dev':
-      return '';
-    case 'prod':
-      return 'UA-9036010-1';
-    default:
-      return 'UA-9036010-31';
-  }
-};
-
 const logglyApiKey = (): string | undefined => {
   if (process.env.NODE_ENV === 'unittest') {
     return '';
@@ -123,7 +106,6 @@ export type ConfigType = {
   ndlaFrontendDomain: string;
   learningPathDomain: string;
   googleTagManagerId: string | undefined;
-  gaTrackingId: string | undefined;
   zendeskWidgetKey: string | undefined;
   localGraphQLApi: boolean;
   showAllFrontpageSubjects: boolean;
@@ -162,7 +144,6 @@ const config: ConfigType = {
     learningPathDomain(),
   ),
   googleTagManagerId: getEnvironmentVariabel('NDLA_GOOGLE_TAG_MANAGER_ID'),
-  gaTrackingId: getEnvironmentVariabel('GA_TRACKING_ID', gaTrackingId()),
   zendeskWidgetKey: getEnvironmentVariabel('NDLA_ZENDESK_WIDGET_KEY'),
   localGraphQLApi: getEnvironmentVariabel('LOCAL_GRAPHQL_API', false),
   showAllFrontpageSubjects: true,

--- a/src/iframe/index.tsx
+++ b/src/iframe/index.tsx
@@ -62,7 +62,7 @@ configureTracker({
   listen: () => {
     return () => {};
   },
-  gaTrackingId: config.gaTrackingId,
+  gaTrackingId: undefined,
   googleTagManagerId: config.googleTagManagerId,
 });
 

--- a/src/server/helpers/Document.tsx
+++ b/src/server/helpers/Document.tsx
@@ -13,7 +13,7 @@ import ScriptLoader from '@ndla/polyfill/lib/ScriptLoader';
 import { GoogleTagMangerScript, GoogleTagMangerNoScript } from './Gtm';
 import { Matomo } from './Matomo';
 import Tagmanager from './Tagmanager';
-import config, { ConfigType } from '../../config';
+import { ConfigType } from '../../config';
 
 export interface Assets {
   css?: string;

--- a/src/server/helpers/Document.tsx
+++ b/src/server/helpers/Document.tsx
@@ -51,9 +51,6 @@ const Document = ({ helmet, assets, data, styles }: Props) => {
           name="viewport"
           content="width=device-width, initial-scale=1 viewport-fit=cover"
         />
-        {config.gaTrackingId ? (
-          <script async src="https://www.google-analytics.com/analytics.js" />
-        ) : null}
         <GoogleTagMangerScript />
         {helmet.title.toComponent()}
         {helmet.meta.toComponent()}


### PR DESCRIPTION
Dropper håndtering av gaTrackingId fordi GA3 er på vei ut.