### PR TITLE
zendesk har flytta

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -43,7 +43,7 @@ export const LocaleValues = ["nb", "nn", "en", "se"] as const;
 export const MastheadHeightPx = 84; // See `misc` in @ndla/core for origin
 
 export const AcquireLicensePage =
-  "https://ndla.zendesk.com/hc/no/articles/360000945552-Bruk-av-lisenser-og-lisensiering";
+  "https://support.ndla.no/hc/no/articles/360000945552-Bruk-av-lisenser-og-lisensiering";
 
 export const aboutNdlaUrl = "https://om.ndla.no/";
 


### PR DESCRIPTION
Ny url til artikkel.
Reknar med at /ndla-dev/ndla-frontend/src/server/contentSecurityPolicy.ts ikkje treng oppdaterast, sidan *.ndla.no vil dekke dette. 

Ser `export const aboutNdlaUrl = "https://om.ndla.no/";` Skal den oppdaterast og?
