### PR TITLE
Replace frameguard with frameAncestors.

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -78,6 +78,23 @@ export const routes = [
   ...privateRoutes,
 ];
 
+export const embedRoutes = [
+  "article-iframe/article/:articleId",
+  "article-iframe/:lang/article/:articleId",
+  "article-iframe/urn:topicOrResourceId/:articleId",
+  "article-iframe/:lang/urn:topicOrResourceId/:articleId",
+  "embed-iframe/video/:videoId",
+  "embed-iframe/audio/:audioId",
+  "embed-iframe/image/:imageId",
+  "embed-iframe/concept/:conceptId",
+  "embed-iframe/h5p/:h5pId",
+  "embed-iframe/:lang/video/:videoId",
+  "embed-iframe/:lang/audio/:audioId",
+  "embed-iframe/:lang/image/:imageId",
+  "embed-iframe/:lang/concept/:conceptId",
+  "embed-iframe/:lang/h5p/:h5pId",
+];
+
 export const oembedRoutes = [
   "subjects/subject:subjectId/topic:topicId",
   "subjects/subject:subjectId/topic:topicId/resource:resourceId",
@@ -110,23 +127,10 @@ export const oembedRoutes = [
   "subject:subjectId/topic:topic1/topic:topic2/topic:topic3/topic:topic4/topic:topicId/resource:resourceId",
   "subject:subjectId/topic:topic1/topic:topic2/topic:topic3/topic:topic4/topic:topicId/resource:resourceId/:stepId",
   "article/:articleId",
-  "article-iframe/article/:articleId",
-  "article-iframe/:lang/article/:articleId",
-  "article-iframe/urn:topicOrResourceId/:articleId",
-  "article-iframe/:lang/urn:topicOrResourceId/:articleId",
   "video/:videoId",
   "image/:imageId",
   "concept/:conceptId",
   "audio/:audioId",
   "h5p/:h5pId",
-  "embed-iframe/video/:videoId",
-  "embed-iframe/audio/:audioId",
-  "embed-iframe/image/:imageId",
-  "embed-iframe/concept/:conceptId",
-  "embed-iframe/h5p/:h5pId",
-  "embed-iframe/:lang/video/:videoId",
-  "embed-iframe/:lang/audio/:audioId",
-  "embed-iframe/:lang/image/:imageId",
-  "embed-iframe/:lang/concept/:conceptId",
-  "embed-iframe/:lang/h5p/:h5pId",
+  ...embedRoutes,
 ];

--- a/src/server/contentSecurityPolicy.ts
+++ b/src/server/contentSecurityPolicy.ts
@@ -234,6 +234,9 @@ const contentSecurityPolicy = {
         if (req.url?.includes("-iframe") || req.url?.includes("lti")) {
           return "*";
         }
+        if (config.ndlaEnvironment === "test") {
+          return "'self' https://tall.test.ndla.no";
+        }
         return "'self' https://tall.ndla.no";
       },
     ],

