### PR TITLE
Bump serialize-javascript & graphql versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "date-fns": "^2.30.0",
     "express": "^4.19.2",
     "express-prom-bundle": "^7.0.0",
-    "graphql": "^16.6.0",
+    "graphql": "^16.8.1",
     "graphql-tag": "^2.12.6",
     "helmet": "^7.0.0",
     "html-react-parser": "^5.1.8",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "react-hook-form": "^7.51.3",
     "react-i18next": "^13.3.0",
     "react-router-dom": "^6.3.0",
-    "serialize-javascript": "^6.0.0",
+    "serialize-javascript": "^6.0.2",
     "source-map-support": "^0.5.9",
     "winston": "^3.12.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9139,10 +9139,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql@npm:^16.6.0":
-  version: 16.6.0
-  resolution: "graphql@npm:16.6.0"
-  checksum: 10c0/3a2c15ff58b69d017618d2b224fa6f3c4a7937e1f711c3a5e0948db536b4931e6e649560b53de7cc26735e027ceea6e2d0a6bb7c29fc4639b290313e3aa71618
+"graphql@npm:^16.8.1":
+  version: 16.8.1
+  resolution: "graphql@npm:16.8.1"
+  checksum: 10c0/129c318156b466f440914de80dbf7bc67d17f776f2a088a40cb0da611d19a97c224b1c6d2b13cbcbc6e5776e45ed7468b8432f9c3536724e079b44f1a3d57a8a
   languageName: node
   linkType: hard
 
@@ -10985,7 +10985,7 @@ __metadata:
     eslint-config-ndla: "npm:^5.0.3"
     express: "npm:^4.19.2"
     express-prom-bundle: "npm:^7.0.0"
-    graphql: "npm:^16.6.0"
+    graphql: "npm:^16.8.1"
     graphql-tag: "npm:^2.12.6"
     helmet: "npm:^7.0.0"
     html-react-parser: "npm:^5.1.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11009,7 +11009,7 @@ __metadata:
     react-hook-form: "npm:^7.51.3"
     react-i18next: "npm:^13.3.0"
     react-router-dom: "npm:^6.3.0"
-    serialize-javascript: "npm:^6.0.0"
+    serialize-javascript: "npm:^6.0.2"
     sirv: "npm:^2.0.4"
     source-map-support: "npm:^0.5.9"
     tsx: "npm:^4.7.2"
@@ -13286,12 +13286,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serialize-javascript@npm:^6.0.0":
-  version: 6.0.1
-  resolution: "serialize-javascript@npm:6.0.1"
+"serialize-javascript@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "serialize-javascript@npm:6.0.2"
   dependencies:
     randombytes: "npm:^2.1.0"
-  checksum: 10c0/1af427f4fee3fee051f54ffe15f77068cff78a3c96d20f5c1178d20630d3ab122d8350e639d5e13cde8111ef9db9439b871305ffb185e24be0a2149cec230988
+  checksum: 10c0/2dd09ef4b65a1289ba24a788b1423a035581bef60817bea1f01eda8e3bda623f86357665fe7ac1b50f6d4f583f97db9615b3f07b2a2e8cbcb75033965f771dd2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fikser to svakheter:
- https://security.snyk.io/vuln/SNYK-JS-SERIALIZEJAVASCRIPT-6147607
- https://security.snyk.io/vuln/SNYK-JS-GRAPHQL-5905181