### PR TITLE
Log `Error` type correctly

### DIFF
--- a/src/util/handleError.ts
+++ b/src/util/handleError.ts
@@ -71,9 +71,19 @@ const getErrorLog = (
   error: ApolloError | Error | string | unknown,
   extraContext: Record<string, unknown>,
 ): ApolloError | Error | string | unknown => {
+  if (error === null) return { message: "Unknown error", ...extraContext };
+
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      stack: error.stack,
+      name: error.name,
+      ...extraContext,
+    };
+  }
+
   if (typeof error === "object") {
-    const errWithPath = error as { requestPath?: string } & object;
-    return { ...errWithPath, ...extraContext };
+    return { ...error, ...extraContext };
   }
 
   if (typeof error === "string") {

--- a/src/util/handleError.ts
+++ b/src/util/handleError.ts
@@ -71,7 +71,7 @@ const getErrorLog = (
   error: ApolloError | Error | string | unknown,
   extraContext: Record<string, unknown>,
 ): ApolloError | Error | string | unknown => {
-  if (error === null) return { message: "Unknown error", ...extraContext };
+  if (!error) return { message: `Unknown error: ${JSON.stringify(error)}`, ...extraContext };
 
   if (error instanceof Error) {
     return {


### PR DESCRIPTION
Var visst en bug her med faktisk `Error` objekter :shrug: 
De oppfører seg visst litt annerledes enn vanlige objekter
