### PR TITLE
Ensure localhost usage in safari does not automatically upgrade http to https

### DIFF
--- a/src/server/contentSecurityPolicy.ts
+++ b/src/server/contentSecurityPolicy.ts
@@ -239,6 +239,7 @@ const contentSecurityPolicy = {
   directives: {
     baseUri: ["'self'", 'https://tall.ndla.no'],
     defaultSrc: ["'self'", 'blob:'],
+    upgradeInsecureRequests: process.env.NODE_ENV === 'development' ? null : [],
     scriptSrc,
     frameSrc,
     frameAncestors: null,


### PR DESCRIPTION
Det fungerte ikke å spinne opp ndla-frontend lokalt med safari. 