### PR TITLE
Fix lists license

### DIFF
--- a/src/components/MediaList/LicenseBylineDescriptionList.tsx
+++ b/src/components/MediaList/LicenseBylineDescriptionList.tsx
@@ -17,7 +17,7 @@ interface LicenseDescriptionListProps {
 const StyledList = styled("ul", {
   base: {
     listStyleType: "disc",
-    listStylePosition: "inside",
+    marginInlineStart: "medium",
   },
 });
 

--- a/src/iframe/__tests__/__snapshots__/IframeArticlePage-test.tsx.snap
+++ b/src/iframe/__tests__/__snapshots__/IframeArticlePage-test.tsx.snap
@@ -222,7 +222,7 @@ exports[`IframeArticlePage with article renderers correctly 1`] = `
                                 <div />
                               </div>
                               <ul
-                                class="li-t_disc li-pos_inside"
+                                class="li-t_disc ms_medium"
                               />
                             </div>
                           </div>


### PR DESCRIPTION
fikser: [trello](https://trello.com/c/JrMnMo0U/78-kulepunkt-har-ikke-innrykk-p%C3%A5-andre-linje-i-gjenbruksboks)