### PR TITLE
Redirect if old programme path

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -61,7 +61,7 @@ export const aboutNdlaContentWidth = 1440;
 export const programmeRedirects: Record<string, string> = {
   'bygg-og-anleggsteknikk': 'bygg-og-anleggsteknikk__847f59182173',
   'elektro-og-datateknologi': 'elektro-og-datateknologi__55ad4a85ba78',
-  'frisor-blomster-interior-og-eksponeringsdesign':
+  'frisør-blomster-interior-og-eksponeringsdesign':
     'frisor-blomster-interiør-og-eksponeringsdesign__235c13273508',
   'handverk-design-og-produktutvikling':
     'håndverk-design-og-produktutvikling__28899b73c188',
@@ -73,7 +73,7 @@ export const programmeRedirects: Record<string, string> = {
   'medier-og-kommunikasjon': 'medier-og-kommunikasjon__57b0e8cd7270',
   'musikk-dans-og-drama': 'musikk-dans-og-drama__338394ba465c',
   naturbruk: 'naturbruk__d23305736cde',
-  pabygg: 'pabygg__6ea1ed34e5e7',
+  pabygg: 'påbygg__6ea1ed34e5e7',
   'restaurant-og-matfag': 'restaurant-og-matfag__0a0cd4e39743',
   'salg-service-og-reiseliv': 'salg-service-og-reiseliv__b55100bbc29e',
   studiespesialisering: 'studiespesialisering__7d5badf01ff2',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -58,6 +58,28 @@ export const AcquireLicensePage =
 export const aboutNdlaUrl = 'https://om.ndla.no/';
 export const aboutNdlaContentWidth = 1440;
 
+export const programmeRedirects: Record<string, string> = {
+  'bygg-og-anleggsteknikk': 'bygg-og-anleggsteknikk__847f59182173',
+  'elektro-og-datateknologi': 'elektro-og-datateknologi__55ad4a85ba78',
+  'frisor-blomster-interior-og-eksponeringsdesign':
+    'frisor-blomster-interiør-og-eksponeringsdesign__235c13273508',
+  'handverk-design-og-produktutvikling':
+    'håndverk-design-og-produktutvikling__28899b73c188',
+  'helse-og-oppvekstfag': 'helse-og-oppvekstfag__5ad439a5dacb',
+  idrettsfag: 'idrettsfag__dd37b407714d',
+  'informasjonsteknologi-og-medieproduksjon':
+    'informasjonsteknologi-og-medieproduksjon__23f18a24131e',
+  'kunst-design-og-arkitektur': 'kunst-design-og-arkitektur__72376dcfd25a',
+  'medier-og-kommunikasjon': 'medier-og-kommunikasjon__57b0e8cd7270',
+  'musikk-dans-og-drama': 'musikk-dans-og-drama__338394ba465c',
+  naturbruk: 'naturbruk__d23305736cde',
+  pabygg: 'pabygg__6ea1ed34e5e7',
+  'restaurant-og-matfag': 'restaurant-og-matfag__0a0cd4e39743',
+  'salg-service-og-reiseliv': 'salg-service-og-reiseliv__b55100bbc29e',
+  studiespesialisering: 'studiespesialisering__7d5badf01ff2',
+  'teknologi-og-industrifag': 'teknologi-og-industrifag__a920d0b5cbbb',
+};
+
 export interface LinkType {
   link: string;
   key: string;

--- a/src/containers/ProgrammePage/ProgrammePage.tsx
+++ b/src/containers/ProgrammePage/ProgrammePage.tsx
@@ -66,7 +66,10 @@ const ProgrammePage = () => {
     return (
       <Status code={301}>
         <RedirectExternal
-          to={toProgramme(programmeRedirects[path] || '', gradeParam)}
+          to={toProgramme(
+            encodeURIComponent(programmeRedirects[path] || ''),
+            gradeParam,
+          )}
         />
       </Status>
     );

--- a/src/containers/ProgrammePage/ProgrammePage.tsx
+++ b/src/containers/ProgrammePage/ProgrammePage.tsx
@@ -12,11 +12,13 @@ import { Spinner } from '@ndla/icons';
 import NotFoundPage from '../NotFoundPage/NotFoundPage';
 import DefaultErrorMessage from '../../components/DefaultErrorMessage';
 import { subjectInfoFragment } from '../../queries';
+import { RedirectExternal, Status } from '../../components';
 import { useGraphQuery } from '../../util/runQueries';
 import { GQLProgrammePageQuery } from '../../graphqlTypes';
-import { TypedParams, useTypedParams } from '../../routeHelpers';
+import { toProgramme, TypedParams, useTypedParams } from '../../routeHelpers';
 import ProgrammeContainer from './ProgrammeContainer';
 import { programmeFragment } from '../WelcomePage/WelcomePage';
+import { programmeRedirects } from '../../constants';
 
 interface MatchParams extends TypedParams {
   programme: string;
@@ -54,10 +56,21 @@ const programmePageQuery = gql`
 const ProgrammePage = () => {
   const { i18n } = useTranslation();
   const { programme: path, grade: gradeParam } = useTypedParams<MatchParams>();
+  const oldProgramme = programmeRedirects[path] !== undefined;
   const { loading, data } = useGraphQuery<GQLProgrammePageQuery>(
     programmePageQuery,
-    { variables: { path: path } },
+    { variables: { path: path }, skip: oldProgramme },
   );
+
+  if (oldProgramme) {
+    return (
+      <Status code={301}>
+        <RedirectExternal
+          to={toProgramme(programmeRedirects[path] || '', gradeParam)}
+        />
+      </Status>
+    );
+  }
 
   if (loading) {
     return <Spinner />;


### PR DESCRIPTION
For å hjelpe alle som har lagra gammel url kan en 301 hjelpe. 

Merk at i redirect-record peikes det på 'pabygg__6ea1ed34e5e7' mens taksonomi returnerer 'påbygg__6ea1ed34e5e7'. Dette går bra fordi det er '__6ea1ed34e5e7' som er signifikant del av urlen. ~Eg måtte ta bort øå fra redirects på grunn av at det feila. Det beste hadde vore å bruke korrekt path, så kom gjerne med forslag.~

Test:
Forsøk å gå til en gammel programfagurl som pabygg eller studiespesialiering og sjå at du redirectes til korrekt side.