### PR TITLE
Provide more info with oembed error logs

### DIFF
--- a/src/server/routes/oembedArticleRoute.ts
+++ b/src/server/routes/oembedArticleRoute.ts
@@ -168,7 +168,7 @@ export async function oembedArticleRoute(req: express.Request) {
     const { html, title } = await getHTMLandTitle(match, req);
     return getOembedObject(req, title, html);
   } catch (error) {
-    handleError(error);
+    handleError(error, undefined, req.path);
 
     const typedError = error as { status?: number };
     const status = typedError.status || INTERNAL_SERVER_ERROR;

--- a/src/util/apiHelpers.ts
+++ b/src/util/apiHelpers.ts
@@ -12,6 +12,7 @@ import { setContext } from "@apollo/client/link/context";
 import { onError } from "@apollo/client/link/error";
 import { getAccessToken, getFeideCookie, isAccessTokenValid, renewAuth } from "./authHelpers";
 import { DebugInMemoryCache } from "./DebugInMemoryCache";
+import { StatusError } from "./error";
 import handleError from "./handleError";
 import config from "../config";
 import { GQLBucketResult, GQLGroupSearch, GQLQueryFolderResourceMetaSearchArgs } from "../graphqlTypes";
@@ -32,10 +33,6 @@ export function apiResourceUrl(path: string) {
   return apiBaseUrl + path;
 }
 
-export function createErrorPayload(status: number, message: string, json: any) {
-  return Object.assign(new Error(message), { status, json });
-}
-
 export function resolveJsonOrRejectWithError<T>(res: Response): Promise<T | undefined> {
   return new Promise((resolve, reject) => {
     if (res.ok) {
@@ -44,7 +41,9 @@ export function resolveJsonOrRejectWithError<T>(res: Response): Promise<T | unde
     return res
       .json()
       .then((json) => {
-        const payload = createErrorPayload(res.status, json.message ?? res.statusText, json);
+        const errorMessage = json.message ?? res.statusText;
+        const msg = `Got error with message '${errorMessage}' and status ${res.status} when requesting '${res.url}'`;
+        const payload = new StatusError(msg, res.status, json);
         reject(payload);
       })
       .catch(reject);

--- a/src/util/error.ts
+++ b/src/util/error.ts
@@ -13,10 +13,12 @@ export type LogLevel = "error" | "warn" | "info";
 
 export class StatusError extends Error {
   status: number | undefined;
+  json: unknown | undefined;
   logLevel: LogLevel = "error";
-  constructor(message: string, status: number) {
+  constructor(message: string, status: number, json?: unknown) {
     super(message);
     this.status = status;
+    this.json = json;
   }
 }
 


### PR DESCRIPTION
Tidligere så ble dette til nestede-logger som så sånn her ut:

```json
{"message":{"level":"error","message":"hallo"}}
```

det ble slitsomt å lese og `ndla logs` slet naturligvis litt med det.

Denne fikser problemet :smile: 