### PR TITLE
Make it possible to override feide domain for cookie

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -136,7 +136,7 @@ const getServerSideConfig = (): ConfigType => {
     zendeskWidgetKey: getEnvironmentVariabel("NDLA_ZENDESK_WIDGET_KEY"),
     localGraphQLApi: getEnvironmentVariabel("LOCAL_GRAPHQL_API", false),
     saamiEnabled: getEnvironmentVariabel("SAAMI_ENABLED", false),
-    feideDomain: feideDomain(ndlaEnvironment),
+    feideDomain: getEnvironmentVariabel("FEIDE_DOMAIN", feideDomain(ndlaEnvironment)),
     matomoUrl: getEnvironmentVariabel("MATOMO_URL", "https://tall.ndla.no"),
     matomoSiteId: getEnvironmentVariabel("MATOMO_SITE_ID", ""),
     matomoTagmanagerId: getEnvironmentVariabel("MATOMO_TAGMANAGER_ID", ""),


### PR DESCRIPTION
Vi setter domain på feide_auth cookie for at ai.ndla.no skal kunne plukke den opp og bruke den for autentisering. Men når vi kjøre denne på vercel så settes denne til localhost, noko som gjør at setting av cookie feiler og innlogging ikkje godtas.
Dette gjør det mogeleg å sette feide_domain til vercel.app slik at innlogging skal fungere.