### PR TITLE
Fix: arena access

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,9 @@ import AboutPage from "./containers/AboutPage/AboutPage";
 import { AccessDeniedPage } from "./containers/AccessDeniedPage/AccessDeniedPage";
 import AllSubjectsPage from "./containers/AllSubjectsPage/AllSubjectsPage";
 import ErrorPage from "./containers/ErrorPage/ErrorPage";
+import { AdminCheck } from "./containers/MyNdla/Arena/AdminCheck";
 import ArenaAdminPage from "./containers/MyNdla/Arena/ArenaAdminPage";
+import { ArenaCheck } from "./containers/MyNdla/Arena/ArenaCheck";
 import ArenaFlagPage from "./containers/MyNdla/Arena/ArenaFlagPage";
 import ArenaNotificationPage from "./containers/MyNdla/Arena/ArenaNotificationsPage";
 import ArenaPage from "./containers/MyNdla/Arena/ArenaPage";
@@ -34,6 +36,7 @@ import ArenaUserPage from "./containers/MyNdla/ArenaUserPage";
 import FavoriteSubjectsPage from "./containers/MyNdla/FavoriteSubjects/FavoriteSubjectsPage";
 import FoldersPage from "./containers/MyNdla/Folders/FoldersPage";
 import FoldersTagsPage from "./containers/MyNdla/Folders/FoldersTagPage";
+import { LearningPathCheck } from "./containers/MyNdla/LearningPath/LearningPathCheck";
 import LearningPathPage from "./containers/MyNdla/LearningPath/LearningPathPage";
 import MyNdlaLayout from "./containers/MyNdla/MyNdlaLayout";
 import MyNdlaPage from "./containers/MyNdla/MyNdlaPage";
@@ -165,19 +168,23 @@ const AppRoutes = ({ base }: AppProps) => {
                     <Route path="tag/:tag" element={<PrivateRoute element={<FoldersTagsPage />} />} />
                     <Route path=":folderId" element={<PrivateRoute element={<FoldersPage />} />} />
                   </Route>
-                  <Route path="arena">
+                  <Route path="arena" element={<ArenaCheck />}>
                     <Route index element={<PrivateRoute element={<ArenaPage />} />} />
-                    <Route path="category/new" element={<PrivateRoute element={<NewCategoryPage />} />} />
+                    <Route path="category/new" element={<AdminCheck />}>
+                      <Route index element={<PrivateRoute element={<NewCategoryPage />} />} />
+                    </Route>
                     <Route path="category/:categoryId">
                       <Route index element={<PrivateRoute element={<TopicPage />} />} />
-                      <Route path="edit" element={<PrivateRoute element={<CategoryEditPage />} />} />
+                      <Route path="edit" element={<AdminCheck />}>
+                        <Route index element={<PrivateRoute element={<CategoryEditPage />} />} />
+                      </Route>
                       <Route path="topic/new" element={<PrivateRoute element={<NewTopicPage />} />} />
                     </Route>
                     <Route path="topic/:topicId" element={<PrivateRoute element={<PostsPage />} />} />
                     <Route path="notifications" element={<PrivateRoute element={<ArenaNotificationPage />} />} />
                     <Route path="user/:username" element={<PrivateRoute element={<ArenaUserPage />} />} />
                   </Route>
-                  <Route path="admin">
+                  <Route path="admin" element={<AdminCheck />}>
                     <Route index element={<PrivateRoute element={<ArenaAdminPage />} />} />
                     <Route path="users" element={<PrivateRoute element={<ArenaUserListPage />} />} />
                     <Route path="flags">
@@ -185,9 +192,11 @@ const AppRoutes = ({ base }: AppProps) => {
                       <Route path=":postId" element={<PrivateRoute element={<ArenaSingleFlagPage />} />} />
                     </Route>
                   </Route>
-                  <Route path="learningpaths">
-                    <Route index element={<PrivateRoute element={<LearningPathPage />} />} />
-                  </Route>
+                  {config.learningpathEnabled && (
+                    <Route path="learningpaths" element={<LearningPathCheck />}>
+                      <Route index element={<PrivateRoute element={<LearningPathPage />} />} />
+                    </Route>
+                  )}
                   <Route path="subjects" element={<PrivateRoute element={<FavoriteSubjectsPage />} />} />
                   <Route path="profile" element={<PrivateRoute element={<MyProfilePage />} />} />
                 </Route>

--- a/src/components/AuthenticationContext.tsx
+++ b/src/components/AuthenticationContext.tsx
@@ -109,10 +109,10 @@ const AuthenticationContext = ({ children }: Props) => {
       window.setTimeout(() => {
         setAuthenticated(false);
       }, timeoutMillis);
-    } else {
+    } else if (!myNdlaData.loading) {
       setLoaded(true);
     }
-  }, [myNdlaData.data]);
+  }, [myNdlaData]);
 
   const login = useCallback(() => setAuthenticated(true), []);
   const logout = useCallback(() => setAuthenticated(false), []);

