### PR TITLE
Close menu when navigating to notifications on mobile

### DIFF
--- a/src/containers/MyNdla/components/MenuModalContent.tsx
+++ b/src/containers/MyNdla/components/MenuModalContent.tsx
@@ -170,6 +170,7 @@ const MenuModalContent = ({
         variant="ghost"
         colorTheme="lighter"
         to={toAllNotifications()}
+        onClick={() => setIsOpen(false)}
         css={buttonCss}
       >
         <BellIcon
@@ -181,7 +182,7 @@ const MenuModalContent = ({
         {t('myNdla.arena.notification.title')}
       </SafeLinkButton>
     ),
-    [notifications, t],
+    [notifications, setIsOpen, t],
   );
 
   const onCloseModal = useCallback(


### PR DESCRIPTION
Fixes https://trello.com/c/YgBxtOjy/560-meny-blir-liggende-foran-varselside-p%C3%A5-mobil