### PR TITLE
Make input appear as intended by not wrapping the entire MarkdownEditor in a InputContainer

### DIFF
--- a/src/containers/MyNdla/Arena/components/ArenaForm.tsx
+++ b/src/containers/MyNdla/Arena/components/ArenaForm.tsx
@@ -180,18 +180,16 @@ const ArenaForm = ({
             >
               {t('myNdla.arena.topic.topicContent')}
             </StyledLabel>
-            <StyledInputContainer>
-              <MarkdownEditor
-                setContentWritten={(val) =>
-                  setValue('content', val, {
-                    shouldValidate: true,
-                    shouldDirty: true,
-                  })
-                }
-                initialValue={initialContent ?? ''}
-                {...field}
-              />
-            </StyledInputContainer>
+            <MarkdownEditor
+              setContentWritten={(val) =>
+                setValue('content', val, {
+                  shouldValidate: true,
+                  shouldDirty: true,
+                })
+              }
+              initialValue={initialContent ?? ''}
+              {...field}
+            />
             <FieldInfoWrapper>
               <FieldLength
                 value={field.value.length ?? 0}


### PR DESCRIPTION
Fikser en feil der bakgrunnen på inputet i lenke-editoren forsvant.