### PR TITLE
Stop including path label for prometheus metrics

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -52,7 +52,7 @@ if (!isProduction) {
 
 const metricsMiddleware = promBundle({
   includeMethod: true,
-  includePath: true,
+  includePath: false,
   excludeRoutes: ["/health"],
 });
 


### PR DESCRIPTION
Siden labelen ikke blir begrenset på antall paths vi har, men alle paths som finnes blir lablet så blir det litt tungt for prometheus.

Ref: https://prometheus.io/docs/practices/instrumentation/#do-not-overuse-labels