### PR TITLE
Show license for textblocks

### DIFF
--- a/src/components/license/LicenseBox.tsx
+++ b/src/components/license/LicenseBox.tsx
@@ -16,7 +16,7 @@ import H5pLicenseList from "./H5pLicenseList";
 import ImageLicenseList from "./ImageLicenseList";
 import OembedItem from "./OembedItem";
 import PodcastLicenseList from "./PodcastLicenseList";
-import TextLicenseList from "./TextLicenseList";
+import TextLicenseList, { TextItem } from "./TextLicenseList";
 import VideoLicenseList from "./VideoLicenseList";
 import { GQLLicenseBox_ArticleFragment } from "../../graphqlTypes";
 
@@ -34,7 +34,25 @@ function buildLicenseTabList(
   const oembed = article.oembed;
   const concepts = article.metaData?.concepts || [];
   const glosses = article.metaData?.glosses || [];
+  const fragments = article.metaData?.fragments || [];
   const tabs = [];
+  const articleTexts: TextItem[] = [
+    {
+      title: article.title,
+      copyright: article.copyright,
+      updated: article.published,
+      copyText,
+    },
+  ];
+  if (fragments.length > 0) {
+    fragments.forEach((fragment) => {
+      articleTexts.push({
+        title: fragment.title || "",
+        copyright: fragment.copyright,
+      });
+    });
+  }
+
   if (images.length > 0) {
     tabs.push({
       title: t("license.tabs.images"),
@@ -45,19 +63,7 @@ function buildLicenseTabList(
   tabs.push({
     title: t("license.tabs.text"),
     id: "text",
-    content: (
-      <TextLicenseList
-        printUrl={printUrl}
-        texts={[
-          {
-            title: article.title,
-            copyright: article.copyright,
-            updated: article.published,
-            copyText,
-          },
-        ]}
-      />
-    ),
+    content: <TextLicenseList printUrl={printUrl} texts={articleTexts} />,
   });
 
   if (audios.length > 0) {
@@ -165,6 +171,12 @@ LicenseBox.fragments = {
         }
         images {
           ...ImageLicenseList_ImageLicense
+        }
+        fragments {
+          title
+          copyright {
+            ...TextLicenseList_Copyright
+          }
         }
       }
     }

--- a/src/components/license/LicenseBox.tsx
+++ b/src/components/license/LicenseBox.tsx
@@ -34,7 +34,7 @@ function buildLicenseTabList(
   const oembed = article.oembed;
   const concepts = article.metaData?.concepts || [];
   const glosses = article.metaData?.glosses || [];
-  const fragments = article.metaData?.fragments || [];
+  const textblocks = article.metaData?.textblocks || [];
   const tabs = [];
   const articleTexts: TextItem[] = [
     {
@@ -44,11 +44,11 @@ function buildLicenseTabList(
       copyText,
     },
   ];
-  if (fragments.length > 0) {
-    fragments.forEach((fragment) => {
+  if (textblocks.length > 0) {
+    textblocks.forEach((textblock) => {
       articleTexts.push({
-        title: fragment.title || "",
-        copyright: fragment.copyright,
+        title: textblock.title || "",
+        copyright: textblock.copyright,
       });
     });
   }
@@ -172,7 +172,7 @@ LicenseBox.fragments = {
         images {
           ...ImageLicenseList_ImageLicense
         }
-        fragments {
+        textblocks {
           title
           copyright {
             ...TextLicenseList_Copyright

--- a/src/components/license/TextLicenseList.tsx
+++ b/src/components/license/TextLicenseList.tsx
@@ -42,11 +42,13 @@ const TextLicenseInfo = ({ text }: TextLicenseInfoProps) => {
       metaType: metaTypes.other,
     });
   }
-  items.push({
-    label: t("article.lastUpdated"),
-    description: text.updated,
-    metaType: metaTypes.other,
-  });
+  if (text.updated) {
+    items.push({
+      label: t("article.lastUpdated"),
+      description: text.updated,
+      metaType: metaTypes.other,
+    });
+  }
 
   if (text.copyright.origin) {
     items.push({
@@ -91,9 +93,9 @@ const TextLicenseInfo = ({ text }: TextLicenseInfoProps) => {
   );
 };
 
-interface TextItem {
+export interface TextItem {
   copyright: GQLTextLicenseList_CopyrightFragment;
-  updated: string;
+  updated?: string;
   copyText?: string;
   title?: string;
 }

--- a/src/graphqlTypes.ts
+++ b/src/graphqlTypes.ts
@@ -233,6 +233,7 @@ export type GQLArticleMetaData = {
   concepts?: Maybe<Array<GQLConceptLicense>>;
   copyText?: Maybe<Scalars["String"]["output"]>;
   footnotes?: Maybe<Array<GQLFootNote>>;
+  fragments?: Maybe<Array<GQLFragmentLicense>>;
   glosses?: Maybe<Array<GQLGlossLicense>>;
   h5ps?: Maybe<Array<GQLH5pLicense>>;
   images?: Maybe<Array<GQLImageLicense>>;
@@ -628,6 +629,12 @@ export type GQLFootNote = {
   year: Scalars["String"]["output"];
 };
 
+export type GQLFragmentLicense = {
+  __typename?: "FragmentLicense";
+  copyright: GQLCopyright;
+  title?: Maybe<Scalars["String"]["output"]>;
+};
+
 export type GQLFrontPageResources = {
   __typename?: "FrontPageResources";
   results: Array<GQLFrontpageSearchResult>;
@@ -639,6 +646,7 @@ export type GQLFrontpageMenu = {
   __typename?: "FrontpageMenu";
   article: GQLArticle;
   articleId: Scalars["Int"]["output"];
+  hideLevel?: Maybe<Scalars["Boolean"]["output"]>;
   menu?: Maybe<Array<Maybe<GQLFrontpageMenu>>>;
 };
 
@@ -2418,6 +2426,11 @@ export type GQLLicenseBox_ArticleFragment = {
     audios?: Array<{ __typename?: "AudioLicense" } & GQLAudioLicenseList_AudioLicenseFragment>;
     podcasts?: Array<{ __typename?: "PodcastLicense" } & GQLPodcastLicenseList_PodcastLicenseFragment>;
     images?: Array<{ __typename?: "ImageLicense" } & GQLImageLicenseList_ImageLicenseFragment>;
+    fragments?: Array<{
+      __typename?: "FragmentLicense";
+      title?: string;
+      copyright: { __typename?: "Copyright" } & GQLTextLicenseList_CopyrightFragment;
+    }>;
   };
 };
 

--- a/src/graphqlTypes.ts
+++ b/src/graphqlTypes.ts
@@ -233,11 +233,11 @@ export type GQLArticleMetaData = {
   concepts?: Maybe<Array<GQLConceptLicense>>;
   copyText?: Maybe<Scalars["String"]["output"]>;
   footnotes?: Maybe<Array<GQLFootNote>>;
-  fragments?: Maybe<Array<GQLFragmentLicense>>;
   glosses?: Maybe<Array<GQLGlossLicense>>;
   h5ps?: Maybe<Array<GQLH5pLicense>>;
   images?: Maybe<Array<GQLImageLicense>>;
   podcasts?: Maybe<Array<GQLPodcastLicense>>;
+  textblocks?: Maybe<Array<GQLTextblockLicense>>;
 };
 
 export type GQLArticleRequiredLibrary = {
@@ -627,12 +627,6 @@ export type GQLFootNote = {
   title: Scalars["String"]["output"];
   url?: Maybe<Scalars["String"]["output"]>;
   year: Scalars["String"]["output"];
-};
-
-export type GQLFragmentLicense = {
-  __typename?: "FragmentLicense";
-  copyright: GQLCopyright;
-  title?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type GQLFrontPageResources = {
@@ -2029,6 +2023,12 @@ export type GQLTaxonomyMetadata = {
   visible: Scalars["Boolean"]["output"];
 };
 
+export type GQLTextblockLicense = {
+  __typename?: "TextblockLicense";
+  copyright: GQLCopyright;
+  title?: Maybe<Scalars["String"]["output"]>;
+};
+
 export type GQLTitle = {
   __typename?: "Title";
   language: Scalars["String"]["output"];
@@ -2426,8 +2426,8 @@ export type GQLLicenseBox_ArticleFragment = {
     audios?: Array<{ __typename?: "AudioLicense" } & GQLAudioLicenseList_AudioLicenseFragment>;
     podcasts?: Array<{ __typename?: "PodcastLicense" } & GQLPodcastLicenseList_PodcastLicenseFragment>;
     images?: Array<{ __typename?: "ImageLicense" } & GQLImageLicenseList_ImageLicenseFragment>;
-    fragments?: Array<{
-      __typename?: "FragmentLicense";
+    textblocks?: Array<{
+      __typename?: "TextblockLicense";
       title?: string;
       copyright: { __typename?: "Copyright" } & GQLTextLicenseList_CopyrightFragment;
     }>;

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -196,11 +196,11 @@ type ArticleMetaData {
   concepts: [ConceptLicense!]
   copyText: String
   footnotes: [FootNote!]
-  fragments: [FragmentLicense!]
   glosses: [GlossLicense!]
   h5ps: [H5pLicense!]
   images: [ImageLicense!]
   podcasts: [PodcastLicense!]
+  textblocks: [TextblockLicense!]
 }
 
 type ArticleRequiredLibrary {
@@ -550,11 +550,6 @@ type FootNote {
   title: String!
   url: String
   year: String!
-}
-
-type FragmentLicense {
-  copyright: Copyright!
-  title: String
 }
 
 type FrontPageResources {
@@ -1454,6 +1449,11 @@ type TaxonomyMetadata {
   customFields: StringRecord!
   grepCodes: [String!]!
   visible: Boolean!
+}
+
+type TextblockLicense {
+  copyright: Copyright!
+  title: String
 }
 
 type Title {

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -196,6 +196,7 @@ type ArticleMetaData {
   concepts: [ConceptLicense!]
   copyText: String
   footnotes: [FootNote!]
+  fragments: [FragmentLicense!]
   glosses: [GlossLicense!]
   h5ps: [H5pLicense!]
   images: [ImageLicense!]
@@ -551,6 +552,11 @@ type FootNote {
   year: String!
 }
 
+type FragmentLicense {
+  copyright: Copyright!
+  title: String
+}
+
 type FrontPageResources {
   results: [FrontpageSearchResult!]!
   suggestions: [SuggestionResult!]!
@@ -560,6 +566,7 @@ type FrontPageResources {
 type FrontpageMenu {
   article: Article!
   articleId: Int!
+  hideLevel: Boolean
   menu: [FrontpageMenu]
 }
 


### PR DESCRIPTION
Depends on https://github.com/NDLANO/graphql-api/pull/437

Legger til blokk for copyrightembed under tekst i regler for bruk.

Testes på https://ndla-frontend-pr-1762.ndla.sh/article/38557