--- a/src/server/contentSecurityPolicy.ts
+++ b/src/server/contentSecurityPolicy.ts
@@ -231,13 +231,10 @@ const contentSecurityPolicy = {
     frameSrc,
     frameAncestors: [
       (req: IncomingMessage, _: ServerResponse) => {
-        if (req.url?.includes("-iframe") || req.url?.includes("lti")) {
+        if (req.url?.includes("-iframe") || req.url?.includes("/lti")) {
           return "*";
         }
-        if (config.ndlaEnvironment === "test") {
-          return "'self' https://tall.test.ndla.no";
-        }
-        return "'self' https://tall.ndla.no";
+        return "'self' https://tall.ndla.no https://tall.test.ndla.no";
       },
     ],
     styleSrc: [

--- a/src/server/contentSecurityPolicy.ts
+++ b/src/server/contentSecurityPolicy.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+import { IncomingMessage, ServerResponse } from "http";
 import config from "../config";
 
 const connectSrc = (() => {
@@ -228,7 +229,14 @@ const contentSecurityPolicy = {
     upgradeInsecureRequests: config.runtimeType === "development" || config.ndlaEnvironment === "local" ? null : [],
     scriptSrc,
     frameSrc,
-    frameAncestors: null,
+    frameAncestors: [
+      (req: IncomingMessage, _: ServerResponse) => {
+        if (req.url?.includes("-iframe") || req.url?.includes("lti")) {
+          return "*";
+        }
+        return "'self' https://tall.ndla.no";
+      },
+    ],
     styleSrc: [
       "'self'",
       "'unsafe-inline'",

--- a/src/server/contentSecurityPolicy.ts
+++ b/src/server/contentSecurityPolicy.ts
@@ -6,7 +6,9 @@
  *
  */
 import { IncomingMessage, ServerResponse } from "http";
+import { matchPath } from "react-router-dom";
 import config from "../config";
+import { embedRoutes } from "../routes";
 
 const connectSrc = (() => {
   const defaultConnectSrc = [
@@ -231,7 +233,8 @@ const contentSecurityPolicy = {
     frameSrc,
     frameAncestors: [
       (req: IncomingMessage, _: ServerResponse) => {
-        if (req.url?.includes("-iframe") || req.url?.startsWith("/lti")) {
+        const isEmbeddable = !!req.url?.length && embedRoutes.some((r) => matchPath(r, req.url || ""));
+        if (isEmbeddable || req.url?.startsWith("/lti")) {
           return "*";
         }
         return "'self' https://tall.ndla.no https://tall.test.ndla.no";

--- a/src/server/contentSecurityPolicy.ts
+++ b/src/server/contentSecurityPolicy.ts
@@ -231,7 +231,7 @@ const contentSecurityPolicy = {
     frameSrc,
     frameAncestors: [
       (req: IncomingMessage, _: ServerResponse) => {
-        if (req.url?.includes("-iframe") || req.url?.includes("/lti")) {
+        if (req.url?.includes("-iframe") || req.url?.startsWith("/lti")) {
           return "*";
         }
         return "'self' https://tall.ndla.no https://tall.test.ndla.no";

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -74,17 +74,12 @@ app.use(
     referrerPolicy: {
       policy: ["origin", "no-referrer-when-downgrade"],
     },
-    hsts: {
+    strictTransportSecurity: {
       maxAge: 31536000,
       includeSubDomains: true,
     },
     contentSecurityPolicy,
-    frameguard:
-      config.runtimeType === "development"
-        ? {
-            action: "sameorigin",
-          }
-        : { action: "deny" },
+    xFrameOptions: false,
   }),
 );
 
@@ -208,12 +203,10 @@ const iframeArticleRoute = async (req: Request) =>
   renderRoute(req, "iframe-article.html", iframeArticleTemplateHtml, "iframeArticle");
 
 app.get("/embed-iframe/:lang?/:embedType/:embedId", async (req, res, next) => {
-  res.removeHeader("X-Frame-Options");
   handleRequest(req, res, next, iframeEmbedRoute);
 });
 
 const iframeArticleCallback = async (req: Request, res: Response, next: NextFunction) => {
-  res.removeHeader("X-Frame-Options");
   handleRequest(req, res, next, iframeArticleRoute);
 };
 
@@ -223,12 +216,10 @@ app.post("/article-iframe/:lang?/article/:articleId", iframeArticleCallback);
 app.post("/article-iframe/:lang?/:taxonomyId/:articleId", iframeArticleCallback);
 
 app.post("/lti", async (req, res, next) => {
-  res.removeHeader("X-Frame-Options");
   handleRequest(req, res, next, ltiRoute);
 });
 
 app.get("/lti", async (req, res, next) => {
-  res.removeHeader("X-Frame-Options");
   handleRequest(req, res, next, ltiRoute);
 });
 


### PR DESCRIPTION
Fikser https://trello.com/c/t0ywLDVe/205-matomo-page-overlay

Bruker frame-ancestors i stedet for xFrameOptions. Dersom frameancestors er satt vil uansett nettlesere ignorere header.
For adresser med lti og -iframe i seg returneres '*' for å signalisere at alt er lov.