### PR TITLE
fix: properly pad each block in transportation pages

### DIFF
--- a/src/components/NavigationBox.tsx
+++ b/src/components/NavigationBox.tsx
@@ -52,7 +52,7 @@ export const NavigationBox = ({ heading, variant, items }: Props & NavigationSaf
   const { t } = useTranslation();
   const headingId = useId();
   return (
-    <StyledWrapper aria-labelledby={headingId}>
+    <StyledWrapper aria-labelledby={headingId} data-nav-box="">
       {heading && (
         <Heading id={headingId} asChild consumeCss textStyle="heading.small" fontWeight="bold">
           <h2>{heading}</h2>

--- a/src/components/Topic/Topic.tsx
+++ b/src/components/Topic/Topic.tsx
@@ -17,8 +17,7 @@ const TopicContent = styled("div", {
     display: "grid",
     gridTemplateColumns: "1fr",
     gap: "medium",
-    paddingBlockStart: "4xlarge",
-    paddingBlockEnd: "xsmall",
+    paddingBlock: "xsmall",
     justifyItems: "center",
     tabletWide: {
       gridTemplateColumns: "auto 360px",
@@ -68,7 +67,7 @@ const Topic = forwardRef<HTMLDivElement, TopicProps>(
     const { t } = useTranslation();
 
     return (
-      <TopicContent ref={ref}>
+      <TopicContent ref={ref} data-topic="">
         <TopicIntroductionWrapper>
           <HeadingWrapper>
             <Heading textStyle="heading.medium" id={id} tabIndex={-1}>

--- a/src/containers/SubjectPage/SubjectContainer.tsx
+++ b/src/containers/SubjectPage/SubjectContainer.tsx
@@ -54,6 +54,10 @@ const StyledTopicWrapper = styled(PageContainer, {
   base: {
     paddingBlockStart: "0",
     overflowX: "hidden",
+    // TODO: There's a bunch of tricky compositions for nested topics. This won't be necessary once we separate each topic out into their own page.
+    "& > [data-nav-box] + :is([data-resource-section], [data-topic]), > [data-resource-section] + [data-topic]": {
+      paddingBlockStart: "4xlarge",
+    },
   },
 });
 

--- a/src/containers/SubjectPage/components/SubjectTopic.tsx
+++ b/src/containers/SubjectPage/components/SubjectTopic.tsx
@@ -14,7 +14,6 @@ import { useTranslation } from "react-i18next";
 import { gql } from "@apollo/client";
 import { extractEmbedMeta } from "@ndla/article-converter";
 import { BleedPageContent, PageContent } from "@ndla/primitives";
-import { styled } from "@ndla/styled-system/jsx";
 import { useTracker } from "@ndla/tracker";
 import TopicVisualElementContent from "./TopicVisualElementContent";
 import { AuthContext } from "../../../components/AuthenticationContext";
@@ -37,15 +36,6 @@ import Resources from "../../Resources/Resources";
 const getDocumentTitle = ({ t, topic }: { t: TFunction; topic: Props["topic"] }) => {
   return htmlTitle(topic?.name, [t("htmlTitles.titleTemplate")]);
 };
-
-// Handles cases where several topics have resources.
-const StyledBleedPageContent = styled(BleedPageContent, {
-  base: {
-    "&:not(:last-child)": {
-      paddingBlockStart: "4xlarge",
-    },
-  },
-});
 
 const PAGE = "page" as const;
 
@@ -168,9 +158,9 @@ const SubjectTopic = ({
         <NavigationBox variant="secondary" heading={t("navigation.topics")} items={subTopics} />
       ) : null}
       {!!resources && (
-        <StyledBleedPageContent>
+        <BleedPageContent data-resource-section="">
           <PageContent variant="article">{resources}</PageContent>
-        </StyledBleedPageContent>
+        </BleedPageContent>
       )}
     </>
   );


### PR DESCRIPTION
Fixes https://trello.com/c/18ZSMXKy/22-lite-luft-mellom-emner-og-tittel-l%C3%A6ringsressurser

Vanskelig å ta stilling til alle mulige komposisjoner. Data-attributter ser ut til å være den greieste løsningen.