### PR TITLE
Bump helmet to v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "express": "^4.17.1",
     "graphql": "^16.6.0",
     "graphql-tag": "^2.12.6",
-    "helmet": "^6.0.1",
+    "helmet": "^7.0.0",
     "html-react-parser": "^4.2.2",
     "i18next": "^23.5.1",
     "isomorphic-unfetch": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7777,10 +7777,10 @@ header-case@^2.0.4:
     capital-case "^1.0.4"
     tslib "^2.0.3"
 
-helmet@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/helmet/-/helmet-6.0.1.tgz#52ec353638b2e87f14fe079d142b368ac11e79a4"
-  integrity sha512-8wo+VdQhTMVBMCITYZaGTbE4lvlthelPYSvoyNvk4RECTmrVjMerp9RfUOQXZWLvCcAn1pKj7ZRxK4lI9Alrcw==
+helmet@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/helmet/-/helmet-7.0.0.tgz#ac3011ba82fa2467f58075afa58a49427ba6212d"
+  integrity sha512-MsIgYmdBh460ZZ8cJC81q4XJknjG567wzEmv46WOBblDb6TUd3z8/GhgmsM9pn8g2B80tAJ4m5/d3Bi1KrSUBQ==
 
 history@^5.2.0:
   version "5.3.0"


### PR DESCRIPTION
To breaking changes:
* Krever node 16
* De skrur nå av `crossOriginEmbedderPolicy` by default. Det har vi allerede skrudd av.