### PR TITLE
Improve loglevel handling of graphql-errors

### DIFF
--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -23,7 +23,7 @@ import { routes } from "../routeHelpers";
 import { privateRoutes } from "../routes";
 import { OK, BAD_REQUEST } from "../statusCodes";
 import { isAccessTokenValid } from "../util/authHelpers";
-import { BadRequestError } from "../util/error";
+import { BadRequestError } from "../util/error/StatusError";
 import { constructNewPath } from "../util/urlHelper";
 
 // To handle uncaught exceptions in async express

--- a/src/util/apiHelpers.ts
+++ b/src/util/apiHelpers.ts
@@ -12,7 +12,8 @@ import { setContext } from "@apollo/client/link/context";
 import { onError } from "@apollo/client/link/error";
 import { getAccessToken, getFeideCookie, isAccessTokenValid, renewAuth } from "./authHelpers";
 import { DebugInMemoryCache } from "./DebugInMemoryCache";
-import { StatusError } from "./error";
+import { NDLAGraphQLError, NDLANetworkError } from "./error/NDLAApolloErrors";
+import { StatusError } from "./error/StatusError";
 import handleError from "./handleError";
 import config from "../config";
 import { GQLBucketResult, GQLGroupSearch, GQLQueryFolderResourceMetaSearchArgs } from "../graphqlTypes";
@@ -224,36 +225,15 @@ export const createApolloLinks = (lang: string, versionHash?: string, requestPat
   });
 
   const errorLink = onError(({ graphQLErrors, networkError, operation }) => {
-    const operationInfo = {
-      operationName: operation.operationName,
-      variables: operation.variables,
-    };
     if (graphQLErrors) {
-      graphQLErrors.forEach(({ message, locations, path, extensions }) => {
-        if (!config.isClient || extensions?.status !== 404) {
-          handleError(`[GraphQL error]: ${message}`, requestPath, {
-            requestPath,
-            graphqlError: {
-              operationInfo,
-              message,
-              locations,
-              path,
-              extensions,
-            },
-          });
+      graphQLErrors.forEach((err) => {
+        if (!config.isClient || err.extensions?.status !== 404) {
+          handleError(new NDLAGraphQLError(err, operation), requestPath);
         }
       });
     }
     if (networkError) {
-      handleError(`[Network error]: ${networkError}`, requestPath, {
-        requestPath,
-        stack: networkError.stack,
-        networkErrorMessage: networkError.message,
-        cause: networkError.cause,
-        graphqlError: {
-          operationInfo,
-        },
-      });
+      handleError(new NDLANetworkError(networkError, operation), requestPath);
     }
   });
 

--- a/src/util/error/NDLAApolloErrors.ts
+++ b/src/util/error/NDLAApolloErrors.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2024-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { GraphQLError } from "graphql";
+import { Operation } from "@apollo/client";
+import { NetworkError } from "@apollo/client/errors";
+import { NDLAError } from "./NDLAError";
+import { getLogLevelFromStatusCode } from "../handleError";
+
+export class NDLAGraphQLError extends NDLAError {
+  constructor(baseError: GraphQLError, operation: Operation) {
+    const message = `[GraphQL error]: ${baseError.message}`;
+    super(message);
+
+    this.stack = baseError.stack;
+    const errorStatus = baseError.extensions.status;
+
+    if (typeof errorStatus === "number") {
+      this.logLevel = getLogLevelFromStatusCode(errorStatus);
+    }
+
+    const operationInfo = {
+      operationName: operation.operationName,
+      variables: operation.variables,
+    };
+
+    this.logContext = {
+      graphqlError: {
+        operationInfo,
+        message,
+        locations: baseError.locations,
+        path: baseError.path,
+        extensions: baseError.extensions,
+      },
+    };
+  }
+}
+
+export class NDLANetworkError extends NDLAError {
+  constructor(baseError: NonNullable<NetworkError>, operation: Operation) {
+    const message = `[Network error]: ${baseError.message}`;
+    super(message);
+
+    this.stack = baseError.stack;
+
+    const operationInfo = {
+      operationName: operation.operationName,
+      variables: operation.variables,
+    };
+
+    this.logContext = {
+      stack: baseError.stack,
+      networkErrorMessage: baseError.message,
+      cause: baseError.cause,
+      graphqlError: {
+        operationInfo,
+      },
+    };
+  }
+}

--- a/src/util/error/NDLAError.ts
+++ b/src/util/error/NDLAError.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2024-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import { LogLevel } from "./index";
+
+export class NDLAError extends Error {
+  logLevel: LogLevel = "error";
+  logContext: Record<string, unknown> = {};
+}

--- a/src/util/error/StatusError.ts
+++ b/src/util/error/StatusError.ts
@@ -6,12 +6,10 @@
  *
  */
 
-import { ApolloError } from "@apollo/client";
+import { LogLevel } from "./index";
+import { NDLAError } from "./NDLAError";
 
-export type ErrorType = ApolloError | Error | StatusError | BadRequestError | string | unknown;
-export type LogLevel = "error" | "warn" | "info";
-
-export class StatusError extends Error {
+export class StatusError extends NDLAError {
   status: number | undefined;
   json: unknown | undefined;
   logLevel: LogLevel = "error";

--- a/src/util/error/index.ts
+++ b/src/util/error/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2024-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { ApolloError } from "@apollo/client";
+import { NDLAError } from "./NDLAError";
+
+export type ErrorType = ApolloError | Error | NDLAError | string | unknown;
+export type LogLevel = "error" | "warn" | "info";


### PR DESCRIPTION
Oppdaget at det var en del errors som ikke er errors i test fremdeles.

Prøver å rette opp i det :smile: 
Lager `Error` typer for graphql feilene for å sende litt mer informasjon rundt :smile: 