### PR TITLE
Return status code from error if it exists

### DIFF
--- a/e2e/apiMocks/unauthenticated_server.spec.ts_That_invalid_urls_return_status_400.har
+++ b/e2e/apiMocks/unauthenticated_server.spec.ts_That_invalid_urls_return_status_400.har
@@ -1,0 +1,1 @@
+{"log":{"version":"1.2","creator":{"name":"Playwright","version":"1.43.1"},"browser":{"name":"chromium","version":"124.0.6367.29"},"entries":[]}}

--- a/e2e/specs/unauthenticated/server.spec.ts
+++ b/e2e/specs/unauthenticated/server.spec.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2024-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { expect } from "@playwright/test";
+import { test } from "../../apiMock";
+
+test("That invalid urls return status 400", async ({ page }) => {
+  const invalidUrls = [
+    "/%c0",
+    "/%c0%ae%c0%ae/%c0%ae%c0%ae/%c0%ae%c0%ae/%c0%ae%c0%ae/%c0%ae%c0%ae/%c0%ae%c0%ae/%c0%ae%c0%ae/%c0%ae%c0%ae/etc/passwd",
+    "/%c0%ae%c0%ae/%c0%ae%c0%ae/%c0%ae%c0%ae/%c0%ae%c0%ae/%c0%ae%c0%ae/%c0%ae%c0%ae/%c0%ae%c0%ae/%c0%ae%c0%ae/windows/win.ini",
+    "/%c0%ae%c0%ae/%c0%ae%c0%ae/%c0%ae%c0%ae/etc/passwd",
+    "/%c0%ae%c0%ae/%c0%ae%c0%ae/%c0%ae%c0%ae/windows/win.ini",
+    "/%c0%ae/%c0%ae/%c0%ae/%c0%ae/WEB-INF/web.xml",
+    "/%c0%ae/%c0%ae/%c0%ae/WEB-INF/web.xml",
+    "/%c0%ae/%c0%ae/WEB-INF/web.xml",
+    "/%c0%ae/WEB-INF/web.xml",
+  ];
+
+  for (const url of invalidUrls) {
+    const response = await page.goto(url);
+    expect(response).toBeDefined();
+    expect(response!.status()).toBe(400);
+  }
+});

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -253,19 +253,33 @@ app.get(
 
 const errorRoute = async (req: Request) => renderRoute(req, "error.html", errorTemplateHtml, "error");
 
-async function sendInternalServerError(req: Request, res: Response) {
+const getStatusCodeToReturn = (err?: Error): number => {
+  if (err && "status" in err && typeof err.status === "number") {
+    if (err.status >= 400 && err.status < 600) return err.status;
+  }
+  return INTERNAL_SERVER_ERROR;
+};
+
+async function sendInternalServerError(req: Request, res: Response, err?: Error) {
+  const statusCode = getStatusCodeToReturn(err);
   if (res.getHeader("Content-Type") === "application/json") {
-    res.status(INTERNAL_SERVER_ERROR).json("Internal server error");
-  } else {
+    res.status(statusCode).json("Internal server error");
+    return;
+  }
+
+  try {
     const { data } = await errorRoute(req);
-    res.status(INTERNAL_SERVER_ERROR).send(data);
+    res.status(statusCode).send(data);
+  } catch (e) {
+    console.error("Something went wrong when retrieving errorRoute.", e);
+    res.status(statusCode).send("Internal server error");
   }
 }
 
 const errorHandler = (err: Error, req: Request, res: Response, __: (err: Error) => void) => {
   vite?.ssrFixStacktrace(err);
   handleError(err);
-  sendInternalServerError(req, res);
+  sendInternalServerError(req, res, err);
 };
 
 app.use(errorHandler);


### PR DESCRIPTION
Noen feil vil inneholde en statuskode vi kan returnere.
Feks så finner jeg en del "rare" url'er ifra prometheus metrikkene våre fra noen dårlige hackerangrep der vi returnerer 500.

- Returnerer fra feilen bare dersom statuskoden'en fra feilen er 400-599.
  - Dette er det express gjør by default så tenkte det var smart oppførsel
- Catcher og returnerer en generisk feilmelding dersom errorRouten vår feiler
  - Skjedde med de rare url'ene lokalt. Går ut i fra at det ikke skjer særlig ofte, men tenker det er lurt å fange de uansett.