### PR TITLE
Handle recoverable errors on `ResourcePage` and `TopicWrapper`

### DIFF
--- a/src/containers/ResourcePage/ResourcePage.tsx
+++ b/src/containers/ResourcePage/ResourcePage.tsx
@@ -18,7 +18,7 @@ import { RELEVANCE_SUPPLEMENTARY, SKIP_TO_CONTENT_ID } from "../../constants";
 import { GQLResource, GQLResourcePageQuery } from "../../graphqlTypes";
 import { useUrnIds } from "../../routeHelpers";
 import { getTopicPath } from "../../util/getTopicPath";
-import { isAccessDeniedError } from "../../util/handleError";
+import { findAccessDeniedErrors } from "../../util/handleError";
 import { useGraphQuery } from "../../util/runQueries";
 import { AccessDeniedPage } from "../AccessDeniedPage/AccessDeniedPage";
 import ArticlePage, { articlePageFragments } from "../ArticlePage/ArticlePage";
@@ -101,8 +101,15 @@ const ResourcePage = () => {
     return <ContentPlaceholder variant="article" />;
   }
 
-  if (isAccessDeniedError(error)) {
-    return <AccessDeniedPage />;
+  const accessDeniedErrors = findAccessDeniedErrors(error);
+  if (accessDeniedErrors) {
+    const nonRecoverableError = accessDeniedErrors.some(
+      (e) => !e.path?.includes("coreResources") && !e.path?.includes("supplementaryResources"),
+    );
+
+    if (nonRecoverableError) {
+      return <AccessDeniedPage />;
+    }
   }
 
   if (error?.graphQLErrors.some((err) => err.extensions.status === 410) && redirectContext) {

--- a/src/containers/Resources/ResourceItem.tsx
+++ b/src/containers/Resources/ResourceItem.tsx
@@ -200,6 +200,8 @@ export const ResourceItem = ({
     return elements.length ? elements.join(" ") : undefined;
   }, [accessId, relevanceId, showAdditionalResources, teacherOnly]);
 
+  if (!learningpath && !article) return null;
+
   return (
     <li>
       <ListItemRoot

--- a/src/util/handleError.ts
+++ b/src/util/handleError.ts
@@ -24,14 +24,15 @@ if (config.runtimeType === "production" && import.meta.env.SSR) {
   });
 }
 
+type SingleGQLError = {
+  status?: number;
+  extensions?: { status?: number };
+  path?: string;
+};
+
 type UnknownGQLError = {
   status?: number;
-  graphQLErrors?:
-    | {
-        status?: number;
-        extensions?: { status?: number };
-      }[]
-    | null;
+  graphQLErrors?: SingleGQLError[] | null;
 };
 
 export const getErrorStatuses = (unknownError: ErrorType | null | undefined): number[] => {
@@ -67,6 +68,16 @@ export const isAccessDeniedError = (error: ErrorType | undefined | null): boolea
   if (!error) return false;
   const codes = getErrorStatuses(error);
   return codes.find((c) => AccessDeniedCodes.includes(c)) !== undefined;
+};
+
+export const findAccessDeniedErrors = (unknownError: ErrorType | undefined | null): SingleGQLError[] => {
+  // We cast to our own error type since we append status in graphql-api
+  const error = unknownError as UnknownGQLError | null | undefined;
+  const accessDeniedErrors = error?.graphQLErrors?.filter((gqle) => {
+    const code = gqle.status ?? gqle.extensions?.status;
+    return AccessDeniedCodes.includes(code ?? 0);
+  });
+  return accessDeniedErrors ?? [];
 };
 
 export const isNotFoundError = (error: ErrorType | undefined | null): boolean => {


### PR DESCRIPTION
Dette gjør at vi ikke lenger viser feilmelding dersom en av ressursene i en topic resulterer i en 403.
(Med mindre det er den du står på).

Forhåpentligvis så skal det ikke skje så ofte, men vi er nok litt utsatte med læringsstier siden de endrer status ved redigering(?)

Kan testes her: http://localhost:3000/subject:20/topic:1:194565/resource:1:179880?disableSSR=true
Og her: http://localhost:3000/subject:20/topic:1:194565/?disableSSR=true
