### PR TITLE
Added error log if mock route operationname is not matching

### DIFF
--- a/e2e/apiMock.ts
+++ b/e2e/apiMock.ts
@@ -116,6 +116,8 @@ export const mockGraphqlRoute = async ({ page, operation }: GraphqlMockRoute) =>
         } catch (e) {
           route.abort();
         }
+      } else {
+        console.error("[ERROR] Operationname array does not match any results. Update mock array and rerecord test");
       }
     }
   });


### PR DESCRIPTION
Ser at vi ikke har noen god måte i vite når en GQL batch request forandrer seg som vil gjøre at testene feiler. 
Legger til en `console.error` for å gi beskjed om det skjer, vi kan også vurdere om vi skal partially matche fixtures om vi ikke får perfekt match. 