### PR TITLE
Use node 18.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18.12'
+          node-version: '18.18'
       - name: 'Login to ECR repo'
         run:
           RES=$(aws sts assume-role --role-arn $CI_RELEASE_ROLE --role-session-name github-actions-ecr-login)
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18.12'
+          node-version: '18.18'
       - name: 'Login to ECR repo'
         run:
           RES=$(aws sts assume-role --role-arn $CI_RELEASE_ROLE --role-session-name github-actions-ecr-login)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ### Build stage
-FROM node:18.12-alpine as builder
+FROM node:18.18-alpine as builder
 
 ENV HOME=/home/app
 ENV APP_PATH=$HOME/ndla-frontend
@@ -23,7 +23,7 @@ COPY public $APP_PATH/public
 RUN yarn run build
 
 ### Run stage
-FROM node:18.12-alpine
+FROM node:18.18-alpine
 
 RUN apk add py-pip jq && pip install awscli
 COPY run-ndla-frontend.sh /

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "check-translations": "cross-env BABEL_ENV=test NODE_ENV=unittest jest src/messages/__tests__/"
   },
   "engines": {
-    "node": ">=18.12.0",
-    "npm": ">=5.0.0"
+    "node": ">=18.18.0",
+    "npm": ">=9.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",


### PR DESCRIPTION
Bumper node for sikkerhetsfikser. Bygger fint lokalt, og kjører via docker så ingen kompabilitetsproblemer.