### PR TITLE
Add `DEBUG_GRAPHQL_CACHE` flag

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -112,6 +112,7 @@ export type ConfigType = {
   enableNodeBB: boolean;
   runtimeType: RuntimeType;
   isClient: boolean;
+  debugGraphQLCache: boolean;
 };
 
 const getServerSideConfig = (): ConfigType => {
@@ -144,6 +145,7 @@ const getServerSideConfig = (): ConfigType => {
     enableNodeBB: getEnvironmentVariabel("ENABLE_NODEBB", false),
     runtimeType: getEnvironmentVariabel("NODE_ENV", "development") as RuntimeType,
     isClient: false,
+    debugGraphQLCache: getEnvironmentVariabel("DEBUG_GRAPHQL_CACHE", false),
   };
 };
 

--- a/src/util/DebugInMemoryCache.ts
+++ b/src/util/DebugInMemoryCache.ts
@@ -10,6 +10,11 @@ import { OperationVariables } from "@apollo/client";
 import { Cache, InMemoryCache } from "@apollo/client/core";
 import handleError from "./handleError";
 
+/**
+ * DebugInMemoryCache extends the InMemoryCache and adds a diff method that will log an error if a partial match is found in the cache.
+ * This is useful for debugging cache issues where a part of some object is found in the cache, but not the whole object.
+ * Can be enabled with `DEBUG_GRAPHQL_CACHE=true` environment variable.
+ */
 export class DebugInMemoryCache extends InMemoryCache {
   findNestedStrings(obj: any, path: string[], error: Error) {
     for (const [key, value] of Object.entries(obj)) {

--- a/src/util/DebugInMemoryCache.ts
+++ b/src/util/DebugInMemoryCache.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2024-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { OperationVariables } from "@apollo/client";
+import { Cache, InMemoryCache } from "@apollo/client/core";
+import handleError from "./handleError";
+
+export class DebugInMemoryCache extends InMemoryCache {
+  findNestedStrings(obj: any, path: string[], error: Error) {
+    for (const [key, value] of Object.entries(obj)) {
+      if (typeof value === "string") {
+        if (path.length > 0) {
+          handleError(new Error(`Missing field in cache: [${[...path, key]}]`, { cause: error }));
+        }
+      } else {
+        this.findNestedStrings(value, [...path, key], error);
+      }
+    }
+  }
+
+  diff<TData, TVariables extends OperationVariables = any>(
+    options: Cache.DiffOptions<TData, TVariables>,
+  ): Cache.DiffResult<TData> {
+    const result = super.diff(options);
+
+    if (result.missing) {
+      result.missing.forEach((m) => {
+        this.findNestedStrings(m.missing, [], m);
+      });
+    }
+
+    return result;
+  }
+}

--- a/src/util/apiHelpers.ts
+++ b/src/util/apiHelpers.ts
@@ -11,6 +11,7 @@ import { BatchHttpLink } from "@apollo/client/link/batch-http";
 import { setContext } from "@apollo/client/link/context";
 import { onError } from "@apollo/client/link/error";
 import { getAccessToken, getFeideCookie, isAccessTokenValid, renewAuth } from "./authHelpers";
+import { DebugInMemoryCache } from "./DebugInMemoryCache";
 import handleError from "./handleError";
 import config from "../config";
 import { GQLBucketResult, GQLGroupSearch, GQLQueryFolderResourceMetaSearchArgs } from "../graphqlTypes";
@@ -187,7 +188,8 @@ const typePolicies: TypePolicies = {
 };
 
 function getCache() {
-  const cache = new InMemoryCache({ possibleTypes, typePolicies });
+  const CacheType = config.debugGraphQLCache ? DebugInMemoryCache : InMemoryCache;
+  const cache: InMemoryCache = new CacheType({ possibleTypes, typePolicies });
   if (config.isClient) {
     cache.restore(window.DATA.apolloState);
   }


### PR DESCRIPTION
Legger til `DEBUG_GRAPHQL_CACHE` flagget som tar i bruk den nye `DebugInMemoryCache`.
Alt den gjør er å logge warnings når man finner noe i cachen som mangler et felt.

Den er ikke perfekt så den blir nok litt støyete å ha enabled by default, men jeg tipper den er fin å ha når vi skal debugge hvorfor noe ikke hydreres riktig eller sånn