### PR TITLE
Moved link to be floating below word initially also

### DIFF
--- a/src/components/MarkdownEditor/FloatingLinkEditorPlugin.tsx
+++ b/src/components/MarkdownEditor/FloatingLinkEditorPlugin.tsx
@@ -60,6 +60,7 @@ const FloatingContainer = styled.div`
   box-shadow: ${shadows.levitate1};
   &[data-visible='true'] {
     display: flex;
+    transform: translate(0, 40px);
   }
 `;
 
@@ -320,7 +321,7 @@ const FloatingLinkEditor = ({
         <InputWrapper>
           <InputV3
             // eslint-disable-next-line jsx-a11y/no-autofocus
-            autoFocus
+            autoFocus={!linkUrl}
             name="url"
             ref={inputRef}
             data-link-input=""


### PR DESCRIPTION
Fjerner autofocus når du blar gjennom teksten. Om du beveger cursor inn i en link block så vil fokus gå direkte inn i link popover. Popoveren vil også dekke ordet.