### PR TITLE
fix: update folder info text color. Use clear icon for settings menu

### DIFF
--- a/src/components/MyNdla/Folder.tsx
+++ b/src/components/MyNdla/Folder.tsx
@@ -31,6 +31,7 @@ const IconTextWrapper = styled(Text, {
     gap: "xxsmall",
     alignItems: "center",
     whiteSpace: "nowrap",
+    color: "text.subtle",
   },
 });
 

--- a/src/containers/MyNdla/components/SettingsMenu.tsx
+++ b/src/containers/MyNdla/components/SettingsMenu.tsx
@@ -176,13 +176,7 @@ const SettingsMenu = ({ menuItems, modalHeader, showSingle, elementSize = "mediu
       onOpenChange={(details) => setOpen(details.open)}
     >
       <MenuTrigger asChild ref={dropdownTriggerRef}>
-        <IconButton
-          title={title}
-          aria-label={title}
-          variant="tertiary"
-          disabled={!menuItems?.length}
-          size={elementSize}
-        >
+        <IconButton title={title} aria-label={title} variant="clear" disabled={!menuItems?.length} size={elementSize}>
           <MoreLine />
         </IconButton>
       </MenuTrigger>


### PR DESCRIPTION
Fixes https://trello.com/c/wwpJSG0v/137-feil-knappetype-og-tekstfarge-min-ndla-mapper