### PR TITLE
Move some search components over from frontend-packages.

### DIFF
--- a/e2e/specs/unauthenticated/search.spec.ts
+++ b/e2e/specs/unauthenticated/search.spec.ts
@@ -13,7 +13,7 @@ test("contains search bar", async ({ page }) => {
   await page.goto("/search/?disableSSR=true");
   await mockWaitResponse(page, "**/graphql-api/*");
 
-  const input = page.getByText("Filtrer på fagSøk");
+  const input = page.getByRole("searchbox");
   expect(input).toBeDefined();
   await expect(input).toBeVisible();
 });
@@ -21,7 +21,7 @@ test("contains search bar", async ({ page }) => {
 test("LTI contains action elements", async ({ page }) => {
   await page.goto("/lti/?disableSSR=true");
 
-  const input = page.getByText("Filtrer på fagSøk");
+  const input = page.getByRole("searchbox");
   expect(input).toBeDefined();
   await expect(input).toBeVisible();
 

--- a/src/containers/SearchPage/SearchContainer.tsx
+++ b/src/containers/SearchPage/SearchContainer.tsx
@@ -12,10 +12,11 @@ import styled from "@emotion/styled";
 import { fonts, spacing, spacingUnit } from "@ndla/core";
 import { Spinner } from "@ndla/icons";
 import { Heading } from "@ndla/typography";
-import { SearchSubjectResult, SearchFilterContent, LanguageSelector } from "@ndla/ui";
+import { SearchFilterContent, LanguageSelector } from "@ndla/ui";
 
 import SearchHeader from "./components/SearchHeader";
 import SearchResults, { ViewType } from "./components/SearchResults";
+import SearchSubjectResult from "./components/SearchSubjectResult";
 import { SearchGroup, sortResourceTypes, TypeFilter } from "./searchHelpers";
 import { SearchCompetenceGoal, SearchCoreElements, SubjectItem } from "./SearchInnerPage";
 import { groupCompetenceGoals } from "../../components/CompetenceGoals";
@@ -36,6 +37,12 @@ const StyledHeading = styled(Heading)`
 
 const CompetenceWrapper = styled.div`
   margin-bottom: ${spacing.normal};
+`;
+
+const StyledMain = styled.main`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.normal};
 `;
 
 interface Props {
@@ -103,7 +110,7 @@ const SearchContainer = ({
   }));
 
   return (
-    <main>
+    <StyledMain>
       <SearchHeader
         query={query}
         suggestion={suggestion}
@@ -166,7 +173,7 @@ const SearchContainer = ({
           )}
         </>
       )}
-    </main>
+    </StyledMain>
   );
 };
 

--- a/src/containers/SearchPage/SearchContainer.tsx
+++ b/src/containers/SearchPage/SearchContainer.tsx
@@ -22,7 +22,6 @@ import { groupCompetenceGoals } from "../../components/CompetenceGoals";
 import { CompetenceItem, CoreElementType } from "../../components/CompetenceGoalTab";
 import { GQLSubjectInfoFragment } from "../../graphqlTypes";
 import { supportedLanguages } from "../../i18n";
-import { LocaleType } from "../../interfaces";
 
 const StyledLanguageSelector = styled.div`
   width: 100%;
@@ -55,7 +54,6 @@ interface Props {
   typeFilter: Record<string, TypeFilter>;
   searchGroups: SearchGroup[];
   showAll: boolean;
-  locale: LocaleType;
   loading: boolean;
   isLti?: boolean;
 }
@@ -73,7 +71,6 @@ const SearchContainer = ({
   typeFilter,
   searchGroups,
   showAll,
-  locale,
   loading,
   isLti,
   competenceGoals,
@@ -114,7 +111,6 @@ const SearchContainer = ({
         handleSearchParamsChange={handleSearchParamsChange}
         subjects={subjects}
         noResults={sortedFilterButtonItems.length === 0}
-        locale={locale}
         competenceGoals={competenceGoals}
         coreElements={coreElements}
         loading={loading}

--- a/src/containers/SearchPage/SearchContainer.tsx
+++ b/src/containers/SearchPage/SearchContainer.tsx
@@ -156,7 +156,7 @@ const SearchContainer = ({
       {subjectItems && subjectItems?.length > 0 && !subjectIds.length && <SearchSubjectResult items={subjectItems} />}
       <div aria-live="assertive">{loading && searchGroups.length === 0 && <Spinner />}</div>
       {searchGroups && searchGroups.length > 0 && (
-        <>
+        <div>
           {sortedFilterButtonItems.length > 1 && (
             <SearchFilterContent
               items={sortedFilterButtonItems}
@@ -184,7 +184,7 @@ const SearchContainer = ({
               <LanguageSelector locales={supportedLanguages} onSelect={i18n.changeLanguage} />
             </StyledLanguageSelector>
           )}
-        </>
+        </div>
       )}
     </StyledMain>
   );

--- a/src/containers/SearchPage/SearchContainer.tsx
+++ b/src/containers/SearchPage/SearchContainer.tsx
@@ -9,14 +9,17 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "@emotion/styled";
+import { ButtonV2 } from "@ndla/button";
 import { fonts, spacing, spacingUnit } from "@ndla/core";
 import { Spinner } from "@ndla/icons";
 import { Heading } from "@ndla/typography";
-import { SearchFilterContent, LanguageSelector } from "@ndla/ui";
+import { LanguageSelector } from "@ndla/ui";
 
+import { SearchFilterContent } from "./components/SearchFilterContent";
 import SearchHeader from "./components/SearchHeader";
-import SearchResults, { ViewType } from "./components/SearchResults";
+import SearchResults from "./components/SearchResults";
 import SearchSubjectResult from "./components/SearchSubjectResult";
+import { ViewType } from "./components/searchTypes";
 import { SearchGroup, sortResourceTypes, TypeFilter } from "./searchHelpers";
 import { SearchCompetenceGoal, SearchCoreElements, SubjectItem } from "./SearchInnerPage";
 import { groupCompetenceGoals } from "../../components/CompetenceGoals";
@@ -43,6 +46,10 @@ const StyledMain = styled.main`
   display: flex;
   flex-direction: column;
   gap: ${spacing.normal};
+`;
+
+const StyledButton = styled(ButtonV2)`
+  align-self: flex-start;
 `;
 
 interface Props {
@@ -100,6 +107,8 @@ const SearchContainer = ({
   const sortedFilterButtonItems = sortResourceTypes(filterButtonItems, "value");
   const sortedSearchGroups = sortResourceTypes(searchGroups, "type");
 
+  const hasSelectedResourceType = sortedFilterButtonItems.some((item) => item.selected);
+
   const competenceGoalsMetadata = groupCompetenceGoals(competenceGoals, false, "LK06");
 
   const mappedCoreElements: CoreElementType["elements"] = coreElements.map((element) => ({
@@ -152,10 +161,14 @@ const SearchContainer = ({
             <SearchFilterContent
               items={sortedFilterButtonItems}
               onFilterToggle={handleFilterToggle}
-              onRemoveAllFilters={handleFilterReset}
               viewType={listViewType}
               onChangeViewType={(viewType) => setListViewType(viewType)}
             />
+          )}
+          {hasSelectedResourceType && (
+            <StyledButton variant="link" onClick={handleFilterReset}>
+              {t(`filterButtons.removeAllFilters`)}
+            </StyledButton>
           )}
           <SearchResults
             showAll={showAll}

--- a/src/containers/SearchPage/SearchInnerPage.tsx
+++ b/src/containers/SearchPage/SearchInnerPage.tsx
@@ -271,7 +271,6 @@ const SearchInnerPage = ({
       typeFilter={typeFilter}
       searchGroups={searchGroups}
       showAll={showAll}
-      locale={i18n.language}
       loading={loading}
       isLti={isLti}
       competenceGoals={competenceGoals}

--- a/src/containers/SearchPage/components/SearchFilterContent.tsx
+++ b/src/containers/SearchPage/components/SearchFilterContent.tsx
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2024-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { useTranslation } from "react-i18next";
+import styled from "@emotion/styled";
+import { ButtonV2, IconButtonV2 } from "@ndla/button";
+import { breakpoints, mq, spacing } from "@ndla/core";
+import { Cross } from "@ndla/icons/action";
+import { Grid } from "@ndla/icons/common";
+import { ListCircle } from "@ndla/icons/editor";
+import { ViewType } from "./searchTypes";
+
+const Container = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  gap: ${spacing.xxsmall};
+  ${mq.range({ until: breakpoints.tablet })} {
+    display: none;
+  }
+`;
+
+const ItemWrapper = styled.div`
+  display: flex;
+  gap: ${spacing.xsmall};
+  flex-wrap: wrap;
+`;
+
+interface Item {
+  label: string;
+  value: string;
+  selected?: boolean;
+}
+
+interface Props {
+  items: Item[];
+  viewType: ViewType;
+  onChangeViewType: (viewType: ViewType) => void;
+  onFilterToggle: (value: string) => void;
+}
+
+export const SearchFilterContent = ({ items, viewType, onChangeViewType, onFilterToggle }: Props) => {
+  const { t } = useTranslation();
+  return (
+    <Container>
+      <ItemWrapper>
+        {items.map((item) => (
+          <ButtonV2
+            key={item.value}
+            shape="pill"
+            onClick={() => onFilterToggle(item.value)}
+            colorTheme={item.selected ? "primary" : "greyLighter"}
+          >
+            {item.label}
+            {item.selected && <Cross />}
+          </ButtonV2>
+        ))}
+      </ItemWrapper>
+      <ButtonWrapper>
+        <IconButtonV2
+          variant={viewType === "grid" ? "solid" : "ghost"}
+          onClick={() => onChangeViewType("grid")}
+          colorTheme="greyLighter"
+          aria-label={t("searchPage.resultType.gridView")}
+          title={t("searchPage.resultType.gridView")}
+        >
+          <Grid />
+        </IconButtonV2>
+        <IconButtonV2
+          variant={viewType === "list" ? "solid" : "ghost"}
+          onClick={() => onChangeViewType("list")}
+          colorTheme="greyLighter"
+          aria-label={t("searchPage.resultType.listView")}
+          title={t("searchPage.resultType.listView")}
+        >
+          <ListCircle />
+        </IconButtonV2>
+      </ButtonWrapper>
+    </Container>
+  );
+};

--- a/src/containers/SearchPage/components/SearchHeader.tsx
+++ b/src/containers/SearchPage/components/SearchHeader.tsx
@@ -6,11 +6,18 @@
  *
  */
 
-import { useState, useEffect, useMemo, FormEvent } from "react";
+import { useState, useEffect, useMemo, FormEvent, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import { SearchHeader as SearchHeaderUI } from "@ndla/ui";
+import styled from "@emotion/styled";
+import { ButtonV2, IconButtonV2 } from "@ndla/button";
+import { breakpoints, mq, spacing } from "@ndla/core";
+import { InputContainer, InputV3 } from "@ndla/forms";
+import { Cross, Plus } from "@ndla/icons/action";
+import { Search } from "@ndla/icons/common";
+import { Modal, ModalBody, ModalCloseButton, ModalContent, ModalHeader, ModalTitle, ModalTrigger } from "@ndla/modal";
+import { Text } from "@ndla/typography";
+import SubjectFilter from "./SubjectFilter";
 import { GQLCompetenceGoal, GQLCoreElement, GQLSubjectInfoFragment } from "../../../graphqlTypes";
-import { LocaleType } from "../../../interfaces";
 import { getSubjectsCategories } from "../../../util/subjects";
 
 interface Props {
@@ -22,15 +29,43 @@ interface Props {
   competenceGoals: GQLCompetenceGoal[];
   coreElements: GQLCoreElement[];
   noResults: boolean;
-  locale: LocaleType;
   loading: boolean;
 }
 
-interface ActiveFilter {
-  value: string;
-  name: string;
-  title: string;
-}
+const MAX_SHOW_SUBJECT_FILTERS = 2;
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.small};
+  margin-top: ${spacing.normal};
+  ${mq.range({ from: breakpoints.tablet })} {
+    margin-top: ${spacing.large};
+  }
+`;
+
+const StyledInputContainer = styled(InputContainer)`
+  background: transparent;
+`;
+
+const FiltersWrapper = styled.div`
+  display: flex;
+  gap: ${spacing.small};
+  flex-wrap: wrap;
+`;
+
+const StyledModalBody = styled(ModalBody)`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const StyledModalHeader = styled(ModalHeader)`
+  width: 100%;
+  max-width: 1040px;
+  padding: 0px;
+`;
+
 const SearchHeader = ({
   query,
   suggestion,
@@ -38,80 +73,44 @@ const SearchHeader = ({
   handleSearchParamsChange,
   subjects,
   noResults,
-  locale,
   competenceGoals,
   coreElements,
   loading,
 }: Props) => {
   const { t } = useTranslation();
-  const [searchValue, setSearchValue] = useState(query);
-  const [activeFilters, setActiveFilters] = useState<ActiveFilter[]>([]);
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchValue, setSearchValue] = useState(query ?? "");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const activeSubjectFilters = useMemo(() => {
+    return subjects?.filter((subject) => subjectIds.includes(subject.id)) ?? [];
+  }, [subjectIds, subjects]);
 
   const localeSubjectCategories = useMemo(() => getSubjectsCategories(t, subjects), [t, subjects]);
 
+  const grepElements = useMemo(() => [...competenceGoals, ...coreElements], [competenceGoals, coreElements]);
+
   useEffect(() => {
-    setSearchValue(query);
+    setSearchValue(query ?? "");
   }, [query]);
-
-  useEffect(() => {
-    const activeSubjects = subjectIds.map((id) => {
-      const name = subjects?.find((subject) => subject.id === id)?.name || "";
-      return {
-        value: id,
-        name: name,
-        title: name,
-      };
-    });
-
-    const activeGrepCodes = [...competenceGoals, ...coreElements].map((e) => ({
-      value: e.id,
-      name: e.id,
-      title: e.id,
-    }));
-
-    setActiveFilters([...activeSubjects, ...activeGrepCodes]);
-  }, [subjects, subjectIds, locale, competenceGoals, coreElements]);
-
-  const onSubjectValuesChange = (values: string[]) => {
-    handleSearchParamsChange({
-      subjects: values,
-    });
-  };
-
-  const onFilterValueChange = (grepCodeFilters: string[], subjectFilters: string[]) => {
-    handleSearchParamsChange({
-      grepCodes: grepCodeFilters,
-      subjects: subjectFilters,
-    });
-  };
-
-  const subjectFilterProps = {
-    subjectCategories: {
-      categories: localeSubjectCategories,
-      values: subjectIds,
-      onSubjectValuesChange: onSubjectValuesChange,
-    },
-    messages: {
-      filterLabel: t("searchPage.searchFilterMessages.filterLabel"),
-      closeButton: t("searchPage.close"),
-      buttonText: t("searchPage.searchFilterMessages.noValuesButtonText"),
-    },
-  };
 
   const handleSearchSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     handleSearchParamsChange({ query: searchValue });
   };
 
-  const handleFilterRemove = (value: string) => {
-    onFilterValueChange(
-      competenceGoals
-        .filter((e) => e.id !== value)
-        .map((e) => e.id)
-        .concat(coreElements.filter((e) => e.id !== value).map((e) => e.id)),
-      subjectIds.filter((id) => id !== value),
-    );
-    setActiveFilters(activeFilters.filter((filter) => filter.value !== value));
+  const onToggleSubject = (subjectId: string) => {
+    if (subjectIds.includes(subjectId)) {
+      handleSearchParamsChange({ subjects: subjectIds.filter((id) => id !== subjectId) });
+    } else {
+      handleSearchParamsChange({ subjects: subjectIds.concat(subjectId) });
+    }
+  };
+
+  const onGrepRemove = (grepValue: string) => {
+    handleSearchParamsChange({
+      grepCodes: grepElements.filter((grep) => grep.id !== grepValue).map((grep) => grep.id),
+    });
   };
 
   const onSearchValueChange = (value: string) => {
@@ -122,23 +121,116 @@ const SearchHeader = ({
   };
 
   return (
-    <SearchHeaderUI
-      searchPhrase={query}
-      searchPhraseSuggestion={suggestion}
-      searchPhraseSuggestionOnClick={() => handleSearchParamsChange({ query: suggestion })}
-      searchValue={searchValue}
-      onSearchValueChange={(value: string) => onSearchValueChange(value)}
-      onSubmit={handleSearchSubmit}
-      activeFilters={{
-        filters: activeFilters,
-        onFilterRemove: handleFilterRemove,
-      }}
-      filters={subjectFilterProps}
-      noResults={noResults}
-      competenceGoals={[]}
-      coreElements={[]}
-      loading={loading}
-    />
+    <Wrapper>
+      <form action="/search/" onSubmit={handleSearchSubmit}>
+        <StyledInputContainer>
+          <InputV3
+            ref={inputRef}
+            type="search"
+            autoComplete="off"
+            id="search"
+            name="search"
+            placeholder={t("searchPage.searchFieldPlaceholder")}
+            value={searchValue}
+            onChange={(e) => onSearchValueChange(e.target.value)}
+          />
+          {searchValue && (
+            <IconButtonV2
+              variant="ghost"
+              colorTheme="greyLighter"
+              aria-label={t("welcomePage.resetSearch")}
+              value={t("welcomePage.resetSearch")}
+              onClick={() => {
+                onSearchValueChange("");
+                inputRef.current?.focus();
+              }}
+            >
+              <Cross />
+            </IconButtonV2>
+          )}
+          <IconButtonV2
+            variant="ghost"
+            colorTheme="light"
+            type="submit"
+            aria-label={t("searchPage.search")}
+            title={t("searchPage.search")}
+          >
+            <Search />
+          </IconButtonV2>
+        </StyledInputContainer>
+      </form>
+      <div aria-live="assertive">
+        {!loading && query && (
+          <div>
+            {noResults ? (
+              <Text textStyle="meta-text-medium" margin="none">
+                {t("searchPage.noHitsShort", { query: query })}
+                {activeSubjectFilters.length ? `. ${t("searchPage.removeFilterSuggestion")}` : undefined}
+              </Text>
+            ) : (
+              <Text textStyle="meta-text-medium" margin="none">
+                {t("searchPage.resultType.showingSearchPhrase")} <b>&ldquo;{query}&rdquo;</b>
+              </Text>
+            )}
+            {suggestion && (
+              <Text textStyle="meta-text-medium" margin="none">
+                {t("searchPage.resultType.searchPhraseSuggestion")}{" "}
+                <ButtonV2 variant="link" onClick={() => handleSearchParamsChange({ query: suggestion })}>
+                  [{suggestion}]
+                </ButtonV2>
+              </Text>
+            )}
+          </div>
+        )}
+        {loading && <div aria-label={t("loading")} />}
+      </div>
+      {!!grepElements.length && (
+        <FiltersWrapper>
+          {grepElements.map((grep) => (
+            <ButtonV2 key={grep.id} shape="pill" onClick={() => onGrepRemove(grep.id)}>
+              {grep.id}
+              <Cross />
+            </ButtonV2>
+          ))}
+        </FiltersWrapper>
+      )}
+      <Modal open={isOpen} onOpenChange={setIsOpen}>
+        <FiltersWrapper>
+          <ModalTrigger>
+            <ButtonV2 colorTheme="greyLighter" shape="pill">
+              {t("searchPage.searchFilterMessages.noValuesButtonText")}
+              <Plus />
+            </ButtonV2>
+          </ModalTrigger>
+          {activeSubjectFilters.slice(0, MAX_SHOW_SUBJECT_FILTERS).map((subject) => (
+            <ButtonV2 key={subject.id} shape="pill" onClick={() => onToggleSubject(subject.id)}>
+              {subject.name}
+              <Cross />
+            </ButtonV2>
+          ))}
+          {activeSubjectFilters.length > MAX_SHOW_SUBJECT_FILTERS && (
+            <ButtonV2 shape="pill" onClick={() => setIsOpen(true)}>
+              {t("searchPage.searchFilterMessages.additionalSubjectFilters", {
+                count: activeSubjectFilters.length - MAX_SHOW_SUBJECT_FILTERS,
+              })}
+            </ButtonV2>
+          )}
+        </FiltersWrapper>
+        <ModalContent size="full">
+          <StyledModalBody>
+            <StyledModalHeader>
+              <ModalTitle>{t("searchPage.searchFilterMessages.filterLabel")}</ModalTitle>
+              <ModalCloseButton />
+            </StyledModalHeader>
+            <SubjectFilter
+              categories={localeSubjectCategories}
+              onToggleSubject={onToggleSubject}
+              selectedSubjects={subjectIds}
+            />
+          </StyledModalBody>
+        </ModalContent>
+      </Modal>
+    </Wrapper>
   );
 };
 

--- a/src/containers/SearchPage/components/SearchSubjectResult.tsx
+++ b/src/containers/SearchPage/components/SearchSubjectResult.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from "react-i18next";
 import styled from "@emotion/styled";
 import { mq, breakpoints, spacing, fonts, misc } from "@ndla/core";
 import { SafeLink } from "@ndla/safelink";
-import { Heading } from "@ndla/typography";
+import { Text } from "@ndla/typography";
 
 interface Props {
   items: {
@@ -53,8 +53,7 @@ const ItemWrapper = styled.div`
   }
 `;
 
-const ItemHeading = styled(Heading)`
-  margin: ${spacing.small} 0px;
+const ItemHeading = styled(Text)`
   font-weight: ${fonts.weight.semibold};
 `;
 
@@ -64,7 +63,7 @@ const SearchSubjectResult = ({ items }: Props) => {
     <Container>
       {items.map((item) => (
         <ItemWrapper key={item.id} style={{ "--background-image": `url(${item.img?.url ?? ""})` } as CSSProperties}>
-          <ItemHeading element="h2" headingStyle="h4">
+          <ItemHeading element="h2" textStyle="label-small" margin="none">
             {item.title}
           </ItemHeading>
           <SafeLink to={item.url}>{t("searchPage.resultType.toSubjectPageLabel")}</SafeLink>

--- a/src/containers/SearchPage/components/SearchSubjectResult.tsx
+++ b/src/containers/SearchPage/components/SearchSubjectResult.tsx
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2020-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { CSSProperties } from "react";
+import { useTranslation } from "react-i18next";
+import styled from "@emotion/styled";
+import { mq, breakpoints, spacing, fonts, misc } from "@ndla/core";
+import { SafeLink } from "@ndla/safelink";
+import { Heading } from "@ndla/typography";
+
+interface Props {
+  items: {
+    id: string;
+    title: string;
+    url: string;
+    img?: { url: string };
+  }[];
+}
+
+const Container = styled.div`
+  display: grid;
+  gap: ${spacing.normal};
+  grid-template-columns: repeat(1, 1fr);
+  ${mq.range({ from: breakpoints.tablet })} {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  ${mq.range({ from: breakpoints.tabletWide })} {
+    grid-template-columns: repeat(3, 1fr);
+  }
+  ${mq.range({ from: breakpoints.desktop })} {
+    grid-template-columns: repeat(4, 1fr);
+  }
+`;
+
+const ItemWrapper = styled.div`
+  background: #deebf6;
+  padding: ${spacing.normal} ${spacing.medium};
+  border-radius: ${misc.borderRadius};
+  height: 150px;
+  background-repeat: no-repeat;
+  background-repeat: no-repeat;
+  background-position-y: 100%;
+  background-position-x: 100%;
+  background-size: auto 100px;
+  background-image: var(--background-image);
+  a {
+    font-weight: ${fonts.weight.semibold};
+  }
+`;
+
+const ItemHeading = styled(Heading)`
+  margin: ${spacing.small} 0px;
+  font-weight: ${fonts.weight.semibold};
+`;
+
+const SearchSubjectResult = ({ items }: Props) => {
+  const { t } = useTranslation();
+  return (
+    <Container>
+      {items.map((item) => (
+        <ItemWrapper key={item.id} style={{ "--background-image": `url(${item.img?.url ?? ""})` } as CSSProperties}>
+          <ItemHeading element="h2" headingStyle="h4">
+            {item.title}
+          </ItemHeading>
+          <SafeLink to={item.url}>{t("searchPage.resultType.toSubjectPageLabel")}</SafeLink>
+        </ItemWrapper>
+      ))}
+    </Container>
+  );
+};
+
+export default SearchSubjectResult;

--- a/src/containers/SearchPage/components/SubjectFilter.tsx
+++ b/src/containers/SearchPage/components/SubjectFilter.tsx
@@ -1,0 +1,184 @@
+/**
+ * Copyright (c) 2020-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import groupBy from "lodash/groupBy";
+import sortBy from "lodash/sortBy";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import styled from "@emotion/styled";
+import { colors, mq, breakpoints, spacing } from "@ndla/core";
+import { CheckboxItem, Label } from "@ndla/forms";
+import { Tabs } from "@ndla/tabs";
+import { Heading } from "@ndla/typography";
+import { MessageBox } from "@ndla/ui";
+import { GQLSubjectInfoFragment } from "../../../graphqlTypes";
+
+const StyledWrapper = styled.nav`
+  margin: 32px 0 0;
+  max-width: 1040px;
+`;
+
+const OuterList = styled.ul`
+  list-style: none;
+  margin: ${spacing.normal} 0 0;
+  padding: 0;
+  ${mq.range({ from: breakpoints.tablet })} {
+    column-count: 2;
+    gap: ${spacing.normal};
+  }
+  ${mq.range({ from: breakpoints.tabletWide })} {
+    column-count: 3;
+    gap: ${spacing.normal};
+  }
+`;
+
+const OuterListItem = styled.li`
+  padding: 0;
+  break-inside: avoid;
+`;
+
+const StyledLetterItem = styled(Heading)`
+  color: ${colors.brand.primary};
+  margin: 0 !important;
+  margin-left: ${spacing.normal} !important;
+`;
+
+const MessageBoxWrapper = styled.div`
+  padding-top: ${spacing.normal};
+`;
+
+const InnerList = styled.ul`
+  display: flex;
+  padding: 0;
+  flex-direction: column;
+  list-style: none;
+  flex-wrap: wrap;
+`;
+
+const InnerListItem = styled.li`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.small};
+  padding: 0;
+  margin-bottom: ${spacing.xxsmall};
+  break-inside: avoid;
+`;
+
+const StyledLabel = styled(Label)`
+  color: ${colors.brand.primary};
+`;
+
+const StyledCheckboxItem = styled(CheckboxItem)`
+  min-width: ${spacing.nsmall};
+  min-height: ${spacing.nsmall};
+  max-height: ${spacing.nsmall};
+  max-width: ${spacing.nsmall};
+`;
+
+interface Category {
+  type?: string;
+  visible?: boolean;
+  message?: string;
+  subjects: GQLSubjectInfoFragment[];
+}
+
+interface SubjectListProps {
+  subjects: Record<string, GQLSubjectInfoFragment[]>;
+  onToggleSubject: (id: string) => void;
+  selectedSubjects: string[];
+}
+
+const SubjectList = ({ subjects, onToggleSubject, selectedSubjects = [] }: SubjectListProps) => (
+  <OuterList>
+    {Object.entries(subjects).map(([letter, subjects]) => {
+      return (
+        <OuterListItem key={letter}>
+          <StyledLetterItem element="h2" headingStyle="h2">
+            {letter}
+          </StyledLetterItem>
+          <InnerList>
+            {subjects.map((subject) => (
+              <InnerListItem key={subject.name}>
+                <StyledCheckboxItem
+                  id={subject.id}
+                  checked={selectedSubjects.includes(subject.id)}
+                  onCheckedChange={() => onToggleSubject(subject.id)}
+                />
+                <StyledLabel htmlFor={subject.id} textStyle="meta-text-small">
+                  {subject.name}
+                </StyledLabel>
+              </InnerListItem>
+            ))}
+          </InnerList>
+        </OuterListItem>
+      );
+    })}
+  </OuterList>
+);
+
+interface Props {
+  categories: Category[];
+  onToggleSubject: (id: string) => void;
+  selectedSubjects: string[];
+}
+
+const SubjectFilter = ({ categories, onToggleSubject, selectedSubjects }: Props) => {
+  const { t } = useTranslation();
+
+  const tabs = useMemo(() => {
+    const allSubjects: GQLSubjectInfoFragment[] = [];
+    const data = [];
+    categories.forEach((category) => {
+      allSubjects.push(...category.subjects);
+      const sortedSubjects = sortBy(category.subjects, (s) => s.name);
+      category.visible &&
+        data.push({
+          title: t(`subjectCategories.${category.type}`),
+          id: category.type,
+          content: (
+            <>
+              {category.message && (
+                <MessageBoxWrapper>
+                  <MessageBox>{category.message}</MessageBox>
+                </MessageBoxWrapper>
+              )}
+              <SubjectList
+                subjects={groupBy(sortedSubjects, (s) => s.name[0]?.toUpperCase())}
+                onToggleSubject={onToggleSubject}
+                selectedSubjects={selectedSubjects}
+              />
+            </>
+          ),
+        });
+    });
+
+    const allSubjectsSorted = sortBy(allSubjects, (s) => s.name);
+
+    data.push({
+      title: t("frontpageMenu.allsubjects"),
+      id: "allsubjects",
+      content: (
+        <SubjectList
+          subjects={groupBy(allSubjectsSorted, (s) => s.name[0]?.toUpperCase())}
+          onToggleSubject={onToggleSubject}
+          selectedSubjects={selectedSubjects}
+        />
+      ),
+    });
+
+    return data;
+  }, [categories, onToggleSubject, selectedSubjects, t]);
+
+  return (
+    <StyledWrapper>
+      <Tabs tabs={tabs} />
+    </StyledWrapper>
+  );
+};
+
+export default SubjectFilter;

--- a/src/containers/SearchPage/components/searchTypes.ts
+++ b/src/containers/SearchPage/components/searchTypes.ts
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) 2024-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+export type ViewType = "grid" | "list";


### PR DESCRIPTION
NB! Disser ikke like det som er i prod i dag.


* Filtre er flyttet fullstendig ut av søke-inputet. De ligger nå samme sted uavhengig av om man er på stor/liten skjerm. 
* Søke-input har endret utseende. Det er nå en "stock" Input-komponent med transparent bakgrunn. Vil vi at den skal være likere det den var før?
* Fag-resultater fyller ikke alltid lenger skjermen når det ikke er nok resultater til å fylle griden. 
* Ressurstype-filtrering er forenklet ganske drastisk. Det er nå bare en liste med knapper som wrapper til neste linje dersom det ikke har plass på en linje. Dette var før to ("tre") forskjellige komponenter: En fullverdig liste, en scrollbar liste og en modal.