### PR TITLE
Remove redundant snackbar from topic creation

### DIFF
--- a/src/containers/MyNdla/Arena/TopicPage.tsx
+++ b/src/containers/MyNdla/Arena/TopicPage.tsx
@@ -13,7 +13,6 @@ import styled from '@emotion/styled';
 import { spacing } from '@ndla/core';
 import { Spinner } from '@ndla/icons';
 import { Heading, Text } from '@ndla/typography';
-import { useSnack } from '@ndla/ui';
 import { HelmetWithTracker, useTracker } from '@ndla/tracker';
 import { arenaCategoryQuery, useArenaCategory } from '../arenaQueries';
 import TopicCard from './components/TopicCard';
@@ -59,7 +58,6 @@ const TopicPage = () => {
   const { categoryId } = useParams();
   const { trackPageView } = useTracker();
   const navigate = useNavigate();
-  const { addSnack } = useSnack();
 
   const { loading, arenaCategory } = useArenaCategory({
     variables: { categoryId: Number(categoryId), page: 1 },
@@ -94,14 +92,10 @@ const TopicPage = () => {
             categoryId: arenaCategory?.id,
           },
         });
-        addSnack({
-          content: t('myNdla.arena.create.topic'),
-          id: 'arenaTopicCreated',
-        });
         navigate(toArenaTopic(topic.data?.newArenaTopic?.id));
       }
     },
-    [arenaCategory, createArenaTopic, navigate, addSnack, t],
+    [arenaCategory, createArenaTopic, navigate],
   );
 
   if (loading) {


### PR DESCRIPTION
Brukeren navigeres automatisk til den nyopprettede tråden, noe skjermleseren vil plukke opp
Fixes https://trello.com/c/Rg9pffyk/573-manglende-tekst-for-myndlaarenacreatetopic