### PR TITLE
Prepare for ndla film refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "@fontsource/source-serif-pro": "^4.5.7",
     "@ndla/article-converter": "^3.0.4",
     "@ndla/button": "^11.0.6",
-    "@ndla/carousel": "^3.1.15",
     "@ndla/core": "^4.1.6",
     "@ndla/dropdown-menu": "^1.0.4",
     "@ndla/error-reporter": "^1.0.31",

--- a/src/containers/FilmFrontpage/MovieCategory.tsx
+++ b/src/containers/FilmFrontpage/MovieCategory.tsx
@@ -6,11 +6,10 @@
  *
  */
 
-import { CarouselAutosize } from '@ndla/carousel';
 import { FilmMovieList, MovieGrid } from '@ndla/ui';
 import { gql } from '@apollo/client';
 import { useTranslation } from 'react-i18next';
-import { breakpoints, findName } from './filmHelper';
+import { findName } from './filmHelper';
 import { GQLMovieCategory_MovieThemeFragment } from '../../graphqlTypes';
 import { MoviesByType } from './NdlaFilmFrontpage';
 import { movieFragment } from '../../queries';
@@ -35,33 +34,31 @@ const MovieCategory = ({
   loadingPlaceholderHeight,
 }: Props) => {
   const { t, i18n } = useTranslation();
+  if (resourceTypeSelected) {
+    return (
+      <MovieGrid
+        resourceTypeName={resourceTypeName}
+        fetchingMoviesByType={!!fetchingMoviesByType}
+        moviesByType={moviesByType ?? []}
+        resourceTypes={resourceTypes}
+        loadingPlaceholderHeight={loadingPlaceholderHeight}
+      />
+    );
+  }
+
   return (
-    <CarouselAutosize breakpoints={breakpoints} itemsLength={themes.length}>
-      {(autoSizedProps) =>
-        resourceTypeSelected ? (
-          <MovieGrid
-            autoSizedProps={autoSizedProps}
-            resourceTypeName={resourceTypeName}
-            fetchingMoviesByType={!!fetchingMoviesByType}
-            moviesByType={moviesByType ?? []}
-            resourceTypes={resourceTypes}
-            loadingPlaceholderHeight={loadingPlaceholderHeight}
-          />
-        ) : (
-          themes.map((theme) => (
-            <FilmMovieList
-              key={theme.name[0]?.name}
-              name={findName(theme.name ?? [], i18n.language)}
-              movies={theme.movies}
-              autoSizedProps={autoSizedProps}
-              slideForwardsLabel={t('ndlaFilm.slideForwardsLabel')}
-              slideBackwardsLabel={t('ndlaFilm.slideBackwardsLabel')}
-              resourceTypes={resourceTypes}
-            />
-          ))
-        )
-      }
-    </CarouselAutosize>
+    <>
+      {themes.map((theme) => (
+        <FilmMovieList
+          key={theme.name[0]?.name}
+          name={findName(theme.name ?? [], i18n.language)}
+          movies={theme.movies}
+          slideForwardsLabel={t('ndlaFilm.slideForwardsLabel')}
+          slideBackwardsLabel={t('ndlaFilm.slideBackwardsLabel')}
+          resourceTypes={resourceTypes}
+        />
+      ))}
+    </>
   );
 };
 

--- a/src/containers/Page/Layout.tsx
+++ b/src/containers/Page/Layout.tsx
@@ -9,7 +9,7 @@
 import { useEffect } from 'react';
 import { Content, PageContainer, useMastheadHeight } from '@ndla/ui';
 import ZendeskButton from '@ndla/zendesk';
-import { spacing } from '@ndla/core';
+import { colors, spacing } from '@ndla/core';
 import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import styled from '@emotion/styled';
@@ -33,6 +33,12 @@ const ZendeskWrapper = styled.div`
 
 const bottomPadding = css`
   padding-bottom: ${spacing.large};
+`;
+
+const StyledPageContainer = styled(PageContainer)`
+  &[data-film='true'] {
+    background-color: ${colors.ndlaFilm.filmColor};
+  }
 `;
 
 const Layout = () => {
@@ -74,7 +80,11 @@ const Layout = () => {
   );
 
   return (
-    <PageContainer backgroundWide={backgroundWide} ndlaFilm={ndlaFilm}>
+    <StyledPageContainer
+      backgroundWide={backgroundWide}
+      ndlaFilm={ndlaFilm}
+      data-film={ndlaFilm}
+    >
       <TitleAnnouncer />
       <Global
         styles={css`
@@ -108,7 +118,7 @@ const Layout = () => {
           </ZendeskButton>
         </ZendeskWrapper>
       )}
-    </PageContainer>
+    </StyledPageContainer>
   );
 };
 export default Layout;


### PR DESCRIPTION
Avhengig av https://github.com/NDLANO/frontend-packages/pull/1815
Vi er ikke lenger avhengige av at `@ndla/carousel` regner ut størrelsen komponentene i Slideshow skal ha. Vi antar istedenfor at alle barna til `Carousel` er like store.

Flytter også setting av bakgrunnsfarge på NDLA film over til Emotion. Dersom vi ikke gjør det vil hele siden være hvit inntil css-filen er lastet inn.