### PR TITLE
align content to bottom in block resource

### DIFF
--- a/src/components/MyNdla/BlockResource.tsx
+++ b/src/components/MyNdla/BlockResource.tsx
@@ -72,7 +72,7 @@ const StyledCardImage = styled(CardImage, {
 
 const StyledCardContent = styled(CardContent, {
   base: {
-    justifyContent: "space-between",
+    justifyContent: "end",
     paddingInline: "xsmall",
   },
   variants: {

--- a/src/components/MyNdla/BlockResource.tsx
+++ b/src/components/MyNdla/BlockResource.tsx
@@ -66,7 +66,7 @@ const LoadingCardRoot = styled(CardRoot, {
 
 const StyledCardImage = styled(CardImage, {
   base: {
-    height: "surface.4xsmall",
+    height: "surface.3xsmall",
   },
 });
 


### PR DESCRIPTION
Blokkressurs ser litt rart ut uten bilder. Ser litt bedre når content er alltid nederst?

![image](https://github.com/user-attachments/assets/38efe71a-2941-49bf-bb7a-2dc94696d0da)

