### PR TITLE
Defaults to frontpage when creating a playwright page

### DIFF
--- a/e2e/apiMock.ts
+++ b/e2e/apiMock.ts
@@ -70,6 +70,7 @@ export const test = Ptest.extend<ExtendParams>({
       updateContent: "embed",
     });
 
+    await page.goto("/");
     await use(page);
 
     await page.close();


### PR DESCRIPTION
Vi har 2 flaky tester som ikke spiller på lag når testene kjøres lokalt headless. 

Playwright defaulter til baseurl når den åpner en page, men usikker på hvordan det håndteres om den det awaites til at den siden blir loadet. Ved å legge til at page automatisk loader `/` så fungerer alt samt. at vi har kontroll på at `/` er loadet før vi starter testene våre iallefall og at server er oppe å kjører.