### PR TITLE
feat: redirect when creating a new folder

### DIFF
--- a/src/containers/MyNdla/Folders/components/FolderActionHooks.tsx
+++ b/src/containers/MyNdla/Folders/components/FolderActionHooks.tsx
@@ -66,6 +66,7 @@ export const useFolderActions = (
         },
       });
       const folder = res.data?.addFolder as GQLFolder | undefined;
+      navigate(routes.myNdla.folder(folder?.id ?? ""));
 
       if (folder) {
         toast.create({
@@ -73,10 +74,9 @@ export const useFolderActions = (
             folderName: folder.name,
           }),
         });
-        setFocusId(folder.id);
       }
     },
-    [addFolder, inToolbar, folderId, selectedFolder?.parentId, toast, t, setFocusId],
+    [addFolder, inToolbar, folderId, selectedFolder?.parentId, navigate, toast, t],
   );
 
   const onDeleteFolder = useCallback(async () => {


### PR DESCRIPTION
Focus handling when creating new folders is both hacky and difficult when on mobile. The dialog for folder creation is nested within another dialog we have no real control over. Furthermore, focus handling diverges between different browsers. Instead, redirect the user to the newly created folder.

Dette dropper egentlig bare hele fokus-debatten. Tror også dette på sikt vil sørge for at vi kan forenkle fokus-håndtering for alle andre meny-komponenter i Min NDLA.

Vet egentlig ikke helt hvem i NDLA dette må igjennom.