### PR TITLE
fix focus bug when lazy-loading dialog

### DIFF
--- a/src/containers/Masthead/components/MastheadSearch.tsx
+++ b/src/containers/Masthead/components/MastheadSearch.tsx
@@ -277,6 +277,8 @@ const MastheadSearch = () => {
       size="xsmall"
       onOpenChange={setDialogState}
       initialFocusEl={() => inputRef.current}
+      lazyMount={false}
+      unmountOnExit={false}
     >
       <DialogTrigger asChild>
         <StyledButton variant="tertiary" aria-label={t("masthead.menu.search")} title={t("masthead.menu.search")}>

--- a/src/containers/Masthead/drawer/MastheadDrawer.tsx
+++ b/src/containers/Masthead/drawer/MastheadDrawer.tsx
@@ -213,6 +213,8 @@ const MastheadDrawer = ({ subject }: Props) => {
       open={open}
       onOpenChange={() => setOpen((prev) => !prev)}
       initialFocusEl={getHeaderElement}
+      lazyMount={false}
+      unmountOnExit={false}
     >
       <DialogTrigger asChild>
         <DrawerButton


### PR DESCRIPTION
fixes https://github.com/NDLANO/Issues/issues/4150

Liten fokus bug med Dialog når `lazyMount `og `unmountOnExit ` er `true`. Forslag til en løsning

@Jonas-C skulle sjekke om det ligger en bug i ark/zag