### PR TITLE
Added spacing that got lost

### DIFF
--- a/src/containers/MyNdla/components/NotificationList.tsx
+++ b/src/containers/MyNdla/components/NotificationList.tsx
@@ -149,7 +149,7 @@ const NotificationList = ({ notifications, close }: Props) => {
                   <StyledKeyboardReturn />
                   <div>
                     <StyledText textStyle="meta-text-medium" margin="none">
-                      {user.displayName}
+                      {`${user.displayName} `}
                       <Trans
                         i18nKey={'myNdla.arena.notification.commentedOn'}
                         tOptions={{ title: topicTitle }}


### PR DESCRIPTION
fikser https://trello.com/c/v6JAsPtl/611-manglende-spacing-mellom-navn-og-svarte-p%C3%A5

Mista en spacing i en merge, kunne kanskje ha brukt `&nbsp;`, men syntes det var like ryddig å bare legge på en space der.
Liker ikke tanken på å ha space i oversettelsen så dette var det jeg slo meg ned på. 