### PR TITLE
PostCard width fix

### DIFF
--- a/src/containers/MyNdla/Arena/components/PostCard.tsx
+++ b/src/containers/MyNdla/Arena/components/PostCard.tsx
@@ -103,7 +103,7 @@ const TimestampText = styled(Text)`
 `;
 
 const StyledContent = styled(Text)`
-  word-wrap: break-word;
+  word-break: break-word;
 `;
 
 const Locales = {


### PR DESCRIPTION
PostCards ble for brede for skjermen, og gjorde at en måtte scrolle til side på mindre skjermer. Denne lille tweaken fikser det problemet.

Feilen kan sees på f.eks. https://test.ndla.no/minndla/arena/topic/151 ved minimere skjermbredde.