### PR TITLE
Add requestPath and other graphql context to graphql errors

### DIFF
--- a/src/iframe/embedIframeIndex.tsx
+++ b/src/iframe/embedIframeIndex.tsx
@@ -61,7 +61,7 @@ const language = initialProps.locale ?? config.defaultLocale;
 
 const cache = createCache({ key: EmotionCacheKey });
 
-const client = createApolloClient(language);
+const client = createApolloClient(language, undefined, window.location.pathname);
 const i18n = initializeI18n(i18nInstance, language);
 
 const renderOrHydrate = (container: HTMLElement, children: ReactNode) => {

--- a/src/server/podcastRssFeed.ts
+++ b/src/server/podcastRssFeed.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import { Request } from "express";
 import { gql, ApolloClient, NormalizedCacheObject } from "@apollo/client/core";
 import config from "../config";
 import { GQLPodcastSeriesQuery } from "../graphqlTypes";
@@ -14,18 +15,18 @@ import { createApolloClient } from "../util/apiHelpers";
 let apolloClient: ApolloClient<NormalizedCacheObject>;
 let storedLocale: string;
 
-const getApolloClient = (locale: string) => {
+const getApolloClient = (locale: string, req: Request) => {
   if (apolloClient && locale === storedLocale) {
     return apolloClient;
   } else {
-    apolloClient = createApolloClient(locale);
+    apolloClient = createApolloClient(locale, undefined, req.path);
     storedLocale = locale;
     return apolloClient;
   }
 };
 
-const podcastRssFeed = async (seriesId: number): Promise<string> => {
-  const client = getApolloClient("nb");
+const podcastRssFeed = async (seriesId: number, req: Request): Promise<string> => {
+  const client = getApolloClient("nb", req);
 
   const { data: { podcastSeries } = {} } = await client.query<GQLPodcastSeriesQuery>({
     query: podcastSeriesQuery,

--- a/src/server/render/defaultRender.tsx
+++ b/src/server/render/defaultRender.tsx
@@ -69,7 +69,7 @@ export const defaultRender: RenderFunc = async (req) => {
     };
   }
 
-  const client = createApolloClient(locale, versionHash);
+  const client = createApolloClient(locale, versionHash, req.path);
   const cache = createCache({ key: EmotionCacheKey });
   const i18n = initializeI18n(i18nInstance, locale);
   const redirectContext: RedirectInfo = {};

--- a/src/server/render/iframeArticleRender.tsx
+++ b/src/server/render/iframeArticleRender.tsx
@@ -56,7 +56,7 @@ export const iframeArticleRender: RenderFunc = async (req) => {
     };
   }
 
-  const client = createApolloClient(locale);
+  const client = createApolloClient(locale, undefined, req.path);
   const cache = createCache({ key: EmotionCacheKey });
   const i18n = initializeI18n(i18nInstance, locale ?? config.defaultLocale);
   const context: RedirectInfo = {};

--- a/src/server/render/iframeEmbedRender.tsx
+++ b/src/server/render/iframeEmbedRender.tsx
@@ -48,7 +48,7 @@ export const iframeEmbedRender: RenderFunc = async (req) => {
     };
   }
 
-  const client = createApolloClient(locale);
+  const client = createApolloClient(locale, undefined, req.path);
   const cache = createCache({ key: EmotionCacheKey });
   const i18n = initializeI18n(i18nInstance, locale ?? config.defaultLocale);
   const context: RedirectInfo = {};

--- a/src/server/routes/oembedArticleRoute.ts
+++ b/src/server/routes/oembedArticleRoute.ts
@@ -44,11 +44,11 @@ type MatchParams = "resourceId" | "topicId" | "lang" | "articleId";
 let apolloClient: ApolloClient<NormalizedCacheObject>;
 let storedLocale: string;
 
-const getApolloClient = (locale: string) => {
+const getApolloClient = (locale: string, req: express.Request) => {
   if (apolloClient && locale === storedLocale) {
     return apolloClient;
   } else {
-    apolloClient = createApolloClient(locale);
+    apolloClient = createApolloClient(locale, undefined, req.path);
     storedLocale = locale;
     return apolloClient;
   }
@@ -111,7 +111,7 @@ const embedOembedQuery = gql`
 `;
 
 const getEmbedObject = async (lang: string, embedId: string, embedType: string, req: express.Request) => {
-  const client = getApolloClient(lang);
+  const client = getApolloClient(lang, req);
 
   const embed = await client.query<GQLEmbedOembedQuery, GQLEmbedOembedQueryVariables>({
     query: embedOembedQuery,

--- a/src/server/routes/podcastFeedRoute.ts
+++ b/src/server/routes/podcastFeedRoute.ts
@@ -18,7 +18,7 @@ export const podcastFeedRoute = async (req: Request, res: Response, next: NextFu
     return;
   }
 
-  await podcastRssFeed(id)
+  await podcastRssFeed(id, req)
     .then((podcastPage) => {
       res.setHeader("Content-Type", "application/xml");
       res.send(podcastPage);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -278,7 +278,7 @@ async function sendInternalServerError(req: Request, res: Response, err?: Error)
 
 const errorHandler = (err: Error, req: Request, res: Response, __: (err: Error) => void) => {
   vite?.ssrFixStacktrace(err);
-  handleError(err, undefined, req);
+  handleError(err, undefined, req.path);
   sendInternalServerError(req, res, err);
 };
 


### PR DESCRIPTION
Legger på litt mer info på graphql feilmeldinger i ndla-frontend og endrer levelet til `warn` dersom feilen svarte med statuskode < 500.