### PR TITLE
fix: do not hyphenate overflowed titles. Instead, overflow anywhere

### DIFF
--- a/src/components/Topic/Topic.tsx
+++ b/src/components/Topic/Topic.tsx
@@ -51,7 +51,7 @@ const HeadingWrapper = styled("hgroup", {
     flexWrap: "wrap",
     alignItems: "center",
     gap: "xsmall",
-    hyphens: "auto",
+    overflowWrap: "anywhere",
   },
 });
 


### PR DESCRIPTION
Samme oppførsel som i artikkel-ingress, I guess