### PR TITLE
fix: Reintroduce LearningpathIframe for ndla iframes. 

### DIFF
--- a/src/components/Learningpath/LearningpathEmbed.tsx
+++ b/src/components/Learningpath/LearningpathEmbed.tsx
@@ -14,6 +14,7 @@ import { gql } from "@apollo/client";
 import { PageContent } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
 import { ArticleContent, ArticleTitle, ArticleWrapper, ExternalEmbed } from "@ndla/ui";
+import LearningpathIframe from "./LearningpathIframe";
 import config from "../../config";
 import { SKIP_TO_CONTENT_ID } from "../../constants";
 import ErrorPage from "../../containers/ErrorPage";
@@ -96,7 +97,10 @@ const LearningpathEmbed = ({ learningpathStep, skipToContentId, subjectId, bread
           subjectId,
         },
       },
-      skip: !!learningpathStep.resource?.article || (!learningpathStep.embedUrl && !learningpathStep.resource),
+      skip:
+        !!learningpathStep.resource?.article ||
+        !articleId ||
+        (!learningpathStep.embedUrl && !learningpathStep.resource),
     },
   );
 
@@ -128,6 +132,10 @@ const LearningpathEmbed = ({ learningpathStep, skipToContentId, subjectId, bread
     oembed &&
     oembed.html
   ) {
+    if (urlIsNDLAUrl(embedUrl.url)) {
+      return <LearningpathIframe url={embedUrl.url} html={oembed.html} />;
+    }
+
     return (
       <EmbedPageContent variant="content">
         <ArticleWrapper>

--- a/src/components/Learningpath/LearningpathIframe.tsx
+++ b/src/components/Learningpath/LearningpathIframe.tsx
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import parse from "html-react-parser";
+import { MutableRefObject, useEffect, useRef, useState } from "react";
+import { styled } from "@ndla/styled-system/jsx";
+
+export const urlIsNDLAApiUrl = (url: string) =>
+  /^(http|https):\/\/(ndla-frontend|www).([a-zA-Z]+.)?api.ndla.no/.test(url);
+export const urlIsNDLAEnvUrl = (url: string) => /^(http|https):\/\/(www.)?([a-zA-Z]+.)?ndla.no/.test(url);
+export const urlIsLocalNdla = (url: string) => /^http:\/\/(proxy.ndla-local|localhost):30017/.test(url);
+export const urlIsNDLAUrl = (url: string) => urlIsNDLAApiUrl(url) || urlIsNDLAEnvUrl(url) || urlIsLocalNdla(url);
+
+interface Props {
+  html: string;
+  url: string;
+}
+
+const IframeWrapper = styled("div", {
+  base: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: "100%",
+    maxWidth: "100%",
+    "& > iframe": {
+      width: "100%",
+      minHeight: "surface.medium",
+      tablet: {
+        borderRadius: "xsmall",
+      },
+    },
+  },
+});
+
+const LearningpathIframe = ({ html, url }: Props) => {
+  const iframeRef = useRef() as MutableRefObject<HTMLInputElement>;
+  const [listeningToMessages, setListeningToMessages] = useState(true);
+
+  const handleIframeResizing = (url: string) => {
+    if (urlIsNDLAUrl(url)) {
+      enableIframeMessageListener();
+    } else {
+      disableIframeMessageListener();
+    }
+  };
+
+  useEffect(() => {
+    handleIframeResizing(url);
+  });
+
+  const getIframeDOM = () => {
+    return iframeRef.current?.children[0] as HTMLIFrameElement;
+  };
+
+  const enableIframeMessageListener = () => {
+    window.addEventListener("message", handleIframeMessages);
+    setListeningToMessages(true);
+  };
+
+  const disableIframeMessageListener = () => {
+    window.removeEventListener("message", handleIframeMessages);
+    setListeningToMessages(false);
+  };
+
+  const handleScrollTo = (evt: MessageEvent) => {
+    const iframe = getIframeDOM();
+    if (iframe) {
+      const rect = iframe.getBoundingClientRect();
+      const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+
+      const top = evt.data.top + rect.top + scrollTop;
+      window.scroll({ top });
+    }
+  };
+
+  const handleResize = (evt: MessageEvent) => {
+    if (!evt.data.height) {
+      return;
+    }
+    const iframe = getIframeDOM();
+    if (iframe) {
+      const newHeight = parseInt(evt.data.height, 10);
+      iframe.style.height = `${newHeight}px`; // eslint-disable-line no-param-reassign
+    }
+  };
+
+  const handleIframeMessages = (event: MessageEvent) => {
+    const iframe = getIframeDOM();
+    /* Needed to enforce content to stay within iframe on Safari iOS */
+    if (iframe) {
+      iframe.setAttribute("scrolling", "no");
+    }
+
+    if (!listeningToMessages || !event || !event.data) {
+      return;
+    }
+
+    switch (event.data.event) {
+      case "resize":
+        handleResize(event);
+        break;
+      case "scrollTo":
+        handleScrollTo(event);
+        break;
+      default:
+        break;
+    }
+  };
+
+  return <IframeWrapper ref={iframeRef}>{parse(html)}</IframeWrapper>;
+};
+
+export default LearningpathIframe;


### PR DESCRIPTION
Fixes https://trello.com/c/59ktoriR/102-ene-steget-i-denne-l%C3%A6ringssteget-ser-litt-rart-ut-kanskje-det-er-noe-feil-med-selve-l%C3%A6ringsstien

This allows NDLA articles and embeds to control the height of the iframe, removing the need for an inner scroll bar

Other embeds rest can still use `ExternalEmbed`