### PR TITLE
Load ErrorPage bundle instead of normal bundle when encountering an unrecoverable error

### DIFF
--- a/src/containers/ErrorPage/ErrorPage.tsx
+++ b/src/containers/ErrorPage/ErrorPage.tsx
@@ -13,8 +13,10 @@ import { ZendeskButton } from "@ndla/button";
 import { stackOrder } from "@ndla/core";
 import { MissingRouterContext } from "@ndla/safelink";
 import { Content, Masthead, Logo, PageContainer } from "@ndla/ui";
+import { Status } from "../../components";
 import DefaultErrorMessage from "../../components/DefaultErrorMessage";
 import config from "../../config";
+import { INTERNAL_SERVER_ERROR } from "../../statusCodes";
 import FeideFooter from "../Page/components/FeideFooter";
 import Footer from "../Page/components/Footer";
 
@@ -33,30 +35,32 @@ const ErrorPage = () => {
   const zendeskLanguage = i18n.language === "nb" || i18n.language === "nn" ? "no" : i18n.language;
   return (
     <MissingRouterContext.Provider value={true}>
-      <PageContainer backgroundWide={true} ndlaFilm={false}>
-        <Helmet
-          htmlAttributes={{ lang: i18n.language === "nb" ? "no" : i18n.language }}
-          title="NDLA"
-          meta={[{ name: "description", content: t("meta.description") }]}
-        />
-        <Masthead fixed>
-          <LogoWrapper>
-            <Logo to="/" locale={i18n.language} label={t("logo.altText")} />
-          </LogoWrapper>
-        </Masthead>
-        <Content>
-          <DefaultErrorMessage />
-        </Content>
-        <Footer />
-        {config.feideEnabled && <FeideFooter />}
-        {config.zendeskWidgetKey && (
-          <ZendeskWrapper>
-            <ZendeskButton locale={zendeskLanguage} widgetKey={config.zendeskWidgetKey}>
-              {t("askNDLA")}
-            </ZendeskButton>
-          </ZendeskWrapper>
-        )}
-      </PageContainer>
+      <Status code={INTERNAL_SERVER_ERROR}>
+        <PageContainer backgroundWide={true} ndlaFilm={false}>
+          <Helmet
+            htmlAttributes={{ lang: i18n.language === "nb" ? "no" : i18n.language }}
+            title="NDLA"
+            meta={[{ name: "description", content: t("meta.description") }]}
+          />
+          <Masthead fixed>
+            <LogoWrapper>
+              <Logo to="/" locale={i18n.language} label={t("logo.altText")} />
+            </LogoWrapper>
+          </Masthead>
+          <Content>
+            <DefaultErrorMessage />
+          </Content>
+          <Footer />
+          {config.feideEnabled && <FeideFooter />}
+          {config.zendeskWidgetKey && (
+            <ZendeskWrapper>
+              <ZendeskButton locale={zendeskLanguage} widgetKey={config.zendeskWidgetKey}>
+                {t("askNDLA")}
+              </ZendeskButton>
+            </ZendeskWrapper>
+          )}
+        </PageContainer>
+      </Status>
     </MissingRouterContext.Provider>
   );
 };

--- a/src/iframe/IframePage.tsx
+++ b/src/iframe/IframePage.tsx
@@ -12,27 +12,31 @@ import { useLocation } from "react-router-dom";
 import { gql } from "@apollo/client";
 import { OneColumn, ErrorMessage } from "@ndla/ui";
 import IframeArticlePage, { iframeArticlePageFragments } from "./IframeArticlePage";
+import { Status } from "../components";
 import RedirectContext from "../components/RedirectContext";
 import NotFound from "../containers/NotFoundPage/NotFoundPage";
 import { GQLIframePageQuery, GQLIframePageQueryVariables } from "../graphqlTypes";
+import { INTERNAL_SERVER_ERROR } from "../statusCodes";
 import { useGraphQuery } from "../util/runQueries";
 import "../style/index.css";
 
 const Error = () => {
   const { t } = useTranslation();
   return (
-    <OneColumn cssModifier="clear">
-      <ErrorMessage
-        illustration={{
-          url: "/static/oops.gif",
-          altText: t("errorMessage.title"),
-        }}
-        messages={{
-          title: t("errorMessage.title"),
-          description: t("errorMessage.description"),
-        }}
-      />
-    </OneColumn>
+    <Status code={INTERNAL_SERVER_ERROR}>
+      <OneColumn cssModifier="clear">
+        <ErrorMessage
+          illustration={{
+            url: "/static/oops.gif",
+            altText: t("errorMessage.title"),
+          }}
+          messages={{
+            title: t("errorMessage.title"),
+            description: t("errorMessage.description"),
+          }}
+        />
+      </OneColumn>
+    </Status>
   );
 };
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -150,7 +150,11 @@ type RouteFunc = (req: Request) => Promise<{ data: any; status: number }>;
 const handleRequest = async (req: Request, res: Response, next: NextFunction, route: RouteFunc) => {
   try {
     const { data, status } = await route(req);
-    sendResponse(res, data, status);
+    if (status === INTERNAL_SERVER_ERROR) {
+      sendInternalServerError(req, res);
+    } else {
+      sendResponse(res, data, status);
+    }
   } catch (err) {
     next(err);
   }


### PR DESCRIPTION
Dette fjerner en del hydreringsfeil som kan oppstå når man f.eks sender ugyldige parametre til GraphQL. Kan gjenskapes i prod ved å gå til ndla.no/concept/123asd. Burde vi gå for en mer robust løsning enn dette? Feil som oppstår i koden vår blir allerede catchet på toppnivå, og plukkes opp av feilhåndtering på toppnivå i express.