### PR TITLE
Request path logging & plaintext logging

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -278,7 +278,7 @@ async function sendInternalServerError(req: Request, res: Response, err?: Error)
 
 const errorHandler = (err: Error, req: Request, res: Response, __: (err: Error) => void) => {
   vite?.ssrFixStacktrace(err);
-  handleError(err);
+  handleError(err, undefined, req);
   sendInternalServerError(req, res, err);
 };
 

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -11,9 +11,17 @@
 import { createLogger, transports, format } from "winston";
 import "source-map-support/register";
 
+const { combine, timestamp, printf } = format;
+
+const errFormat = printf(({ level, message, stack, requestPath, timestamp }) => {
+  const stackString = stack ? `\n${stack}` : "";
+  const requestPathStr = requestPath ? `${requestPath} ` : "";
+  return `[ndla-frontend] ${timestamp} [${level}] ${requestPathStr}${message}${stackString}`;
+});
+
 const log = createLogger({
   defaultMeta: { service: "ndla-frontend" },
-  format: format.combine(format.timestamp(), format.errors({ stack: true }), format.json()),
+  format: combine(timestamp(), errFormat),
   transports: [new transports.Console()],
 });
 

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -11,17 +11,9 @@
 import { createLogger, transports, format } from "winston";
 import "source-map-support/register";
 
-const { combine, timestamp, printf } = format;
-
-const errFormat = printf(({ level, message, stack, requestPath, timestamp }) => {
-  const stackString = stack ? `\n${stack}` : "";
-  const requestPathStr = requestPath ? `${requestPath} ` : "";
-  return `[ndla-frontend] ${timestamp} [${level}] ${requestPathStr}${message}${stackString}`;
-});
-
 const log = createLogger({
   defaultMeta: { service: "ndla-frontend" },
-  format: combine(timestamp(), errFormat),
+  format: format.combine(format.timestamp(), format.errors({ stack: true }), format.json()),
   transports: [new transports.Console()],
 });
 


### PR DESCRIPTION
- Legger til request path på logger på server siden.
- Setter opp logging til å være plaintext fremfor json

Tenkte det ville vært nyttig å ha med requestpathen i loggene for å enklere kunne reprodusere feil.

Personlig liker jeeg ikke json-feilmeldingene våre så veldig godt så jeg endret winston-saken til å logge plaintext istedet. Kan droppe og bare ha med requestPath i json objektet om andre har andre preferanser på json vs plaintext.

<img width="1622" alt="image" src="https://github.com/NDLANO/ndla-frontend/assets/7853824/66443ad3-d4da-489b-bd2a-02282dbcdf72">
