### PR TITLE
Fix spacing in mobileview in MastheadDrawer

### DIFF
--- a/src/containers/Masthead/drawer/DrawerPortion.tsx
+++ b/src/containers/Masthead/drawer/DrawerPortion.tsx
@@ -89,7 +89,10 @@ export const DrawerHeaderLink = styled(SafeLinkButton, {
     textStyle: "title.medium",
     fontWeight: "bold",
     paddingInline: "small",
-    paddingBlockEnd: "small",
+    paddingBlock: "xxsmall",
+    tabletDown: {
+      marginBlockStart: "xsmall",
+    },
     _currentPage: {
       borderRadius: "0",
       _before: {

--- a/src/containers/Masthead/drawer/TopicMenu.tsx
+++ b/src/containers/Masthead/drawer/TopicMenu.tsx
@@ -90,7 +90,7 @@ const TopicMenu = ({ topic, subject, onClose, topicPath, onCloseMenuPortion, add
         <DrawerListItem role="none" data-list-item>
           <DrawerHeaderLink
             variant="link"
-            aria-current={location.pathname === topic.path ? "page" : undefined}
+            aria-current={location.pathname.replaceAll("/", "") === topic.path.replaceAll("/", "") ? "page" : undefined}
             tabIndex={-1}
             role="menuitem"
             to={topic.path}


### PR DESCRIPTION
Fikser:
<img width="399" alt="Skjermbilde 2024-09-23 kl  10 09 58" src="https://github.com/user-attachments/assets/15201cd1-78d2-43d7-a485-31c8f6b83882">