--- a/src/containers/ErrorPage/ForbiddenPage.tsx
+++ b/src/containers/ErrorPage/ForbiddenPage.tsx
@@ -6,8 +6,9 @@
  *
  */
 
+import { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { LinkProps, useNavigate } from "react-router-dom";
 import {
   Button,
   ErrorMessageActions,
@@ -24,11 +25,13 @@ import { SKIP_TO_CONTENT_ID } from "../../constants";
 
 interface Props {
   applySkipToContentId?: boolean;
+  navigationLink?: LinkProps & { children: ReactNode };
 }
 
-export const Forbidden = ({ applySkipToContentId }: Props) => {
+export const Forbidden = ({ applySkipToContentId, navigationLink }: Props) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const { children, ...linkProps } = navigationLink ?? { to: "/", children: t("errorMessage.goToFrontPage") };
 
   return (
     <Status code={403}>
@@ -42,9 +45,9 @@ export const Forbidden = ({ applySkipToContentId }: Props) => {
           <ErrorMessageDescription>{t("forbiddenPage.errorDescription")}</ErrorMessageDescription>
         </ErrorMessageContent>
         <ErrorMessageActions>
-          <SafeLink to="/">{t("errorMessage.goToFrontPage")}</SafeLink>
+          <SafeLink {...linkProps}>{children}</SafeLink>
           <Button variant="link" onClick={() => navigate(-1)}>
-            {t("errorMessage.goBack")}
+            {t("errorMessage.back")}
           </Button>
         </ErrorMessageActions>
       </ErrorMessageRoot>
@@ -52,11 +55,11 @@ export const Forbidden = ({ applySkipToContentId }: Props) => {
   );
 };
 
-export const ForbiddenPage = () => {
+export const ForbiddenPage = (props: Props) => {
   return (
     <PageContainer asChild consumeCss>
       <main>
-        <Forbidden applySkipToContentId={true} />
+        <Forbidden applySkipToContentId={true} {...props} />
       </main>
     </PageContainer>
   );

--- a/src/containers/ErrorPage/ForbiddenPage.tsx
+++ b/src/containers/ErrorPage/ForbiddenPage.tsx
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2024-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
+import {
+  Button,
+  ErrorMessageActions,
+  ErrorMessageContent,
+  ErrorMessageDescription,
+  ErrorMessageRoot,
+  ErrorMessageTitle,
+} from "@ndla/primitives";
+import { SafeLink } from "@ndla/safelink";
+import { HelmetWithTracker } from "@ndla/tracker";
+import { Status } from "../../components";
+import { PageContainer } from "../../components/Layout/PageContainer";
+import { SKIP_TO_CONTENT_ID } from "../../constants";
+
+interface Props {
+  applySkipToContentId?: boolean;
+}
+
+export const Forbidden = ({ applySkipToContentId }: Props) => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  return (
+    <Status code={403}>
+      <ErrorMessageRoot>
+        <HelmetWithTracker title={t("htmlTitles.forbidden")} />
+        <img src={"/static/not-exist.gif"} alt={t("errorMessage.title")} />
+        <ErrorMessageContent>
+          <ErrorMessageTitle id={applySkipToContentId ? SKIP_TO_CONTENT_ID : undefined}>
+            {t("forbiddenPage.title")}
+          </ErrorMessageTitle>
+          <ErrorMessageDescription>{t("forbiddenPage.errorDescription")}</ErrorMessageDescription>
+        </ErrorMessageContent>
+        <ErrorMessageActions>
+          <SafeLink to="/">{t("errorMessage.goToFrontPage")}</SafeLink>
+          <Button variant="link" onClick={() => navigate(-1)}>
+            {t("errorMessage.goBack")}
+          </Button>
+        </ErrorMessageActions>
+      </ErrorMessageRoot>
+    </Status>
+  );
+};
+
+export const ForbiddenPage = () => {
+  return (
+    <PageContainer asChild consumeCss>
+      <main>
+        <Forbidden applySkipToContentId={true} />
+      </main>
+    </PageContainer>
+  );
+};

--- a/src/containers/MyNdla/Arena/AdminCheck.tsx
+++ b/src/containers/MyNdla/Arena/AdminCheck.tsx
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2024-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { useContext } from "react";
+import { useTranslation } from "react-i18next";
+import { Outlet } from "react-router-dom";
+import { AuthContext } from "../../../components/AuthenticationContext";
+import { PageSpinner } from "../../../components/PageSpinner";
+import { routes } from "../../../routeHelpers";
+import { ForbiddenPage } from "../../ErrorPage/ForbiddenPage";
+
+export const AdminCheck = () => {
+  const { t } = useTranslation();
+  const { authContextLoaded, authenticated, user } = useContext(AuthContext);
+
+  if (!authContextLoaded || (authenticated && !user)) return <PageSpinner />;
+
+  if (!authenticated || !user || !user.arenaEnabled || !user.isModerator) {
+    return <ForbiddenPage navigationLink={{ to: routes.myNdla.root, children: t("myNdla.goToMyNdla") }} />;
+  }
+
+  return <Outlet />;
+};

--- a/src/containers/MyNdla/Arena/ArenaAdminPage.tsx
+++ b/src/containers/MyNdla/Arena/ArenaAdminPage.tsx
@@ -6,26 +6,16 @@
  *
  */
 
-import { useContext } from "react";
 import { useTranslation } from "react-i18next";
-import { Navigate } from "react-router-dom";
 import { UserLine, AlertLine } from "@ndla/icons/common";
 import { Heading, Text } from "@ndla/primitives";
 import { HelmetWithTracker } from "@ndla/tracker";
 import AdminNavLink from "./components/AdminNavLink";
-import { AuthContext } from "../../../components/AuthenticationContext";
-import { PageSpinner } from "../../../components/PageSpinner";
 import { SKIP_TO_CONTENT_ID } from "../../../constants";
-import { routes } from "../../../routeHelpers";
 import MyNdlaPageWrapper from "../components/MyNdlaPageWrapper";
 
 const ArenaAdminPage = () => {
   const { t } = useTranslation();
-  const { authContextLoaded, authenticated, user } = useContext(AuthContext);
-
-  if (!authContextLoaded) return <PageSpinner />;
-
-  if (!authenticated || (user && !(user.arenaEnabled || user.isModerator))) return <Navigate to={routes.myNdla.root} />;
 
   return (
     <MyNdlaPageWrapper>

--- a/src/containers/MyNdla/Arena/ArenaCheck.tsx
+++ b/src/containers/MyNdla/Arena/ArenaCheck.tsx
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2024-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { useContext } from "react";
+import { useTranslation } from "react-i18next";
+import { Outlet } from "react-router-dom";
+import { AuthContext } from "../../../components/AuthenticationContext";
+import { PageSpinner } from "../../../components/PageSpinner";
+import { routes } from "../../../routeHelpers";
+import { ForbiddenPage } from "../../ErrorPage/ForbiddenPage";
+
+export const ArenaCheck = () => {
+  const { t } = useTranslation();
+  const { authContextLoaded, authenticated, user } = useContext(AuthContext);
+
+  if (!authContextLoaded) return <PageSpinner />;
+
+  if (!authenticated || !user || !user.arenaEnabled) {
+    return <ForbiddenPage navigationLink={{ to: routes.myNdla.root, children: t("myNdla.goToMyNdla") }} />;
+  }
+
+  return <Outlet />;
+};

--- a/src/containers/MyNdla/Arena/ArenaFlagPage.tsx
+++ b/src/containers/MyNdla/Arena/ArenaFlagPage.tsx
@@ -6,27 +6,16 @@
  *
  */
 
-import { useContext } from "react";
 import { useTranslation } from "react-i18next";
-import { Navigate } from "react-router-dom";
 import { Heading, Text } from "@ndla/primitives";
 import { HelmetWithTracker } from "@ndla/tracker";
 import FlaggedPosts from "./components/FlaggedPosts";
-import { AuthContext } from "../../../components/AuthenticationContext";
-import { PageSpinner } from "../../../components/PageSpinner";
 import { SKIP_TO_CONTENT_ID } from "../../../constants";
-import { routes } from "../../../routeHelpers";
 import MyNdlaBreadcrumb from "../components/MyNdlaBreadcrumb";
 import MyNdlaPageWrapper from "../components/MyNdlaPageWrapper";
 
 const ArenaFlagPage = () => {
   const { t } = useTranslation();
-  const { authContextLoaded, authenticated, user } = useContext(AuthContext);
-
-  if (!authContextLoaded) return <PageSpinner />;
-
-  if (!authenticated || (user && !(user.arenaEnabled || user.isModerator)))
-    return <Navigate to={routes.myNdla.arena} />;
 
   return (
     <MyNdlaPageWrapper>

--- a/src/containers/MyNdla/Arena/ArenaNotificationsPage.tsx
+++ b/src/containers/MyNdla/Arena/ArenaNotificationsPage.tsx
@@ -6,16 +6,12 @@
  *
  */
 
-import { useCallback, useContext } from "react";
+import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { Navigate } from "react-router-dom";
 import { Button } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
 import { HelmetWithTracker } from "@ndla/tracker";
 import { useArenaMarkNotificationsAsRead, useTemporaryArenaNotifications } from "./components/temporaryNodebbHooks";
-import { AuthContext } from "../../../components/AuthenticationContext";
-import { PageSpinner } from "../../../components/PageSpinner";
-import { routes } from "../../../routeHelpers";
 import MyNdlaBreadcrumb from "../components/MyNdlaBreadcrumb";
 import MyNdlaPageWrapper from "../components/MyNdlaPageWrapper";
 import MyNdlaTitle from "../components/MyNdlaTitle";
@@ -39,7 +35,6 @@ const StyledMyNdlaPageWrapper = styled(MyNdlaPageWrapper, {
 
 const ArenaNotificationPage = () => {
   const { t } = useTranslation();
-  const { authContextLoaded, authenticated, user } = useContext(AuthContext);
   const { notifications } = useTemporaryArenaNotifications();
   const { markNotificationsAsRead } = useArenaMarkNotificationsAsRead();
 
@@ -52,8 +47,6 @@ const ArenaNotificationPage = () => {
     });
   }, [notifications, markNotificationsAsRead]);
 
-  if (!authContextLoaded) return <PageSpinner />;
-  if (!authenticated || (user && !user.arenaEnabled)) return <Navigate to={routes.myNdla.arena} />;
   return (
     <StyledMyNdlaPageWrapper>
       <HelmetWithTracker title={t("myNdla.arena.notification.myNotification")} />

--- a/src/containers/MyNdla/Arena/ArenaPage.tsx
+++ b/src/containers/MyNdla/Arena/ArenaPage.tsx
@@ -9,7 +9,6 @@
 import parse from "html-react-parser";
 import { useContext, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Navigate } from "react-router-dom";
 import { AddLine } from "@ndla/icons/action";
 import { Button, Text, Heading } from "@ndla/primitives";
 import { SafeLink, SafeLinkButton } from "@ndla/safelink";
@@ -20,7 +19,6 @@ import { useArenaCategories } from "./components/temporaryNodebbHooks";
 import { AuthContext } from "../../../components/AuthenticationContext";
 import { PageSpinner } from "../../../components/PageSpinner";
 import { SKIP_TO_CONTENT_ID } from "../../../constants";
-import { routes } from "../../../routeHelpers";
 import { getAllDimensions } from "../../../util/trackingUtil";
 import MyNdlaPageWrapper from "../components/MyNdlaPageWrapper";
 import { MenuItemProps } from "../components/SettingsMenu";
@@ -59,22 +57,19 @@ const ArenaPage = () => {
   const { t } = useTranslation();
   const { loading, arenaCategories, refetch: refetchCategories } = useArenaCategories();
   const { trackPageView } = useTracker();
-  const { user, authContextLoaded, authenticated } = useContext(AuthContext);
+  const { user } = useContext(AuthContext);
   const [isEditing, setIsEditing] = useState(false);
 
   useEffect(() => {
-    if (!authContextLoaded || !user?.arenaEnabled) return;
     trackPageView({
       title: t("htmlTitles.arenaPage"),
       dimensions: getAllDimensions({ user }),
     });
-  }, [authContextLoaded, t, trackPageView, user]);
+  }, [t, trackPageView, user]);
 
-  if (loading || !authContextLoaded) {
+  if (loading) {
     return <PageSpinner />;
   }
-
-  if (!authenticated || (user && !user.arenaEnabled)) return <Navigate to={routes.myNdla.root} />;
 
   const menuItems: MenuItemProps[] = [
     {

--- a/src/containers/MyNdla/Arena/ArenaSingleFlagPage.tsx
+++ b/src/containers/MyNdla/Arena/ArenaSingleFlagPage.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import { useContext } from "react";
 import { useTranslation } from "react-i18next";
 import { Navigate, useParams } from "react-router-dom";
 import { Heading, Text } from "@ndla/primitives";
@@ -15,7 +14,6 @@ import { styled } from "@ndla/styled-system/jsx";
 import { HelmetWithTracker } from "@ndla/tracker";
 import Flags from "./components/FlagCard";
 import FlaggedPostCard from "./components/FlaggedPostCard";
-import { AuthContext } from "../../../components/AuthenticationContext";
 import { PageSpinner } from "../../../components/PageSpinner";
 import { routes } from "../../../routeHelpers";
 import { useArenaPostInContext } from "../arenaQueries";
@@ -40,14 +38,10 @@ const ArenaSingleFlagPage = () => {
     },
     skip: !Number(postId),
   });
-  const { authContextLoaded, authenticated, user } = useContext(AuthContext);
 
-  if (loading || !authContextLoaded) return <PageSpinner />;
+  if (loading) return <PageSpinner />;
 
   const flaggedPost = topic?.posts?.items[0];
-
-  if (!authenticated || (user && !(user.arenaEnabled || user.isModerator)))
-    return <Navigate to={routes.myNdla.arena} />;
 
   if (!postId || !topic || !flaggedPost) return <Navigate to={"/404"} replace />;
 

--- a/src/containers/MyNdla/Arena/ArenaUserListPage.tsx
+++ b/src/containers/MyNdla/Arena/ArenaUserListPage.tsx
@@ -6,29 +6,16 @@
  *
  */
 
-import { useContext } from "react";
 import { useTranslation } from "react-i18next";
-import { Navigate } from "react-router-dom";
 import { Heading, Text } from "@ndla/primitives";
 import { HelmetWithTracker } from "@ndla/tracker";
 import Users from "./components/Users";
-import { AuthContext } from "../../../components/AuthenticationContext";
-import { PageSpinner } from "../../../components/PageSpinner";
 import { SKIP_TO_CONTENT_ID } from "../../../constants";
-import { routes } from "../../../routeHelpers";
 import MyNdlaBreadcrumb from "../components/MyNdlaBreadcrumb";
 import MyNdlaPageWrapper from "../components/MyNdlaPageWrapper";
 
 const ArenaFlagPage = () => {
   const { t } = useTranslation();
-  const { authContextLoaded, authenticated, user } = useContext(AuthContext);
-
-  if (!authContextLoaded) {
-    return <PageSpinner />;
-  }
-
-  if (!authenticated || (user && !(user.arenaEnabled || user.isModerator)))
-    return <Navigate to={routes.myNdla.arena} />;
 
   return (
     <MyNdlaPageWrapper>

--- a/src/containers/MyNdla/Arena/CategoryEditPage.tsx
+++ b/src/containers/MyNdla/Arena/CategoryEditPage.tsx
@@ -30,15 +30,14 @@ const CategoryEditPage = () => {
   const navigate = useNavigate();
   const { loading, arenaCategory } = useArenaCategory(categoryId);
   const updateCategory = useEditArenaCategory();
-  const { user, authContextLoaded } = useContext(AuthContext);
+  const { user } = useContext(AuthContext);
 
   useEffect(() => {
-    if (!authContextLoaded || !user?.arenaEnabled || !user?.isModerator) return;
     trackPageView({
       title: t("htmlTitles.arenaNewCategoryPage"),
       dimensions: getAllDimensions({ user }),
     });
-  }, [authContextLoaded, t, trackPageView, user]);
+  }, [t, trackPageView, user]);
 
   const onSave = useCallback(
     async (values: Partial<INewCategory>) => {
@@ -64,10 +63,8 @@ const CategoryEditPage = () => {
     else navigate(routes.myNdla.arena);
   }, [categoryId, navigate]);
 
-  if (loading || !authContextLoaded) return <PageSpinner />;
+  if (loading) return <PageSpinner />;
   if (!categoryId) return <Navigate to={routes.myNdla.arena} />;
-  if (user && !(user.isModerator || user.arenaEnabled))
-    return <Navigate to={routes.myNdla.arenaCategory(Number(categoryId))} />;
 
   return (
     <MyNdlaPageWrapper>

--- a/src/containers/MyNdla/Arena/NewCategoryPage.tsx
+++ b/src/containers/MyNdla/Arena/NewCategoryPage.tsx
@@ -8,14 +8,13 @@
 
 import { useCallback, useContext, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { Navigate, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { Heading } from "@ndla/primitives";
 import { HelmetWithTracker, useTracker } from "@ndla/tracker";
 import { INewCategory } from "@ndla/types-backend/myndla-api";
 import ArenaCategoryForm from "./components/ArenaCategoryForm";
 import { ArenaFormWrapper } from "./components/ArenaForm";
 import { AuthContext } from "../../../components/AuthenticationContext";
-import { PageSpinner } from "../../../components/PageSpinner";
 import { routes } from "../../../routeHelpers";
 import { getAllDimensions } from "../../../util/trackingUtil";
 import { useCreateArenaCategory } from "../arenaMutations";
@@ -27,15 +26,14 @@ export const NewCategoryPage = () => {
   const { trackPageView } = useTracker();
   const navigate = useNavigate();
   const newCategoryMutation = useCreateArenaCategory();
-  const { user, authContextLoaded, authenticated } = useContext(AuthContext);
+  const { user } = useContext(AuthContext);
 
   useEffect(() => {
-    if (!authContextLoaded || !user?.arenaEnabled || !user?.isModerator) return;
     trackPageView({
       title: t("htmlTitles.arenaNewCategoryPage"),
       dimensions: getAllDimensions({ user }),
     });
-  }, [authContextLoaded, t, trackPageView, user]);
+  }, [t, trackPageView, user]);
 
   const onSave = useCallback(
     async (values: Partial<INewCategory>) => {
@@ -56,9 +54,6 @@ export const NewCategoryPage = () => {
   );
 
   const onAbort = useCallback(() => navigate(routes.myNdla.arena), [navigate]);
-
-  if (!authContextLoaded) return <PageSpinner />;
-  if (!authenticated || (user && !user.arenaEnabled)) return <Navigate to={routes.myNdla.arena} />;
 
   return (
     <MyNdlaPageWrapper>

--- a/src/containers/MyNdla/Arena/NewTopicPage.tsx
+++ b/src/containers/MyNdla/Arena/NewTopicPage.tsx
@@ -8,7 +8,7 @@
 
 import { useCallback, useContext, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { Navigate, useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { Heading } from "@ndla/primitives";
 import { HelmetWithTracker, useTracker } from "@ndla/tracker";
 import ArenaForm, { ArenaFormValues, ArenaFormWrapper } from "./components/ArenaForm";
@@ -27,15 +27,14 @@ export const NewTopicPage = () => {
   const navigate = useNavigate();
   const arenaTopicMutation = useArenaCreateTopic(categoryId);
   const { loading, arenaCategory } = useArenaCategory(categoryId);
-  const { user, authContextLoaded, authenticated } = useContext(AuthContext);
+  const { user, authContextLoaded } = useContext(AuthContext);
 
   useEffect(() => {
-    if (!authContextLoaded || !user?.arenaEnabled || !loading) return;
     trackPageView({
       title: t("htmlTitles.arenaNewTopicPage"),
       dimensions: getAllDimensions({ user }),
     });
-  }, [arenaCategory?.title, authContextLoaded, loading, t, trackPageView, user]);
+  }, [arenaCategory?.title, loading, t, trackPageView, user]);
 
   const onSave = useCallback(
     async (values: Partial<ArenaFormValues>) => {
@@ -65,7 +64,6 @@ export const NewTopicPage = () => {
   }, [categoryId, navigate]);
 
   if (!authContextLoaded || loading) return <PageSpinner />;
-  if (!authenticated || (user && !user.arenaEnabled)) return <Navigate to={routes.myNdla.arena} />;
 
   const parentCrumbs =
     arenaCategory?.breadcrumbs?.map((crumb) => ({ name: crumb.title, id: `category/${crumb.id}` })) ?? [];

--- a/src/containers/MyNdla/Arena/PostsPage.tsx
+++ b/src/containers/MyNdla/Arena/PostsPage.tsx
@@ -8,7 +8,7 @@
 
 import { useCallback, useContext, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Navigate, useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { Button } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
 import { HelmetWithTracker, useTracker } from "@ndla/tracker";
@@ -61,7 +61,7 @@ const PostsPage = () => {
   const userAgent = useUserAgent();
   const { arenaCategory } = useArenaCategory(arenaTopic?.categoryId?.toString());
   const { trackPageView } = useTracker();
-  const { user, authContextLoaded, authenticated } = useContext(AuthContext);
+  const { user } = useContext(AuthContext);
 
   const [subscribeToTopic] = useArenaFollowTopicMutation();
   const [unsubscribeFromTopic] = useArenaUnfollowTopicMutation();
@@ -101,12 +101,11 @@ const PostsPage = () => {
   }, [arenaTopic, unsubscribeFromTopic, toast, t, subscribeToTopic]);
 
   useEffect(() => {
-    if (!authContextLoaded || !user?.arenaEnabled || loading) return;
     trackPageView({
       title: t("htmlTitles.arenaPostPage", { name: arenaTopic?.title ?? "" }),
       dimensions: getAllDimensions({ user }),
     });
-  }, [arenaTopic?.title, authContextLoaded, loading, t, trackPageView, user]);
+  }, [arenaTopic?.title, loading, t, trackPageView, user]);
 
   useEffect(() => {
     if (document.getElementById(`post-${focusId}`)) {
@@ -132,8 +131,7 @@ const PostsPage = () => {
     arenaCategory?.breadcrumbs?.map((crumb) => ({ name: crumb.title, id: `category/${crumb.id}` })) ?? [];
   const crumbs = [...parentCrumbs, { name: arenaTopic?.title ?? "", id: topicId ?? "" }];
 
-  if (loading || !authContextLoaded || !arenaTopic?.posts?.items) return <PageSpinner />;
-  if (!authenticated || (user && !user.arenaEnabled)) return <Navigate to={routes.myNdla.root} />;
+  if (loading || !arenaTopic?.posts?.items) return <PageSpinner />;
 
   return (
     <StyledMyNdlaPageWrapper>

--- a/src/containers/MyNdla/Arena/TopicPage.tsx
+++ b/src/containers/MyNdla/Arena/TopicPage.tsx
@@ -90,19 +90,17 @@ const TopicPage = () => {
   const { trackPageView } = useTracker();
 
   const { loading, arenaCategory, refetch: refetchCategory } = useArenaCategory(categoryId);
-  const { user, authContextLoaded, authenticated } = useContext(AuthContext);
+  const { user } = useContext(AuthContext);
   const [isEditing, setIsEditing] = useState(false);
 
   useEffect(() => {
-    if (!authContextLoaded || !user?.arenaEnabled || !loading) return;
     trackPageView({
       title: t("htmlTitles.arenaTopicPage", { name: arenaCategory?.title }),
       dimensions: getAllDimensions({ user }),
     });
-  }, [arenaCategory?.title, authContextLoaded, loading, t, trackPageView, user]);
+  }, [arenaCategory?.title, loading, t, trackPageView, user]);
 
-  if (loading || !authContextLoaded) return <PageSpinner />;
-  if (!authenticated || (user && !user.arenaEnabled)) return <Navigate to={routes.myNdla.root} />;
+  if (loading) return <PageSpinner />;
   if (!arenaCategory) return <Navigate to={routes.myNdla.arena} />;
   const crumbs = arenaCategory.breadcrumbs?.map((crumb) => ({ name: crumb.title, id: `category/${crumb.id}` })) ?? [];
   const showCategories = !!arenaCategory.subcategories?.length || user?.isModerator;

--- a/src/containers/MyNdla/LearningPath/LearningPathCheck.tsx
+++ b/src/containers/MyNdla/LearningPath/LearningPathCheck.tsx
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2024-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { useContext } from "react";
+import { useTranslation } from "react-i18next";
+import { Outlet } from "react-router-dom";
+import { AuthContext } from "../../../components/AuthenticationContext";
+import { PageSpinner } from "../../../components/PageSpinner";
+import { routes } from "../../../routeHelpers";
+import { ForbiddenPage } from "../../ErrorPage/ForbiddenPage";
+
+export const LearningPathCheck = () => {
+  const { t } = useTranslation();
+  const { authContextLoaded, authenticated, user } = useContext(AuthContext);
+
+  if (!authContextLoaded) return <PageSpinner />;
+
+  if (!authenticated || !user || user.role !== "employee") {
+    return <ForbiddenPage navigationLink={{ to: routes.myNdla.root, children: t("myNdla.goToMyNdla") }} />;
+  }
+
+  return <Outlet />;
+};

--- a/src/containers/MyNdla/LearningPath/LearningPathPage.tsx
+++ b/src/containers/MyNdla/LearningPath/LearningPathPage.tsx
@@ -8,30 +8,21 @@
 
 import { useContext, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { Navigate } from "react-router-dom";
 import { Heading } from "@ndla/primitives";
 import { HelmetWithTracker, useTracker } from "@ndla/tracker";
 import { AuthContext } from "../../../components/AuthenticationContext";
-import { PageSpinner } from "../../../components/PageSpinner";
-import config from "../../../config";
 import { SKIP_TO_CONTENT_ID } from "../../../constants";
-import { routes } from "../../../routeHelpers";
 import { getAllDimensions } from "../../../util/trackingUtil";
 import MyNdlaPageWrapper from "../components/MyNdlaPageWrapper";
 
 const LearningPathPage = () => {
   const { t } = useTranslation();
   const { trackPageView } = useTracker();
-  const { authContextLoaded, authenticated, user } = useContext(AuthContext);
+  const { user } = useContext(AuthContext);
 
   useEffect(() => {
-    if (!authContextLoaded) return;
     trackPageView({ title: t("htmlTitles.learningpathPage"), dimensions: getAllDimensions({ user }) });
-  }, [authContextLoaded, t, trackPageView, user]);
-
-  if (!authContextLoaded) return <PageSpinner />;
-  if (!authenticated || !config.learningpathEnabled || (user && !(user.role === "employee")))
-    return <Navigate to={routes.myNdla.root} />;
+  }, [t, trackPageView, user]);
 
   return (
     <MyNdlaPageWrapper>

--- a/src/messages/messagesEN.ts
+++ b/src/messages/messagesEN.ts
@@ -95,6 +95,7 @@ const messages = {
       error: "An error occured",
       userUpdated: "User updated",
     },
+    goToMyNdla: "Go to My NDLA",
   },
   ndlaFilm: {
     films: "Films",

--- a/src/messages/messagesEN.ts
+++ b/src/messages/messagesEN.ts
@@ -16,6 +16,7 @@ const messages = {
     subjectsPage: `All subjects - ${titleTemplate}`,
     searchPage: `Search - ${titleTemplate}`,
     notFound: `Page not found - ${titleTemplate}`,
+    forbidden: `Access denied - ${titleTemplate}`,
     unpublished: `Resource is unpublished - ${titleTemplate}`,
     accessDenied: `Access denied - ${titleTemplate}`,
     subject: "Subject",
@@ -195,6 +196,10 @@ const messages = {
   movedResourcePage: {
     title: "The page has moved, but you can find it here:",
     openInSubject: "Open the article in a subject:",
+  },
+  forbiddenPage: {
+    title: "Access denied",
+    errorDescription: "You do not have access to this page.",
   },
 };
 

--- a/src/messages/messagesNB.ts
+++ b/src/messages/messagesNB.ts
@@ -95,6 +95,7 @@ const messages = {
       error: "En feil oppstod",
       userUpdated: "Bruker oppdatert",
     },
+    goToMyNdla: "Gå til Min NDLA",
   },
   ndlaFilm: {
     films: "Filmer",

--- a/src/messages/messagesNB.ts
+++ b/src/messages/messagesNB.ts
@@ -16,6 +16,7 @@ const messages = {
     subjectsPage: `Alle fag - ${titleTemplate}`,
     searchPage: `Søk - ${titleTemplate}`,
     notFound: `Siden finnes ikke - ${titleTemplate}`,
+    forbidden: `Tilgang nektet - ${titleTemplate}`,
     unpublished: `Ressursen er avpublisert - ${titleTemplate}`,
     accessDenied: `Ingen tilgang - ${titleTemplate}`,
     subject: "Fag",
@@ -195,6 +196,10 @@ const messages = {
   movedResourcePage: {
     title: "Siden har flyttet, men du finner den her:",
     openInSubject: "Åpne artikkelen i et fag:",
+  },
+  forbiddenPage: {
+    title: "Tilgang nektet",
+    errorDescription: "Du har ikke tilgang til denne siden.",
   },
 };
 

--- a/src/messages/messagesNN.ts
+++ b/src/messages/messagesNN.ts
@@ -16,6 +16,7 @@ const messages = {
     subjectsPage: `Alle fag - ${titleTemplate}`,
     searchPage: `Søk - ${titleTemplate}`,
     notFound: `Sida finst ikkje - ${titleTemplate}`,
+    forbidden: `Tilgang nektet - ${titleTemplate}`,
     unpublished: `Ressursen er avpublisert - ${titleTemplate}`,
     accessDenied: `Ingen tilgang - ${titleTemplate}`,
     subject: "Fag",
@@ -195,6 +196,10 @@ const messages = {
   movedResourcePage: {
     title: "Sida har flytta, men du finn den her:",
     openInSubject: "Opne artikkelen i eit fag:",
+  },
+  forbiddenPage: {
+    title: "Tilgang nekta",
+    errorDescription: "Du har ikke tilgang til denne sida",
   },
 };
 

--- a/src/messages/messagesNN.ts
+++ b/src/messages/messagesNN.ts
@@ -16,7 +16,7 @@ const messages = {
     subjectsPage: `Alle fag - ${titleTemplate}`,
     searchPage: `Søk - ${titleTemplate}`,
     notFound: `Sida finst ikkje - ${titleTemplate}`,
-    forbidden: `Tilgang nektet - ${titleTemplate}`,
+    forbidden: `Tilgang nekta - ${titleTemplate}`,
     unpublished: `Ressursen er avpublisert - ${titleTemplate}`,
     accessDenied: `Ingen tilgang - ${titleTemplate}`,
     subject: "Fag",
@@ -95,6 +95,7 @@ const messages = {
       error: "Ein feil oppstod",
       userUpdated: "Bruker oppdatert",
     },
+    goToMyNdla: "Gå til Min NDLA",
   },
   ndlaFilm: {
     films: "Filmar",

--- a/src/messages/messagesSE.ts
+++ b/src/messages/messagesSE.ts
@@ -16,6 +16,7 @@ const messages = {
     subjectsPage: `Vállje fága - ${titleTemplate}`,
     searchPage: `Oza - ${titleTemplate}`,
     notFound: `Siidu ii gávdno - ${titleTemplate}`,
+    forbidden: `Tilgang nektet - ${titleTemplate}`,
     unpublished: `Ressursen er avpublisert - ${titleTemplate}`,
     accessDenied: `Ingen tilgang - ${titleTemplate}`,
     subject: "Fága",
@@ -191,6 +192,10 @@ const messages = {
   movedResourcePage: {
     title: "Siden har flyttet, men du finner den her:",
     openInSubject: "Åpne artikkelen i et fag:",
+  },
+  forbiddenPage: {
+    title: "Tilgang nekta",
+    errorDescription: "Du har ikke tilgang til denne sida",
   },
 };
 

--- a/src/messages/messagesSE.ts
+++ b/src/messages/messagesSE.ts
@@ -94,6 +94,7 @@ const messages = {
       error: "En feil oppstod",
       userUpdated: "Bruker oppdatert",
     },
+    goToMyNdla: "Gå til Min NDLA",
   },
   ndlaFilm: {
     films: "Filmer",


### PR DESCRIPTION
Fant plutselig ut av at det gikk an å få tilgang til mer eller mindre alt i arena så lenge en var logget på. 

Er heller ikke så veldig fin av at man må skrive tilgangslogikk i hver eneste route. Dette splitter tilgangslogikken i arena inn i to blokker: admin og arena-tilgang. Konsekvensen av dette er at vi mister litt fleksibilitet rundt åpenhet, men det er nok verdt det.

Burde nok testes nøye. 