### PR TITLE
Show programme image regardless of breakpoint

### DIFF
--- a/src/containers/WelcomePage/Components/Programmes.tsx
+++ b/src/containers/WelcomePage/Components/Programmes.tsx
@@ -78,11 +78,8 @@ const StyledAccordionHeader = styled(AccordionHeader)`
 const ImageWrapper = styled.div`
   width: 100%;
   height: 100%;
-  display: none;
+  display: flex;
   justify-content: center;
-  ${mq.range({ until: breakpoints.tablet })} {
-    display: flex;
-  }
 `;
 
 const StyledNav = styled.nav`


### PR DESCRIPTION
Fixes https://trello.com/c/acxCFgCL/433-menybilde-vises-ikke-p%C3%A5-tablet-breakpoint-bommert
Denne komponenten vises kun dersom vi parser user-agent til å være tablet eller mobil. Da kan vi like så godt vise den uavhengig av skjermstørrelse.