### PR TITLE
Redirect if the page cannot be found

### DIFF
--- a/src/containers/AboutPage/AboutPageContent.tsx
+++ b/src/containers/AboutPage/AboutPageContent.tsx
@@ -65,17 +65,21 @@ export const findBreadcrumb = (
   menu: GQLAboutPage_FrontpageMenuFragment[],
   slug: string | undefined,
   currentPath: GQLAboutPage_FrontpageMenuFragment[] = [],
+  previousPath: GQLAboutPage_FrontpageMenuFragment[] = [],
 ): GQLAboutPage_FrontpageMenuFragment[] => {
   for (const item of menu) {
     const newPath = currentPath.concat(item);
     if (item.article.slug?.toLowerCase() === slug?.toLowerCase()) {
       return newPath;
     } else if (item.menu?.length) {
-      const foundPath = findBreadcrumb(item.menu as GQLAboutPage_FrontpageMenuFragment[], slug, newPath);
+      const foundPath = findBreadcrumb(item.menu as GQLAboutPage_FrontpageMenuFragment[], slug, newPath, currentPath);
       if (foundPath.length) {
         return foundPath;
       }
     }
+  }
+  if (previousPath?.length > 0) {
+    return previousPath.slice(0, 1);
   }
   return [];
 };


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/4106

Crash skjer fordi slug ikke gir treff på noen sider i About-menyen, og deretter prøver å finne hideLevel på noe som ikke er der. Så har gjort et forsøk på å fallbacke menyen, slik at den blir mer robust for slike tilfeller.