### PR TITLE
Set referrer-policy to strict-origin-when-cross-origin

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -79,6 +79,9 @@ const ndlaMiddleware = [
       maxAge: 31536000,
       includeSubDomains: true,
     },
+    referrerPolicy: {
+      policy: 'strict-origin-when-cross-origin',
+    },
     contentSecurityPolicy,
     frameguard:
       process.env.NODE_ENV === 'development'


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3737
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy
Setter `referrer-policy` til `strict-origin-when-cross-origin`, som er default.