### PR TITLE
fix learningpath breadcrumb spacing

### DIFF
--- a/src/components/Learningpath/Learningpath.tsx
+++ b/src/components/Learningpath/Learningpath.tsx
@@ -48,6 +48,9 @@ const StyledHeroContent = styled(HeroContent)`
 
   ${mq.range({ from: breakpoints.desktop })} {
     display: flex;
+    min-height: ${spacing.xxlarge}; //TODO: Temporary fix until design is finished
+    align-items: end;
+    padding: ${spacing.small} 0 ${spacing.xxsmall};
   }
 `;
 


### PR DESCRIPTION
Liten midlertidig fiks mens vi mangler design. Avstanden er vel 6px større enn i prod men jeg fikk brukt spacing verdi 🤷‍♂️

fikser: [#4103](https://github.com/orgs/NDLANO/projects/2/views/9?pane=issue&itemId=72845463)