### PR TITLE
Handle existing as object and not array

### DIFF
--- a/src/containers/MyNdla/folderMutations.ts
+++ b/src/containers/MyNdla/folderMutations.ts
@@ -584,10 +584,20 @@ export const useCopySharedFolderMutation = () => {
       } else {
         cache.modify({
           fields: {
-            folders: (existing = []) =>
-              existing.concat({
-                __ref: cache.identify(data.copySharedFolder),
-              }),
+            folders: (
+              { folders: existing, ...rest } = {
+                folders: [],
+                sharedFolders: [],
+                __typename: "UserFolder",
+              },
+            ) => {
+              return {
+                folders: existing.concat({
+                  __ref: cache.identify(data.copySharedFolder),
+                }),
+                ...rest,
+              };
+            },
           },
         });
       }


### PR DESCRIPTION
Fixes NDLANO/Issues#4129

Gjør det slik at du får oppdatert cache ved kopiering av mappe.
Lager branches basert på både prod og test med denne commiten putta inn.