### PR TITLE
remove h2 element from folder

### DIFF
--- a/src/components/MyNdla/Folder.tsx
+++ b/src/components/MyNdla/Folder.tsx
@@ -144,11 +144,11 @@ export const Folder = ({
             aria-label={`${isShared ? `${t("myNdla.folder.sharing.shared")} ` : ""}${t("myNdla.folder.folder")}`}
           />
           <ListItemHeading asChild consumeCss>
-            <h2>
+            <span>
               <StyledSafeLink to={link ?? defaultLink} unstyled css={linkOverlay.raw()}>
                 {name}
               </StyledSafeLink>
-            </h2>
+            </span>
           </ListItemHeading>
         </TitleWrapper>
         <FolderInfo>


### PR DESCRIPTION
fikser https://trello.com/c/QNyLsC12/150-lenkemapper-m%C3%A5-ikke-v%C3%A6re-h2
