### PR TITLE
Replace possible empty topicpath[0] with subjectid

### DIFF
--- a/src/containers/SubjectPage/components/SubjectTopic.tsx
+++ b/src/containers/SubjectPage/components/SubjectTopic.tsx
@@ -132,7 +132,7 @@ const SubjectTopic = ({
       ...subtopic,
       label: subtopic.name,
       selected: subtopic.id === subTopicId,
-      url: toTopic(topicPath[0]!.id, ...topicPath.slice(1).map((t) => t.id), topic?.id, subtopic.id),
+      url: toTopic(subjectId, ...topicPath.slice(1).map((t) => t.id), topic?.id, subtopic.id),
       isAdditionalResource: subtopic.relevanceId === RELEVANCE_SUPPLEMENTARY,
     };
   });


### PR DESCRIPTION
Fixes NDLANO/Issues#4065

topicPath kan være tom (sjølv om det då sannsynligvis skyldes manglende data fra taksonomi), men skal peike på rot for kontekst som er subjectid.