### PR TITLE
New frontpage

### DIFF
--- a/src/containers/Page/Layout.tsx
+++ b/src/containers/Page/Layout.tsx
@@ -64,7 +64,7 @@ const Layout = () => {
   const metaChildren = isDefaultVersion ? null : <meta name="robots" content="noindex, nofollow" />;
 
   return (
-    <PageContainer backgroundWide={backgroundWide} data-frontpage={frontpage}>
+    <PageContainer backgroundWide={backgroundWide}>
       <TitleAnnouncer />
       <Helmet
         htmlAttributes={{ lang: i18n.language === "nb" ? "no" : i18n.language }}

--- a/src/containers/Page/Layout.tsx
+++ b/src/containers/Page/Layout.tsx
@@ -11,7 +11,7 @@ import { Helmet } from "react-helmet-async";
 import { useTranslation } from "react-i18next";
 import { matchPath, Outlet, useLocation } from "react-router-dom";
 import styled from "@emotion/styled";
-import { colors, spacing } from "@ndla/core";
+import { spacing } from "@ndla/core";
 import { useComponentSize } from "@ndla/hooks";
 import { PageContainer } from "@ndla/ui";
 import Footer from "./components/Footer";
@@ -25,12 +25,6 @@ const BottomPadding = styled.div`
   padding-bottom: ${spacing.large};
   &[data-no-padding="true"] {
     padding-bottom: unset;
-  }
-`;
-
-const StyledPageContainer = styled(PageContainer)`
-  &[data-frontpage="true"] {
-    background-color: ${colors.background.lightBlue};
   }
 `;
 
@@ -70,7 +64,7 @@ const Layout = () => {
   const metaChildren = isDefaultVersion ? null : <meta name="robots" content="noindex, nofollow" />;
 
   return (
-    <StyledPageContainer backgroundWide={backgroundWide} data-frontpage={frontpage}>
+    <PageContainer backgroundWide={backgroundWide} data-frontpage={frontpage}>
       <TitleAnnouncer />
       <Helmet
         htmlAttributes={{ lang: i18n.language === "nb" ? "no" : i18n.language }}
@@ -85,7 +79,7 @@ const Layout = () => {
         </BottomPadding>
       </div>
       <Footer />
-    </StyledPageContainer>
+    </PageContainer>
   );
 };
 export default Layout;

--- a/src/containers/WelcomePage/Components/Programmes.tsx
+++ b/src/containers/WelcomePage/Components/Programmes.tsx
@@ -25,6 +25,7 @@ import { useUserAgent } from "../../../UserAgentContext";
 const StyledWrapper = styled("div", {
   base: {
     display: "flex",
+    width: "100%",
     flexDirection: "column",
     alignItems: "center",
     margin: "0",
@@ -75,6 +76,12 @@ const StyledAccordionRoot = styled(AccordionRoot, {
   base: {
     borderRadius: "small",
     boxShadow: "full",
+  },
+});
+
+const StyledAccordionItemContent = styled(AccordionItemContent, {
+  base: {
+    background: "surface.default",
   },
 });
 
@@ -129,11 +136,11 @@ const Programmes = ({ programmes }: Props) => {
                 </AccordionItemTrigger>
               </h2>
             </Heading>
-            <AccordionItemContent>
+            <StyledAccordionItemContent>
               <nav aria-labelledby="accordionHeader">
                 <StyledList>{programmeCards}</StyledList>
               </nav>
-            </AccordionItemContent>
+            </StyledAccordionItemContent>
           </AccordionItem>
         </StyledAccordionRoot>
       </FullWidth>

--- a/src/containers/WelcomePage/WelcomePage.tsx
+++ b/src/containers/WelcomePage/WelcomePage.tsx
@@ -9,10 +9,10 @@
 import { useContext, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { gql } from "@apollo/client";
-import styled from "@emotion/styled";
-import { breakpoints, mq, spacing, utils } from "@ndla/core";
+import { Heading, Hero, HeroBackground } from "@ndla/primitives";
+import { styled } from "@ndla/styled-system/jsx";
 import { HelmetWithTracker, useTracker } from "@ndla/tracker";
-import { ProgrammeV2, FrontpageArticle, WIDE_FRONTPAGE_ARTICLE_MAX_WIDTH } from "@ndla/ui";
+import { ProgrammeV2, OneColumn, ArticleWrapper, ArticleContent } from "@ndla/ui";
 import Programmes from "./Components/Programmes";
 import { AuthContext } from "../../components/AuthenticationContext";
 import LicenseBox from "../../components/license/LicenseBox";
@@ -26,39 +26,36 @@ import { useGraphQuery } from "../../util/runQueries";
 import { getAllDimensions } from "../../util/trackingUtil";
 import { transformArticle } from "../../util/transformArticle";
 
-const HiddenHeading = styled.h1`
-  ${utils.visuallyHidden};
-`;
+// TODO: Move WIDE_FRONTPAGE_ARTICLE_MAX_WIDTH to semantic tokens
+// TODO: Figure out what size this should be. Either add a variant to OneColumn or to Article.
+// The accordion in the "header" should match up with the content in the "body" of the article.
 
-const StyledMain = styled.main`
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding-bottom: ${spacing.xlarge};
-  padding-top: ${spacing.normal};
+const StyledMain = styled("main", {
+  base: {
+    paddingBlockEnd: "3xlarge",
+  },
+});
 
-  section {
-    padding: 0px;
-  }
-  nav {
-    max-width: ${WIDE_FRONTPAGE_ARTICLE_MAX_WIDTH};
-    width: 100%;
-  }
-  ${mq.range({ until: breakpoints.wide })} {
-    padding-left: ${spacing.normal};
-    padding-right: ${spacing.normal};
-  }
-  /* This is a SSR-friendly :first-child */
-  [data-wide] > section > *:not(:is(*:not(style) ~ *)) {
-    margin-top: ${spacing.xxlarge};
-  }
-`;
+const ContentWrapper = styled("div", {
+  base: {
+    paddingBlockStart: "medium",
+  },
+});
 
-const ProgrammeWrapper = styled.div`
-  max-width: ${WIDE_FRONTPAGE_ARTICLE_MAX_WIDTH};
-  width: 100%;
-`;
+const StyledOneColumn = styled(OneColumn, {
+  base: {
+    paddingBlockStart: "medium",
+    paddingBlockEnd: "surface.4xsmall",
+  },
+});
+
+const StyledHeroBackground = styled(HeroBackground, {
+  base: {
+    display: "flex",
+    justifyContent: "center",
+    height: "unset",
+  },
+});
 
 export const programmeFragment = gql`
   fragment ProgrammeFragment on ProgrammePage {
@@ -184,7 +181,7 @@ const WelcomePage = () => {
 
   return (
     <>
-      <HiddenHeading>{t("welcomePage.heading.heading")}</HiddenHeading>
+      <Heading srOnly>{t("welcomePage.heading.heading")}</Heading>
       <HelmetWithTracker title={t("htmlTitles.welcomePage")}>
         <script type="application/ld+json">{googleSearchJSONLd()}</script>
       </HelmetWithTracker>
@@ -197,11 +194,21 @@ const WelcomePage = () => {
         <meta name="keywords" content={t("meta.keywords")} />
       </SocialMediaMetadata>
       <StyledMain>
-        <ProgrammeWrapper data-testid="programme-list">
-          <Programmes programmes={programmes} />
-        </ProgrammeWrapper>
+        <Hero absolute={false} variant="brand1">
+          <StyledHeroBackground>
+            <StyledOneColumn wide data-testid="programme-list">
+              <Programmes programmes={programmes} />
+            </StyledOneColumn>
+          </StyledHeroBackground>
+        </Hero>
         {article && (
-          <FrontpageArticle isWide id={SKIP_TO_CONTENT_ID} article={{ ...article, ...article.transformedContent }} />
+          <ContentWrapper>
+            <OneColumn wide>
+              <ArticleWrapper id={SKIP_TO_CONTENT_ID}>
+                <ArticleContent>{article.transformedContent.content}</ArticleContent>
+              </ArticleWrapper>
+            </OneColumn>
+          </ContentWrapper>
         )}
       </StyledMain>
     </>

--- a/src/containers/WelcomePage/WelcomePage.tsx
+++ b/src/containers/WelcomePage/WelcomePage.tsx
@@ -26,7 +26,6 @@ import { useGraphQuery } from "../../util/runQueries";
 import { getAllDimensions } from "../../util/trackingUtil";
 import { transformArticle } from "../../util/transformArticle";
 
-// TODO: Move WIDE_FRONTPAGE_ARTICLE_MAX_WIDTH to semantic tokens
 // TODO: Figure out what size this should be. Either add a variant to OneColumn or to Article.
 // The accordion in the "header" should match up with the content in the "body" of the article.
 


### PR DESCRIPTION
Dropper `FrontpageArticle` fullstendig. Tenker heller at vi kan tilpasse vanlig `Article` eller `OneColumn` til hva nå enn bredden på dette skal være. For at denne skal se riktig ut må noen oppdatere marginer for alle frontend-komponenter. Må med andre ord få inn ting som https://github.com/NDLANO/frontend-packages/pull/2390, samt at man må publisere og bumpe pakker igjen.