### PR TITLE
Fixes missing sub-types in search-result

### DIFF
--- a/src/containers/SearchPage/searchHelpers.tsx
+++ b/src/containers/SearchPage/searchHelpers.tsx
@@ -175,7 +175,8 @@ const getContextLabels = (
   contexts: GQLGroupSearchResourceFragment['contexts'] | undefined,
 ) => {
   if (!contexts?.[0]) return [];
-  const types = contexts[0].resourceTypes?.slice(1)?.map((t) => t.name) ?? [];
+  const types =
+    contexts[0].resourceTypes?.slice(0, 1)?.map((t) => t.name) ?? [];
   const relevance = isSupplementary(contexts[0]) ? [contexts[0].relevance] : [];
   const labels = types.concat(relevance);
   return labels.filter((label): label is string => label !== undefined);
@@ -221,8 +222,8 @@ export const mapResourcesToItems = (
       ? resource.path
       : plainUrl(resource.path),
     labels: [
-      ...mapTraits(resource.traits, t),
       ...getContextLabels(resource.contexts),
+      ...mapTraits(resource.traits, t),
     ],
     contexts: resource.contexts?.map((context) => ({
       url: context.path,


### PR DESCRIPTION
I test så vil slice fjerne første leddet, og det er der subtypen ligger, mens den tidligere antageligvis låg sist.

Sammenlign labels fra test og fra pr-installsjon og sjekk at subtyper som "Oppgave" vises under "Oppgaver og aktiviteter"