### PR TITLE
Use a different json-ld structure to fix crash in Safari

### DIFF
--- a/src/util/__tests__/getStructuredDataFromArticle-test.js
+++ b/src/util/__tests__/getStructuredDataFromArticle-test.js
@@ -43,7 +43,7 @@ const getBaseArticle = () => ({
 test('util/getStructuredDataFromArticle article with copyright should return structured data', () => {
   const article = getBaseArticle();
 
-  const structuredData = getStructuredDataFromArticle(article, 'nb');
+  const structuredData = getStructuredDataFromArticle(article, 'nb')['@graph'];
   expect(structuredData.length).toBe(1);
   expect(structuredData[0].author[0].name).toBe(
     article.copyright.creators[0].name,
@@ -71,7 +71,7 @@ test('util/getStructuredDataFromArticle article with image should return image s
     },
   ];
 
-  const structuredData = getStructuredDataFromArticle(article, 'nb');
+  const structuredData = getStructuredDataFromArticle(article, 'nb')['@graph'];
 
   expect(structuredData.length).toBe(2);
   expect(structuredData[1].name).toBe(article.metaData.images[0].title);
@@ -89,7 +89,7 @@ test('util/getStructuredDataFromArticle article with video should return video s
     },
   ];
 
-  const structuredData = getStructuredDataFromArticle(article, 'nb');
+  const structuredData = getStructuredDataFromArticle(article, 'nb')['@graph'];
 
   expect(structuredData.length).toBe(2);
   expect(structuredData[1].name).toBe(article.metaData.brightcoves[0].title);
@@ -113,7 +113,7 @@ test('util/getStructuredDataFromArticle article with breadcrumbs should return b
     article,
     'nb',
     breadcrumbItems,
-  );
+  )['@graph'];
   expect(structuredData.length).toBe(2);
   expect(structuredData[1]['@type']).toBe('BreadcrumbList');
   expect(structuredData[1].numberOfItems).toBe(2);

--- a/src/util/getStructuredDataFromArticle.ts
+++ b/src/util/getStructuredDataFromArticle.ts
@@ -345,7 +345,10 @@ const getStructuredDataFromArticle = (
   const podcastData = createPodcastData(podcasts);
   const videoData = createVideoData(videos);
 
-  return [...structuredData, ...mediaData, ...podcastData, ...videoData];
+  return {
+    ...structuredDataBase,
+    '@graph': [...structuredData, ...mediaData, ...podcastData, ...videoData],
+  };
 };
 
 const createMediaData = (media: Mediaelements[]): StructuredData[] =>


### PR DESCRIPTION
Jeg kan ingenting om json-ld, men det krasjer visstnok i safari når man har en array med verdier. Baserte meg på https://stackoverflow.com/questions/76995140/safari-throws-when-parsing-json-ld. Ser ut som at det validerer fint