### PR TITLE
Revert "Forsøk på å gjøre about-menyen mer robust."

### DIFF
--- a/src/containers/AboutPage/AboutPageContent.tsx
+++ b/src/containers/AboutPage/AboutPageContent.tsx
@@ -65,21 +65,17 @@ export const findBreadcrumb = (
   menu: GQLAboutPage_FrontpageMenuFragment[],
   slug: string | undefined,
   currentPath: GQLAboutPage_FrontpageMenuFragment[] = [],
-  previousPath: GQLAboutPage_FrontpageMenuFragment[] = [],
 ): GQLAboutPage_FrontpageMenuFragment[] => {
   for (const item of menu) {
     const newPath = currentPath.concat(item);
     if (item.article.slug?.toLowerCase() === slug?.toLowerCase()) {
       return newPath;
     } else if (item.menu?.length) {
-      const foundPath = findBreadcrumb(item.menu as GQLAboutPage_FrontpageMenuFragment[], slug, newPath, currentPath);
+      const foundPath = findBreadcrumb(item.menu as GQLAboutPage_FrontpageMenuFragment[], slug, newPath);
       if (foundPath.length) {
         return foundPath;
       }
     }
-  }
-  if (previousPath?.length > 0) {
-    return previousPath.slice(0, 1);
   }
   return [];
 };


### PR DESCRIPTION
Reverts NDLANO/ndla-frontend#1949

Oppdaget at dette brekker genereringen av brødsmulesti og navigering til Om ndla sider fra meny-drawer 😅 Tror vi skal se om vi finner en annen løsning på problemet!

Brødsmulesti ser man blir feil når man laster inn denne feks: https://ndla-frontend-master.vercel.app/about/jobb-hos-oss

Burde nok åpne det opprinnelige issuet igjen om denne tas inn!