### PR TITLE
Removing usage of the preview endpoint

### DIFF
--- a/src/containers/SharedFolderPage/components/Folder.tsx
+++ b/src/containers/SharedFolderPage/components/Folder.tsx
@@ -121,7 +121,7 @@ interface Props {
 }
 
 const Folder = ({ folder, meta, setFocus, defaultOpenFolder, root, level, onClose, subfolderKey }: Props) => {
-  const { name, subfolders, resources, status } = folder;
+  const { name, subfolders, resources } = folder;
   const { folderId: rootFolderId, resourceId, subfolderId } = useParams();
   const { t } = useTranslation();
 
@@ -133,8 +133,6 @@ const Folder = ({ folder, meta, setFocus, defaultOpenFolder, root, level, onClos
   if (isEmpty) {
     return null;
   }
-
-  const preview = status === "private";
 
   const handleKeydown = (e: KeyboardEvent<HTMLButtonElement | HTMLAnchorElement>) => {
     if (e.key === "ArrowLeft") {
@@ -178,7 +176,7 @@ const Folder = ({ folder, meta, setFocus, defaultOpenFolder, root, level, onClos
                   <StyledArrow data-open={isOpen} />
                 </ToggleOpenButton>
                 <FolderLink
-                  to={preview ? routes.myNdla.folderPreview(folder.id) : routes.folder(folder.id)}
+                  to={routes.folder(folder.id)}
                   aria-owns={`folder-sublist-${folder.id}`}
                   id={`shared-${folder.id}`}
                   tabIndex={-1}
@@ -216,11 +214,7 @@ const Folder = ({ folder, meta, setFocus, defaultOpenFolder, root, level, onClos
                 <StyledArrow data-open={isOpen} />
               </ToggleOpenButton>
               <FolderLink
-                to={
-                  preview
-                    ? `${routes.myNdla.folderPreview(rootFolderId as string)}/${subfolderKey}`
-                    : `${routes.folder(rootFolderId as string)}/${subfolderKey}`
-                }
+                to={`${routes.folder(rootFolderId as string)}/${subfolderKey}`}
                 aria-owns={`folder-sublist-${folder.id}`}
                 id={`shared-${folder.id}`}
                 tabIndex={-1}
@@ -254,7 +248,6 @@ const Folder = ({ folder, meta, setFocus, defaultOpenFolder, root, level, onClos
                   isLast={i === resources.length - 1}
                   meta={meta[`${resource.resourceType}-${resource.resourceId}`]}
                   resource={resource}
-                  preview={preview}
                 />
               ),
           )}

--- a/src/containers/SharedFolderPage/components/FolderResource.tsx
+++ b/src/containers/SharedFolderPage/components/FolderResource.tsx
@@ -81,10 +81,9 @@ interface Props {
   setFocus: (id: string) => void;
   level: number;
   isLast?: boolean;
-  preview?: boolean;
 }
 
-const FolderResource = ({ parentId, resource, meta, setFocus, level, isLast, onClose, preview }: Props) => {
+const FolderResource = ({ parentId, resource, meta, setFocus, level, isLast, onClose }: Props) => {
   const { folderId: rootFolderId, subfolderId, resourceId } = useParams();
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -93,13 +92,8 @@ const FolderResource = ({ parentId, resource, meta, setFocus, level, isLast, onC
     [resource.resourceType],
   );
   const link = useMemo(
-    () =>
-      isLearningPathOrCase
-        ? resource.path
-        : preview
-          ? `${routes.myNdla.folderPreview(rootFolderId ?? "")}/${parentId}/${resource.id}`
-          : `${routes.folder(rootFolderId ?? "")}/${parentId}/${resource.id}`,
-    [isLearningPathOrCase, resource.path, resource.id, rootFolderId, parentId, preview],
+    () => (isLearningPathOrCase ? resource.path : `${routes.folder(rootFolderId ?? "")}/${parentId}/${resource.id}`),
+    [isLearningPathOrCase, resource.path, resource.id, rootFolderId, parentId],
   );
 
   const onClick = useCallback(

--- a/src/routeHelpers.tsx
+++ b/src/routeHelpers.tsx
@@ -213,6 +213,5 @@ export const routes = {
     arenaTopic: (topicId?: number) => `/minndla/arena/topic/${topicId}`,
     arenaUser: (username: String) => `/minndla/arena/user/${username}`,
     folder: (folderId: String) => `/minndla/folders/${folderId}`,
-    folderPreview: (folderId: String) => `/minndla/folders/preview/${folderId}`,
   },
 };


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/4035

...MEN; denne bør testes. ~~Jeg har ikke klart å gjenskape problemet som er beskrevet i https://trello.com/c/XOWL0aTf/836-minndla-delte-mapper-bug-forh%C3%A5ndsvising, og~~ jeg er egentlig tvilende til at å fjerne preview-endepunktet er svar på problemet (heller at det fikser et symptom på et annet problem eller noe som henger igjen). For å gjenskape feilen, har jeg:

1. Funnet ei delt mappe på en testbruker
2. Logget inn på en annen testbruker
3. Gått inn på lenka og trykket Kopier Mappe + lagret den (også i en mappe som heter Favoritter, for sikkerhets skyld)
4. Gått inn igjen i MinNDLA, åpnet delt mappe for Favoritter og valgt mappa som nettopp er kopiert i strukturen

Når jeg kopierer en mappe, lages vel egentlig en ny mappe hos meg med samme innhold; som skal oppføre seg likt (rettighetsmessig) som hvis man trykker Ny og lager mappe (som ifølge samme Trellokort fungerer), om jeg har forstått rett. ~~Men forsøkene jeg har gjort på kopiering og gå via mappene til delt-lenke og forhåndsvis-lenke oppfører seg altså likt i master og i denne branchen så langt.~~

Edit: Klarer fremprovosere "/preview"-lenke dersom jeg velger en ikke delt mappe fra en annen ikke delt mappe i forhåndsvisning sidemeny. Og det forsvinner iallefall med denne PRen.