### PR TITLE
Flytter toolbar et nivå opp og ut av outlet.

### DIFF
--- a/src/containers/MyNdla/FavoriteSubjects/FavoriteSubjectsPage.tsx
+++ b/src/containers/MyNdla/FavoriteSubjects/FavoriteSubjectsPage.tsx
@@ -8,7 +8,7 @@
 
 import { useEffect, useContext, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useOutletContext } from 'react-router-dom';
 import styled from '@emotion/styled';
 import { colors, spacing } from '@ndla/core';
 import { Spinner } from '@ndla/icons';
@@ -22,6 +22,7 @@ import MyNdlaPageWrapper from '../components/MyNdlaPageWrapper';
 import MyNdlaTitle from '../components/MyNdlaTitle';
 import SettingsMenu from '../components/SettingsMenu';
 import { buttonCss, iconCss } from '../Folders/FoldersPage';
+import { OutletContext } from '../MyNdlaLayout';
 import { useSubjects } from '../subjectQueries';
 
 const StyledSubjectLink = styled(SubjectLink)`
@@ -50,19 +51,12 @@ const FavoriteSubjectsPage = () => {
   const { user, authContextLoaded } = useContext(AuthContext);
   const { trackPageView } = useTracker();
   const navigate = useNavigate();
+  const { setButtons, setMenu } = useOutletContext<OutletContext>();
 
   const favoriteSubjects = useMemo(() => {
     if (loading || !subjects || !user?.favoriteSubjects) return [];
     return subjects.filter((s) => user.favoriteSubjects.includes(s.id));
   }, [loading, user?.favoriteSubjects, subjects]);
-
-  useEffect(() => {
-    if (!authContextLoaded) return;
-    trackPageView({
-      title: t('myNdla.favoriteSubjects.title'),
-      dimensions: getAllDimensions({ user }),
-    });
-  }, [authContextLoaded, t, trackPageView, user]);
 
   const allSubjects = useMemo(
     () => (
@@ -94,18 +88,29 @@ const FavoriteSubjectsPage = () => {
     [t, navigate],
   );
 
+  useEffect(() => {
+    if (!authContextLoaded) return;
+    trackPageView({
+      title: t('myNdla.favoriteSubjects.title'),
+      dimensions: getAllDimensions({ user }),
+    });
+  }, [authContextLoaded, t, trackPageView, user]);
+
+  useEffect(() => {
+    setButtons(allSubjects);
+    setMenu(dropDown);
+  }, [allSubjects, dropDown, setButtons, setMenu]);
+
   if (loading) {
     return <Spinner />;
   }
 
   return (
-    <MyNdlaPageWrapper buttons={allSubjects} dropDownMenu={dropDown}>
+    <MyNdlaPageWrapper>
       <Wrapper>
         <HelmetWithTracker title={t('myNdla.favoriteSubjects.title')} />
         <MyNdlaTitle title={t('myNdla.favoriteSubjects.title')} />
-        {loading ? (
-          <Spinner />
-        ) : !favoriteSubjects?.length ? (
+        {!favoriteSubjects?.length ? (
           <p>{t('myNdla.favoriteSubjects.noFavorites')}</p>
         ) : (
           <StyledUl>

--- a/src/containers/MyNdla/Folders/FolderButtons.tsx
+++ b/src/containers/MyNdla/Folders/FolderButtons.tsx
@@ -16,7 +16,7 @@ import {
   useState,
 } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate, useParams, useOutletContext } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { ButtonV2 } from '@ndla/button';
 import { Cross, Copy } from '@ndla/icons/action';
 import { Share, ShareArrow } from '@ndla/icons/common';
@@ -40,20 +40,25 @@ import {
   useUpdateFolderStatusMutation,
   useDeleteFolderMutation,
 } from '../folderMutations';
-import { OutletContext } from '../MyNdlaLayout';
 
 interface FolderButtonProps {
   setFocusId: Dispatch<SetStateAction<string | undefined>>;
   selectedFolder: GQLFolder | null;
+  setIsOpen: Dispatch<SetStateAction<boolean>>;
+  setResetFocus: Dispatch<SetStateAction<boolean>>;
 }
 
-const FolderButtons = ({ setFocusId, selectedFolder }: FolderButtonProps) => {
+const FolderButtons = ({
+  setFocusId,
+  selectedFolder,
+  setIsOpen,
+  setResetFocus,
+}: FolderButtonProps) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { folderId } = useParams();
   const { addSnack } = useSnack();
   const { examLock, user } = useContext(AuthContext);
-  const { setResetFocus, setIsOpen } = useOutletContext<OutletContext>();
   const userAgent = useUserAgent();
 
   const shareRef = useRef<HTMLButtonElement | null>(null);

--- a/src/containers/MyNdla/Folders/FoldersPage.tsx
+++ b/src/containers/MyNdla/Folders/FoldersPage.tsx
@@ -9,7 +9,7 @@
 import isEqual from 'lodash/isEqual';
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
+import { useOutletContext, useParams } from 'react-router-dom';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { breakpoints, fonts, mq, spacing } from '@ndla/core';
@@ -21,6 +21,7 @@ import FolderButtons from './FolderButtons';
 import FolderList from './FolderList';
 import FoldersPageTitle from './FoldersPageTitle';
 import ListViewOptions from './ListViewOptions';
+import FolderViewType from './ListViewOptionsMobile';
 import ResourceList from './ResourceList';
 import { AuthContext } from '../../../components/AuthenticationContext';
 import { STORED_RESOURCE_VIEW_SETTINGS } from '../../../constants';
@@ -29,6 +30,7 @@ import { useGraphQuery } from '../../../util/runQueries';
 import { getAllDimensions } from '../../../util/trackingUtil';
 import MyNdlaPageWrapper from '../components/MyNdlaPageWrapper';
 import { foldersPageQuery, useFolder } from '../folderMutations';
+import { OutletContext } from '../MyNdlaLayout';
 
 const FoldersPageContainer = styled.div`
   display: flex;
