### PR TITLE
Add a back button to LTI resources

### DIFF
--- a/src/components/LtiContext.tsx
+++ b/src/components/LtiContext.tsx
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { ReactNode, createContext, useContext } from 'react';
+import { LtiData } from '../interfaces';
+
+interface LtiContextType {
+  ltiData?: LtiData;
+}
+
+const LtiContext = createContext<LtiContextType | undefined>(undefined);
+
+interface Props {
+  ltiData?: LtiData;
+  children: ReactNode;
+}
+
+export const LtiContextProvider = ({ ltiData, children }: Props) => (
+  <LtiContext.Provider value={{ ltiData }}>{children}</LtiContext.Provider>
+);
+
+export const useLtiData = () => {
+  const context = useContext(LtiContext);
+  return context;
+};

--- a/src/containers/SearchPage/searchHelpers.tsx
+++ b/src/containers/SearchPage/searchHelpers.tsx
@@ -126,7 +126,7 @@ const getLtiUrl = (
   isContext: boolean,
   language?: LocaleType,
 ) => {
-  const commonPath = `article-iframe/${language ? `${language}/` : ''}`;
+  const commonPath = `/article-iframe/${language ? `${language}/` : ''}`;
   if (isContext) {
     return `${commonPath}urn:${path.split('/').pop()}/${id}`;
   }

--- a/src/iframe/IframeArticlePage.tsx
+++ b/src/iframe/IframeArticlePage.tsx
@@ -8,10 +8,13 @@
 
 import { useEffect, useMemo } from 'react';
 import { gql } from '@apollo/client';
+import { useNavigate } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
-import { OneColumn, CreatedBy, constants } from '@ndla/ui';
+import { OneColumn, CreatedBy, constants, LayoutItem } from '@ndla/ui';
 import { useTracker } from '@ndla/tracker';
 import { useTranslation } from 'react-i18next';
+import { ButtonV2 } from '@ndla/button';
+import { Back } from '@ndla/icons/common';
 import { transformArticle } from '../util/transformArticle';
 import Article from '../components/Article';
 import { getArticleScripts } from '../util/getArticleScripts';
@@ -28,6 +31,7 @@ import { LocaleType } from '../interfaces';
 import getStructuredDataFromArticle, {
   structuredArticleDataFragment,
 } from '../util/getStructuredDataFromArticle';
+import { useLtiData } from '../components/LtiContext';
 
 interface Props {
   locale?: LocaleType;
@@ -48,6 +52,8 @@ const IframeArticlePage = ({
   locale: localeProp,
 }: Props) => {
   const { trackPageView } = useTracker();
+  const navigate = useNavigate();
+  const ltiData = useLtiData();
   const { t, i18n } = useTranslation();
   const locale = localeProp ?? i18n.language;
 
@@ -117,6 +123,14 @@ const IframeArticlePage = ({
       />
       <PostResizeMessage />
       <main>
+        {!!ltiData && (
+          <LayoutItem layout="center">
+            <ButtonV2 variant="link" onClick={() => navigate(-1)}>
+              <Back />
+              {t('lti.goBack')}
+            </ButtonV2>
+          </LayoutItem>
+        )}
         <Article
           contentTransformed
           article={article}

--- a/src/lti/LtiIframePage.tsx
+++ b/src/lti/LtiIframePage.tsx
@@ -17,7 +17,7 @@ export const LtiIframePage = () => {
     <PageContainer>
       <Helmet htmlAttributes={{ lang: lang }} />
       <IframePage
-        status={'success'}
+        status="success"
         taxonomyId={taxonomyId}
         articleId={articleId}
       />

--- a/src/lti/LtiIframePage.tsx
+++ b/src/lti/LtiIframePage.tsx
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Helmet } from 'react-helmet-async';
+import { useParams } from 'react-router-dom';
+import { PageContainer } from '@ndla/ui';
+import IframePage from '../iframe/IframePage';
+
+export const LtiIframePage = () => {
+  const { taxonomyId, articleId, lang } = useParams();
+  return (
+    <PageContainer>
+      <Helmet htmlAttributes={{ lang: lang }} />
+      <IframePage
+        status={'success'}
+        taxonomyId={taxonomyId}
+        articleId={articleId}
+      />
+    </PageContainer>
+  );
+};

--- a/src/lti/LtiProvider.tsx
+++ b/src/lti/LtiProvider.tsx
@@ -23,12 +23,12 @@ import {
   RESOURCE_TYPE_LEARNING_PATH,
   STORED_LANGUAGE_COOKIE_KEY,
 } from '../constants';
-import { LocaleType, LtiData } from '../interfaces';
+import { LocaleType } from '../interfaces';
 import { GQLSearchPageQuery } from '../graphqlTypes';
 import { createApolloLinks } from '../util/apiHelpers';
+import { useLtiData } from '../components/LtiContext';
 
 interface Props {
-  ltiData?: LtiData;
   locale?: LocaleType;
 }
 
@@ -39,7 +39,8 @@ interface SearchParams {
   selectedFilters: string[];
   activeSubFilters: string[];
 }
-const LtiProvider = ({ locale: propsLocale, ltiData }: Props) => {
+const LtiProvider = ({ locale: propsLocale }: Props) => {
+  const ltiContext = useLtiData();
   const [searchParams, setSearchParams] = useState<SearchParams>({
     query: '',
     subjects: [],
@@ -108,7 +109,7 @@ const LtiProvider = ({ locale: propsLocale, ltiData }: Props) => {
         resourceTypes={data?.resourceTypes?.filter(
           (type) => type.id !== RESOURCE_TYPE_LEARNING_PATH,
         )}
-        ltiData={ltiData}
+        ltiData={ltiContext?.ltiData}
         isLti
       />
     </ErrorBoundary>

--- a/src/lti/index.tsx
+++ b/src/lti/index.tsx
@@ -7,11 +7,11 @@
  */
 
 import 'isomorphic-unfetch';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { createRoot } from 'react-dom/client';
 import { HelmetProvider } from 'react-helmet-async';
 import { I18nextProvider } from 'react-i18next';
 import ErrorReporter from '@ndla/error-reporter';
-import { MissingRouterContext } from '@ndla/safelink';
 import { i18nInstance } from '@ndla/ui';
 import { ApolloProvider } from '@apollo/client';
 import '@fontsource/source-sans-pro/index.css';
@@ -32,6 +32,8 @@ import LtiProvider from './LtiProvider';
 import '../style/index.css';
 import { STORED_LANGUAGE_COOKIE_KEY } from '../constants';
 import { initializeI18n, isValidLocale } from '../i18n';
+import { LtiContextProvider } from '../components/LtiContext';
+import { LtiIframePage } from './LtiIframePage';
 
 const {
   DATA: { initialProps, config },
@@ -56,13 +58,23 @@ const i18n = initializeI18n(i18nInstance, language);
 const root = createRoot(document.getElementById('root')!);
 root.render(
   <HelmetProvider>
-    <I18nextProvider i18n={i18n}>
-      <ApolloProvider client={client}>
-        <MissingRouterContext.Provider value={true}>
-          <LtiProvider {...initialProps} />
-        </MissingRouterContext.Provider>
-      </ApolloProvider>
-    </I18nextProvider>
+    <LtiContextProvider ltiData={initialProps.ltiData}>
+      <I18nextProvider i18n={i18n}>
+        <ApolloProvider client={client}>
+          <MemoryRouter initialEntries={['/lti']} basename="/">
+            <Routes>
+              <Route path="lti" element={<LtiProvider />} />
+              <Route path="article-iframe" element={<LtiIframePage />}>
+                <Route path="article/:articleId" element={null} />
+                <Route path=":lang/article/:articleId" element={null} />
+                <Route path=":taxonomyId/:articleId" element={null} />
+                <Route path=":lang/:taxonomyId/:articleId" element={null} />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        </ApolloProvider>
+      </I18nextProvider>
+    </LtiContextProvider>
   </HelmetProvider>,
 );
 

--- a/src/messages/messagesEN.ts
+++ b/src/messages/messagesEN.ts
@@ -71,6 +71,9 @@ const messages = {
     maxLength: 'This field can only contain {{count}} characters',
     maxLengthField: `$t(validation.fields.{{field}}) can only contain {{count}} characters`,
   },
+  lti: {
+    goBack: 'Go back to LTI search',
+  },
   resourcepageTitles: {
     video: 'Video',
     image: 'Image',

--- a/src/messages/messagesNB.ts
+++ b/src/messages/messagesNB.ts
@@ -72,6 +72,9 @@ const messages = {
     maxLengthField:
       '$t(validation.fields.{{field}}) kan maks innholde {{count}} tegn',
   },
+  lti: {
+    goBack: 'Tilbake til LTI-søk',
+  },
   resourcepageTitles: {
     video: 'Video',
     image: 'Bilde',

--- a/src/messages/messagesNN.ts
+++ b/src/messages/messagesNN.ts
@@ -72,6 +72,9 @@ const messages = {
     maxLengthField:
       '$t(validation.fields.{{field}}) kan maks innehalde {{count}} teikn',
   },
+  lti: {
+    goBack: 'Tilbake til LTI-søk',
+  },
   resourcepageTitles: {
     video: 'Video',
     image: 'Bilde',


### PR DESCRIPTION
Tenk å trenge så vanskelig kode bare for å legge til en tilbakeknapp.

LTI var ikke så veldig glad i sidenavigering, så jeg følte meg litt tvunget til å implementere client-side routing. Har testet med saLTIre og på localhost:3000. Kan eventuelt spørre Haldor om de har mulighet til å teste med en PR-instans.

Sjekk at LTI fungerer som det gjorde før når man ikke tester med LTI-integrasjon. Akkurat saLTIre er det nok greiest at vi tester sammen på jobb, da det er litt umulig å sette opp