### PR TITLE
fix resourceitem alignment

### DIFF
--- a/src/components/MyNdla/ListResource.tsx
+++ b/src/components/MyNdla/ListResource.tsx
@@ -27,7 +27,6 @@ const resourceEmbedTypeMapping = constants.resourceEmbedTypeMapping;
 const StyledListItemContent = styled(ListItemContent, {
   base: {
     flexDirection: "column",
-    placeSelf: "flex-start",
     alignItems: "center",
     justifyContent: "center",
     gap: "4xsmall",


### PR DESCRIPTION
Ser ut som den skal midtstilles [figma](https://www.figma.com/design/E4Y9nwHcDVTETrEQFxf3bD/Components-2024?node-id=683-13669&m=dev)

Burde kanskje gjøre samme på `ListItem`? Den ser litt rart ut i Storybook når "List" er valgt og tittelen er ikke sentrert med resten av innhold @Jonas-C 