@@ -119,6 +121,14 @@ const FoldersPage = () => {
   const { data, loading } =
     useGraphQuery<GQLFoldersPageQuery>(foldersPageQuery);
   const selectedFolder = useFolder(folderId);
+  const {
+    setResetFocus,
+    setIsOpen,
+    setButtons,
+    setMenu,
+    setShowButtons,
+    setListView,
+  } = useOutletContext<OutletContext>();
 
   const title = useMemo(() => {
     if (folderId) {
@@ -214,19 +224,40 @@ const FoldersPage = () => {
 
   const folderButtons = useMemo(
     () => (
-      <FolderButtons selectedFolder={selectedFolder} setFocusId={setFocusId} />
+      <FolderButtons
+        setResetFocus={setResetFocus}
+        setIsOpen={setIsOpen}
+        selectedFolder={selectedFolder}
+        setFocusId={setFocusId}
+      />
     ),
-    [selectedFolder, setFocusId],
+    [selectedFolder, setFocusId, setResetFocus, setIsOpen],
   );
 
+  const viewTypeMobile = useMemo(
+    () => <FolderViewType setViewType={setViewType} viewType={viewType} />,
+    [setViewType, viewType],
+  );
+
+  useEffect(() => {
+    setButtons(folderButtons);
+    setMenu(dropDownMenu);
+    setShowButtons(!examLock || !!selectedFolder);
+    setListView(viewTypeMobile);
+  }, [
+    folderButtons,
+    dropDownMenu,
+    examLock,
+    selectedFolder,
+    setButtons,
+    setMenu,
+    setShowButtons,
+    setListView,
+    viewTypeMobile,
+  ]);
+
   return (
-    <MyNdlaPageWrapper
-      dropDownMenu={dropDownMenu}
-      buttons={folderButtons}
-      viewType={viewType}
-      onViewTypeChange={setViewType}
-      showButtons={!examLock || !!selectedFolder}
-    >
+    <MyNdlaPageWrapper>
       <FoldersPageContainer>
         <HelmetWithTracker title={title} />
         <FoldersPageTitle

--- a/src/containers/MyNdla/Folders/ListViewOptionsMobile.tsx
+++ b/src/containers/MyNdla/Folders/ListViewOptionsMobile.tsx
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import styled from '@emotion/styled';
+import { IconButtonV2 } from '@ndla/button';
+import { spacing, colors } from '@ndla/core';
+import { FourlineHamburger, List } from '@ndla/icons/action';
+import { Text } from '@ndla/typography';
+import { ViewType } from './FoldersPage';
+
+const ViewButtonWrapper = styled.div`
+  display: flex;
+  gap: ${spacing.xxsmall};
+  padding-left: ${spacing.small};
+`;
+
+const ViewButton = styled(IconButtonV2)`
+  display: flex;
+  flex-direction: column;
+
+  background-color: transparent;
+  color: ${colors.brand.primary};
+  border-radius: ${spacing.xxsmall};
+  border-color: ${colors.brand.light};
+
+  &[aria-current='true'] {
+    background-color: ${colors.brand.lightest};
+  }
+`;
+
+interface FolderViewTypeProps {
+  viewType: ViewType;
+  setViewType: (val: ViewType) => void;
+}
+
+const FolderViewType = ({ viewType, setViewType }: FolderViewTypeProps) => {
+  const { t } = useTranslation();
+  return (
+    <ViewButtonWrapper>
+      <ViewButton
+        aria-label={t('myNdla.listView')}
+        aria-current={viewType === 'list'}
+        onClick={() => setViewType('list')}
+      >
+        <FourlineHamburger />
+        <Text textStyle="meta-text-xxsmall" margin="none">
+          {t('myNdla.simpleList')}
+        </Text>
+      </ViewButton>
+      <ViewButton
+        aria-label={t('myNdla.detailView')}
+        aria-current={viewType === 'listLarger'}
+        onClick={() => setViewType('listLarger')}
+      >
+        <List />
+        <Text textStyle="meta-text-xxsmall" margin="none">
+          {t('myNdla.detailedList')}
+        </Text>
+      </ViewButton>
+    </ViewButtonWrapper>
+  );
+};
+
+export default memo(
+  FolderViewType,
+  (prev, next) => prev.viewType !== next.viewType,
+);

--- a/src/containers/MyNdla/MyNdlaLayout.tsx
+++ b/src/containers/MyNdla/MyNdlaLayout.tsx
@@ -7,7 +7,14 @@
  */
 
 import { TFunction } from 'i18next';
-import { useMemo, useContext, useState, Dispatch, SetStateAction } from 'react';
+import {
+  useMemo,
+  useContext,
+  useState,
+  Dispatch,
+  SetStateAction,
+  ReactNode,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { Location, Outlet, useLocation } from 'react-router-dom';
 import styled from '@emotion/styled';
@@ -31,6 +38,7 @@ import { Modal, ModalTrigger } from '@ndla/modal';
 import { Text } from '@ndla/typography';
 import { MessageBox } from '@ndla/ui';
 import NavigationLink from './components/NavigationLink';
+import Toolbar from './components/Toolbar';
 import { AuthContext } from '../../components/AuthenticationContext';
 import { toHref } from '../../util/urlHelper';
 
@@ -122,6 +130,10 @@ export interface OutletContext {
   setResetFocus: Dispatch<SetStateAction<boolean>>;
   setIsOpen: Dispatch<SetStateAction<boolean>>;
   resetFocus: boolean;
+  setButtons: Dispatch<SetStateAction<ReactNode>>;
+  setMenu: Dispatch<SetStateAction<ReactNode>>;
+  setShowButtons: Dispatch<SetStateAction<boolean>>;
+  setListView: Dispatch<SetStateAction<ReactNode>>;
 }
 
 const MyNdlaLayout = () => {
@@ -130,6 +142,10 @@ const MyNdlaLayout = () => {
   const location = useLocation();
   const [isOpen, setIsOpen] = useState(false);
   const [resetFocus, setResetFocus] = useState(false);
+  const [buttons, setButtons] = useState<ReactNode | undefined>(undefined);
+  const [menu, setMenu] = useState<ReactNode | undefined>(undefined);
+  const [listView, setListView] = useState<ReactNode | undefined>(undefined);
+  const [showButtons, setShowButtons] = useState<boolean>(false);
 
   const menuLink = useMemo(
     () =>
@@ -180,7 +196,26 @@ const MyNdlaLayout = () => {
               <MessageBox>{t('myNdla.examLockInfo')}</MessageBox>
             </MessageboxWrapper>
           )}
-          <Outlet context={{ setIsOpen, resetFocus, setResetFocus }} />
+          <Toolbar
+            buttons={buttons}
+            dropDownMenu={menu}
+            showButtons={showButtons}
+            setResetFocus={setResetFocus}
+            resetFocus={resetFocus}
+            setIsOpen={setIsOpen}
+            listView={listView}
+          />
+          <Outlet
+            context={{
+              setIsOpen,
+              resetFocus,
+              setResetFocus,
+              setButtons,
+              setMenu,
+              setShowButtons,
+              setListView,
+            }}
+          />
         </StyledContent>
       </Modal>
     </StyledLayout>

--- a/src/containers/MyNdla/components/MenuModalContent.tsx
+++ b/src/containers/MyNdla/components/MenuModalContent.tsx
@@ -6,13 +6,18 @@
  *
  */
 
-import { ReactNode, useCallback, useContext, useMemo } from 'react';
+import {
+  Dispatch,
+  ReactNode,
+  SetStateAction,
+  useCallback,
+  useContext,
+  useMemo,
+} from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation, useOutletContext } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import styled from '@emotion/styled';
-import { IconButtonV2 } from '@ndla/button';
 import { spacing, colors, fonts } from '@ndla/core';
-import { FourlineHamburger, List } from '@ndla/icons/action';
 import {
   ModalBody,
   ModalHeader,
@@ -27,8 +32,8 @@ import { BellIcon } from './NotificationButton';
 import { AuthContext } from '../../../components/AuthenticationContext';
 import { toAllNotifications } from '../Arena/utils';
 import { useArenaNotifications } from '../arenaQueries';
-import { ViewType, buttonCss } from '../Folders/FoldersPage';
-import { OutletContext, menuLinks } from '../MyNdlaLayout';
+import { buttonCss } from '../Folders/FoldersPage';
+import { menuLinks } from '../MyNdlaLayout';
 
 const MenuItem = styled.li`
   list-style: none;
@@ -95,26 +100,6 @@ const StyledModalHeader = styled(ModalHeader)`
   background: ${colors.background.lightBlue};
 `;
 
-const ViewButtonWrapper = styled.div`
-  display: flex;
-  gap: ${spacing.xxsmall};
-  padding-left: ${spacing.small};
-`;
-
-const ViewButton = styled(IconButtonV2)`
-  display: flex;
-  flex-direction: column;
-
-  background-color: transparent;
-  color: ${colors.brand.primary};
-  border-radius: ${spacing.xxsmall};
-  border-color: ${colors.brand.light};
-
-  &[aria-current='true'] {
-    background-color: ${colors.brand.lightest};
-  }
-`;
-
 const CloseWrapper = styled.div`
   display: flex;
   flex-direction: column;
@@ -124,22 +109,25 @@ const CloseWrapper = styled.div`
 `;
 
 interface Props {
-  onViewTypeChange?: (val: ViewType) => void;
-  viewType?: ViewType;
+  listView?: ReactNode;
   buttons?: ReactNode;
   showButtons?: boolean;
+  setResetFocus: Dispatch<SetStateAction<boolean>>;
+  resetFocus: boolean;
+  setIsOpen: Dispatch<SetStateAction<boolean>>;
 }
 
 const MenuModalContent = ({
-  onViewTypeChange,
-  viewType,
+  listView,
   buttons,
+  setIsOpen,
+  resetFocus,
+  setResetFocus,
   showButtons = true,
 }: Props) => {
   const { t } = useTranslation();
   const location = useLocation();
-  const { setIsOpen, resetFocus, setResetFocus } =
-    useOutletContext<OutletContext>();
+
   const { user } = useContext(AuthContext);
   const { notifications } = useArenaNotifications({
     skip: !user?.arenaEnabled,
@@ -228,7 +216,7 @@ const MenuModalContent = ({
             </ToolMenu>
           </>
         )}
-        {!!viewType && (
+        {!!listView && (
           <>
             <StyledText
               data-border-top={showButtons}
@@ -237,28 +225,7 @@ const MenuModalContent = ({
             >
               {t('myNdla.selectView')}
             </StyledText>
-            <ViewButtonWrapper>
-              <ViewButton
-                aria-label={t('myNdla.listView')}
-                aria-current={viewType === 'list'}
-                onClick={() => onViewTypeChange?.('list')}
-              >
-                <FourlineHamburger />
-                <Text textStyle="meta-text-xxsmall" margin="none">
-                  {t('myNdla.simpleList')}
-                </Text>
-              </ViewButton>
-              <ViewButton
-                aria-label={t('myNdla.detailView')}
-                aria-current={viewType === 'listLarger'}
-                onClick={() => onViewTypeChange?.('listLarger')}
-              >
-                <List />
-                <Text textStyle="meta-text-xxsmall" margin="none">
-                  {t('myNdla.detailedList')}
-                </Text>
-              </ViewButton>
-            </ViewButtonWrapper>
+            {listView}
           </>
         )}
       </StyledModalBody>

--- a/src/containers/MyNdla/components/MyNdlaPageWrapper.tsx
+++ b/src/containers/MyNdla/components/MyNdlaPageWrapper.tsx
@@ -6,12 +6,10 @@
  *
  */
 
-import { HTMLAttributes, ReactNode } from 'react';
+import { HTMLAttributes } from 'react';
 import styled from '@emotion/styled';
 import { breakpoints, mq, spacing, spacingUnit } from '@ndla/core';
-import Toolbar from './Toolbar';
 import { MY_NDLA_CONTENT_WIDTH } from '../../../constants';
-import { ViewType } from '../Folders/FoldersPage';
 
 const ContentWrapper = styled.div`
   display: flex;
@@ -28,36 +26,12 @@ export const Content = styled.div`
   width: 100%;
 `;
 
-interface Props extends HTMLAttributes<HTMLDivElement> {
-  dropDownMenu?: ReactNode;
-  buttons?: ReactNode;
-  viewType?: ViewType;
-  onViewTypeChange?: (val: ViewType) => void;
-  showButtons?: boolean;
-}
+interface Props extends HTMLAttributes<HTMLDivElement> {}
 
-const MyNdlaPageWrapper = ({
-  buttons,
-  dropDownMenu,
-  onViewTypeChange,
-  viewType,
-  showButtons,
-  children,
-}: Props) => {
-  return (
-    <>
-      <Toolbar
-        buttons={buttons}
-        dropDownMenu={dropDownMenu}
-        onViewTypeChange={onViewTypeChange}
-        viewType={viewType}
-        showButtons={showButtons}
-      />
-      <ContentWrapper>
-        <Content>{children}</Content>
-      </ContentWrapper>
-    </>
-  );
-};
+const MyNdlaPageWrapper = ({ children }: Props) => (
+  <ContentWrapper>
+    <Content>{children}</Content>
+  </ContentWrapper>
+);
 
 export default MyNdlaPageWrapper;

--- a/src/containers/MyNdla/components/Toolbar.tsx
+++ b/src/containers/MyNdla/components/Toolbar.tsx
@@ -6,14 +6,13 @@
  *
  */
 
-import { ReactNode, useContext } from 'react';
+import { Dispatch, ReactNode, SetStateAction, useContext } from 'react';
 import styled from '@emotion/styled';
 import { breakpoints, colors, mq, spacing, spacingUnit } from '@ndla/core';
 import MenuModalContent from './MenuModalContent';
 import NotificationPopover from './NotificationPopover';
 import { AuthContext } from '../../../components/AuthenticationContext';
 import { MY_NDLA_CONTENT_WIDTH } from '../../../constants';
-import { ViewType } from '../Folders/FoldersPage';
 
 const ToolbarContainer = styled.div`
   display: none;
@@ -62,17 +61,21 @@ const Wrapper = styled.div`
 interface Props {
   buttons?: ReactNode;
   dropDownMenu?: ReactNode;
-  viewType?: ViewType;
-  onViewTypeChange?: (val: ViewType) => void;
+  listView?: ReactNode;
   showButtons?: boolean;
+  setResetFocus: Dispatch<SetStateAction<boolean>>;
+  resetFocus: boolean;
+  setIsOpen: Dispatch<SetStateAction<boolean>>;
 }
 
 const Toolbar = ({
   buttons,
   dropDownMenu,
-  onViewTypeChange,
-  viewType,
+  listView,
   showButtons,
+  setIsOpen,
+  resetFocus,
+  setResetFocus,
 }: Props) => {
   const { user } = useContext(AuthContext);
   return (
@@ -85,10 +88,12 @@ const Toolbar = ({
         {user?.arenaEnabled && <NotificationPopover />}
       </Wrapper>
       <MenuModalContent
-        onViewTypeChange={onViewTypeChange}
+        listView={listView}
         buttons={buttons}
-        viewType={viewType}
         showButtons={showButtons}
+        setIsOpen={setIsOpen}
+        resetFocus={resetFocus}
+        setResetFocus={setResetFocus}
       />
     </ToolbarContainer>
   );


### PR DESCRIPTION
Flytter toolbar til å ligge på layout nivå til MinNDLA. Det betyr at vi må håndtere props til toolbaren som egne states i myNdlaLayout. Jeg er ikke veldig fan av det kodemessig da jeg syntes det kan være litt rotete men det gir mening også i mitt hode. Dette gir alle pages som ligger under `/minndla` tilgang på menumodalcontent, uten at vi ikke må passe på at `MyNdlaPageWrapper` alltid wrapper sidene. 

TLDR git commit:
Moved toolbar to layout instead of in wrapper. Added states for handling the toolbar in layout. MenumodalContent is no longer dependent on myNdlaPageWrapper inside myNDLA path.
