### PR TITLE
fix: do not show link title when a folder is not meant to be interacted with

### DIFF
--- a/src/components/MyNdla/CopyFolder.tsx
+++ b/src/components/MyNdla/CopyFolder.tsx
@@ -71,7 +71,13 @@ const CopyFolder = ({ folder, onClose }: Props) => {
         <DialogCloseButton />
       </DialogHeader>
       <StyledDialogBody>
-        <Folder variant="standalone" folder={folder} foldersCount={folderCount} link={routes.folder(folder.id)} />
+        <Folder
+          variant="standalone"
+          nonInteractive
+          folder={folder}
+          foldersCount={folderCount}
+          link={routes.folder(folder.id)}
+        />
         {examLock ? (
           <MessageBox variant="warning">
             <InformationLine />

--- a/src/components/MyNdla/CopyFolderModal.tsx
+++ b/src/components/MyNdla/CopyFolderModal.tsx
@@ -41,7 +41,13 @@ const CopyFolderModal = ({ folder, children }: Props) => {
           title={t("myNdla.loginCopyFolderPitch")}
           content={
             folder && (
-              <Folder variant="standalone" folder={folder} foldersCount={folderCount} link={routes.folder(folder.id)} />
+              <Folder
+                variant="standalone"
+                nonInteractive
+                folder={folder}
+                foldersCount={folderCount}
+                link={routes.folder(folder.id)}
+              />
             )
           }
         />

--- a/src/components/MyNdla/Folder.tsx
+++ b/src/components/MyNdla/Folder.tsx
@@ -73,6 +73,7 @@ interface Props {
   foldersCount?: FolderTotalCount;
   isFavorited?: boolean;
   link?: string;
+  nonInteractive?: boolean;
   variant?: NonNullable<ListItemVariantProps>["variant"];
 }
 
@@ -119,6 +120,7 @@ export const Folder = ({
   variant = "list",
   foldersCount,
   isFavorited,
+  nonInteractive,
   link,
 }: Props) => {
   const { t } = useTranslation();
@@ -127,7 +129,7 @@ export const Folder = ({
   const defaultLink = isFavorited ? routes.folder(id) : routes.myNdla.folder(id);
 
   return (
-    <ListItemRoot variant={variant} id={id}>
+    <ListItemRoot variant={variant} nonInteractive={nonInteractive} id={id}>
       <ListItemContent
         css={{
           alignItems: "center",
@@ -143,11 +145,15 @@ export const Folder = ({
             aria-hidden={false}
             aria-label={`${isShared ? `${t("myNdla.folder.sharing.shared")} ` : ""}${t("myNdla.folder.folder")}`}
           />
-          <ListItemHeading asChild consumeCss>
-            <StyledSafeLink to={link ?? defaultLink} unstyled css={linkOverlay.raw()}>
-              {name}
-            </StyledSafeLink>
-          </ListItemHeading>
+          {nonInteractive ? (
+            <ListItemHeading>{name}</ListItemHeading>
+          ) : (
+            <ListItemHeading asChild consumeCss>
+              <StyledSafeLink to={link ?? defaultLink} unstyled css={linkOverlay.raw()}>
+                {name}
+              </StyledSafeLink>
+            </ListItemHeading>
+          )}
         </TitleWrapper>
         <FolderInfo>
           {isShared && (

--- a/src/containers/MyNdla/Folders/components/FolderShareModalContent.tsx
+++ b/src/containers/MyNdla/Folders/components/FolderShareModalContent.tsx
@@ -72,7 +72,7 @@ const FolderShareModalContent = ({ onClose, folder, onCopyText }: FolderShareMod
         <DialogCloseButton />
       </DialogHeader>
       <StyledDialogBody>
-        <Folder folder={folder} variant="standalone" foldersCount={getTotalCountForFolder(folder)} />
+        <Folder folder={folder} nonInteractive variant="standalone" foldersCount={getTotalCountForFolder(folder)} />
         <Text textStyle="body.large">{t("myNdla.folder.sharing.description.private")}</Text>
         <Text textStyle="body.large">{t("myNdla.folder.sharing.description.shared")}</Text>
         <GapWrapper>

--- a/src/containers/SharedFolderPage/components/SaveLink.tsx
+++ b/src/containers/SharedFolderPage/components/SaveLink.tsx
@@ -69,7 +69,13 @@ export const SaveLink = ({ folder }: SaveLinkProps) => {
             <DialogCloseButton />
           </DialogHeader>
           <DialogBody>
-            <Folder variant="standalone" folder={folder} foldersCount={folderCount} link={routes.folder(folder.id)} />
+            <Folder
+              variant="standalone"
+              nonInteractive
+              folder={folder}
+              foldersCount={folderCount}
+              link={routes.folder(folder.id)}
+            />
             <MessageBox variant="warning">
               <InformationLine />
               <Text>{t("myNdla.folder.sharing.save.warning")}</Text>
@@ -88,7 +94,13 @@ export const SaveLink = ({ folder }: SaveLinkProps) => {
         <LoginModalContent
           title={t("myNdla.loginSaveFolderLinkPitch")}
           content={
-            <Folder variant="standalone" folder={folder} foldersCount={folderCount} link={routes.folder(folder.id)} />
+            <Folder
+              variant="standalone"
+              nonInteractive
+              folder={folder}
+              foldersCount={folderCount}
+              link={routes.folder(folder.id)}
+            />
           }
         />
       )}


### PR DESCRIPTION
Fixes https://trello.com/c/5tZVb69C/143-min-ndla-dialog-ved-del-mappe-klikkbar-lenke-til-siden-jeg-st%C3%A5r-p%C3%A5