### PR TITLE
Repurpose feideDomain for feide cookie

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -71,13 +71,12 @@ const learningPathDomain = (): string => {
 export const feideDomain = (): string => {
   switch (ndlaEnvironment) {
     case 'local':
-      return 'http://localhost:30017';
     case 'dev':
-      return 'http://localhost:3000';
+      return 'localhost';
     case 'prod':
-      return 'https://ndla.no';
+      return 'ndla.no';
     default:
-      return `https://${ndlaEnvironmentHostname}.ndla.no`;
+      return `${ndlaEnvironmentHostname}.ndla.no`;
   }
 };
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -49,7 +49,7 @@ import {
 } from '../statusCodes';
 import { isAccessTokenValid } from '../util/authHelpers';
 import { constructNewPath } from '../util/urlHelper';
-import { getDefaultLocale } from '../config';
+import config, { getDefaultLocale } from '../config';
 
 // @ts-ignore
 global.fetch = fetch;
@@ -181,6 +181,7 @@ app.get('/login/success', async (req: Request, res: Response) => {
     res.cookie('feide_auth', JSON.stringify(feideCookie), {
       expires: new Date(feideCookie.ndla_expires_at),
       encode: String,
+      domain: `.${config.feideDomain}`,
     });
     const languageCookie = getCookie(
       STORED_LANGUAGE_COOKIE_KEY,


### PR DESCRIPTION
Jan hos NDLA ønsker å få tak i feide_auth cookie fra ai.ndla.no for å sjekke at brukere faktisk er logga inn. 
Det såg ikkje ut som om feideDomain var i bruk så brukte den i stedet for å lage en ny. dev må ha localhost for at cookie skal settes.