### PR TITLE
Aria expanded toggles 

### DIFF
--- a/src/containers/Masthead/drawer/MastheadDrawer.tsx
+++ b/src/containers/Masthead/drawer/MastheadDrawer.tsx
@@ -200,7 +200,7 @@ const MastheadDrawer = ({ subject }: Props) => {
         <MainMenu>
           <HeadWrapper>
             <ModalCloseButton>
-              <ButtonV2 variant="outline" shape="pill">
+              <ButtonV2 variant="outline" shape="pill" aria-expanded="true">
                 <Cross />
                 {t('close')}
               </ButtonV2>


### PR DESCRIPTION
https://github.com/NDLANO/Issues/issues/3216

Så ut til å være på plass i arena og på min ndla. Lukkeknapp i masthead drawer burde kanskje ha, så den er lagt på. Kikka litt rundt på andre sider og undersider, og fant ingen åpenbare andre. Hvis jeg har misset noen, let me know.