### PR TITLE
show user learningpaths and create new ones 

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@ndla/error-reporter": "^2.0.4",
     "@ndla/hooks": "^2.1.9",
     "@ndla/icons": "^8.0.33-alpha.0",
+    "@ndla/image-search": "^11.0.52-alpha.0",
     "@ndla/licenses": "^8.0.3-alpha.0",
     "@ndla/primitives": "^1.0.48-alpha.0",
     "@ndla/safelink": "^7.0.49-alpha.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import FavoriteSubjectsPage from "./containers/MyNdla/FavoriteSubjects/FavoriteS
 import FoldersPage from "./containers/MyNdla/Folders/FoldersPage";
 import FoldersTagsPage from "./containers/MyNdla/Folders/FoldersTagPage";
 import { LearningPathCheck } from "./containers/MyNdla/LearningPath/LearningPathCheck";
+import LearningPathCreateNew from "./containers/MyNdla/LearningPath/LearningPathCreateNew";
 import LearningPathPage from "./containers/MyNdla/LearningPath/LearningPathPage";
 import MyNdlaLayout from "./containers/MyNdla/MyNdlaLayout";
 import MyNdlaPage from "./containers/MyNdla/MyNdlaPage";
@@ -195,6 +196,7 @@ const AppRoutes = ({ base }: AppProps) => {
                   {config.learningpathEnabled && (
                     <Route path="learningpaths" element={<LearningPathCheck />}>
                       <Route index element={<PrivateRoute element={<LearningPathPage />} />} />
+                      <Route path="new" element={<PrivateRoute element={<LearningPathCreateNew />} />} />
                     </Route>
                   )}
                   <Route path="subjects" element={<PrivateRoute element={<FavoriteSubjectsPage />} />} />

--- a/src/containers/MyNdla/LearningPath/LearningPathCreateNew.tsx
+++ b/src/containers/MyNdla/LearningPath/LearningPathCreateNew.tsx
@@ -9,11 +9,20 @@
 import { useContext, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { Heading } from "@ndla/primitives";
+import { styled } from "@ndla/styled-system/jsx";
 import { HelmetWithTracker, useTracker } from "@ndla/tracker";
+import LearningPathTitleForm, { LearningpathFormValues } from "./components/LearningPathTitleForm";
 import { AuthContext } from "../../../components/AuthenticationContext";
 import { SKIP_TO_CONTENT_ID } from "../../../constants";
 import { getAllDimensions } from "../../../util/trackingUtil";
+import MyNdlaBreadcrumb from "../components/MyNdlaBreadcrumb";
 import MyNdlaPageWrapper from "../components/MyNdlaPageWrapper";
+
+const StyledMyNdlaPageWrapper = styled(MyNdlaPageWrapper, {
+  base: {
+    gap: "xlarge",
+  },
+});
 
 const LearningPathCreateNew = () => {
   const { t } = useTranslation();
@@ -24,14 +33,27 @@ const LearningPathCreateNew = () => {
     trackPageView({ title: t("htmlTitles.learningpathPage"), dimensions: getAllDimensions({ user }) });
   }, [t, trackPageView, user]);
 
+  const onCreate = (values: LearningpathFormValues) => {
+    //Change when graphql is connected
+    console.log(values);
+  };
+
   return (
-    <MyNdlaPageWrapper>
+    <StyledMyNdlaPageWrapper>
       <HelmetWithTracker title={t("htmlTitles.learningpathPage")} />
+      <MyNdlaBreadcrumb
+        breadcrumbs={[{ id: "0", name: `${t("myNdla.learningpath.newLearningpath")}` }]}
+        page="learningpath"
+      />
       <Heading id={SKIP_TO_CONTENT_ID} textStyle="heading.medium">
-        {/* {t("myNdla.learningpath.title")} */}
-        "Ny læringssti"
+        {t("myNdla.learningpath.newLearningpath")}
       </Heading>
-    </MyNdlaPageWrapper>
+      <LearningPathTitleForm
+        onSave={async (values) => {
+          await onCreate(values);
+        }}
+      />
+    </StyledMyNdlaPageWrapper>
   );
 };
 

--- a/src/containers/MyNdla/LearningPath/LearningPathCreateNew.tsx
+++ b/src/containers/MyNdla/LearningPath/LearningPathCreateNew.tsx
@@ -8,42 +8,31 @@
 
 import { useContext, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { AddLine } from "@ndla/icons/action";
 import { Heading } from "@ndla/primitives";
 import { HelmetWithTracker, useTracker } from "@ndla/tracker";
 import { AuthContext } from "../../../components/AuthenticationContext";
 import { SKIP_TO_CONTENT_ID } from "../../../constants";
 import { getAllDimensions } from "../../../util/trackingUtil";
 import MyNdlaPageWrapper from "../components/MyNdlaPageWrapper";
-import { MenuItemProps } from "../components/SettingsMenu";
 
-const LearningPathPage = () => {
+const LearningPathCreateNew = () => {
   const { t } = useTranslation();
   const { trackPageView } = useTracker();
   const { user } = useContext(AuthContext);
-
-  const menuItems: MenuItemProps[] = [
-    {
-      type: "link",
-      value: "newFolder",
-      icon: <AddLine size="small" />,
-      text: t("myNdla.newFolderShort"),
-      link: "new",
-    },
-  ];
 
   useEffect(() => {
     trackPageView({ title: t("htmlTitles.learningpathPage"), dimensions: getAllDimensions({ user }) });
   }, [t, trackPageView, user]);
 
   return (
-    <MyNdlaPageWrapper menuItems={menuItems}>
+    <MyNdlaPageWrapper>
       <HelmetWithTracker title={t("htmlTitles.learningpathPage")} />
       <Heading id={SKIP_TO_CONTENT_ID} textStyle="heading.medium">
-        {t("myNdla.learningpath.title")}
+        {/* {t("myNdla.learningpath.title")} */}
+        "Ny læringssti"
       </Heading>
     </MyNdlaPageWrapper>
   );
 };
 
-export default LearningPathPage;
+export default LearningPathCreateNew;

--- a/src/containers/MyNdla/LearningPath/LearningPathPage.tsx
+++ b/src/containers/MyNdla/LearningPath/LearningPathPage.tsx
@@ -9,13 +9,29 @@
 import { useContext, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { AddLine } from "@ndla/icons/action";
-import { Heading } from "@ndla/primitives";
+import { Heading, Text } from "@ndla/primitives";
+import { styled } from "@ndla/styled-system/jsx";
 import { HelmetWithTracker, useTracker } from "@ndla/tracker";
+import LearningPathList from "./components/LearningPathList";
 import { AuthContext } from "../../../components/AuthenticationContext";
 import { SKIP_TO_CONTENT_ID } from "../../../constants";
 import { getAllDimensions } from "../../../util/trackingUtil";
 import MyNdlaPageWrapper from "../components/MyNdlaPageWrapper";
 import { MenuItemProps } from "../components/SettingsMenu";
+
+const StyledMyNdlaPageWrapper = styled(MyNdlaPageWrapper, {
+  base: {
+    gap: "xlarge",
+  },
+});
+
+const HeadingWrapper = styled("div", {
+  base: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "medium",
+  },
+});
 
 const LearningPathPage = () => {
   const { t } = useTranslation();
@@ -37,12 +53,16 @@ const LearningPathPage = () => {
   }, [t, trackPageView, user]);
 
   return (
-    <MyNdlaPageWrapper menuItems={menuItems}>
+    <StyledMyNdlaPageWrapper menuItems={menuItems}>
       <HelmetWithTracker title={t("htmlTitles.learningpathPage")} />
-      <Heading id={SKIP_TO_CONTENT_ID} textStyle="heading.medium">
-        {t("myNdla.learningpath.title")}
-      </Heading>
-    </MyNdlaPageWrapper>
+      <HeadingWrapper>
+        <Heading id={SKIP_TO_CONTENT_ID} textStyle="heading.medium">
+          {t("myNdla.learningpath.title")}
+        </Heading>
+        <Text textStyle="body.medium">{t("myNdla.learningpath.description")}</Text>
+      </HeadingWrapper>
+      <LearningPathList loading={false} learningPaths={[]} />
+    </StyledMyNdlaPageWrapper>
   );
 };
 

--- a/src/containers/MyNdla/LearningPath/LearningPathPage.tsx
+++ b/src/containers/MyNdla/LearningPath/LearningPathPage.tsx
@@ -33,6 +33,22 @@ const HeadingWrapper = styled("div", {
   },
 });
 
+// Delete after graphql is connected
+const testData = [
+  {
+    id: "1",
+    created: "2024.12.12",
+    shared: "2024.12.13",
+    title: "Naturfag",
+  },
+  {
+    id: "2",
+    created: "2024.12.15",
+    shared: "2024.12.16",
+    title: "Engelsk",
+  },
+];
+
 const LearningPathPage = () => {
   const { t } = useTranslation();
   const { trackPageView } = useTracker();
@@ -61,7 +77,7 @@ const LearningPathPage = () => {
         </Heading>
         <Text textStyle="body.medium">{t("myNdla.learningpath.description")}</Text>
       </HeadingWrapper>
-      <LearningPathList loading={false} learningPaths={[]} />
+      <LearningPathList loading={false} learningPaths={testData} />
     </StyledMyNdlaPageWrapper>
   );
 };

--- a/src/containers/MyNdla/LearningPath/components/LearningPathItem.tsx
+++ b/src/containers/MyNdla/LearningPath/components/LearningPathItem.tsx
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2024-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { ListItemContent, ListItemHeading, ListItemRoot, ListItemVariantProps } from "@ndla/primitives";
+import { SafeLink } from "@ndla/safelink";
+import { styled } from "@ndla/styled-system/jsx";
+import SettingsMenu from "../../../../containers/MyNdla/components/SettingsMenu";
+import { useFolderActions } from "../../../../containers/MyNdla/Folders/components/FolderActionHooks";
+import { linkOverlay } from "@ndla/styled-system/patterns";
+import { RouteFill } from "@ndla/icons/common";
+import { GQLLearningPath } from "./LearningPathList";
+
+interface Props {
+  learningPath: GQLLearningPath;
+  variant?: NonNullable<ListItemVariantProps>["variant"];
+  context?: NonNullable<ListItemVariantProps>["context"];
+  link: string;
+}
+
+const TitleWrapper = styled("div", {
+  base: {
+    display: "flex",
+    gap: "small",
+  },
+});
+
+const LearningPathInfo = styled("div", {
+  base: {
+    display: "flex",
+    gap: "xsmall",
+  },
+});
+
+const MenuWrapper = styled("div", {
+  base: {
+    position: "relative",
+  },
+});
+
+const StyledSafeLink = styled(SafeLink, {
+  base: {
+    lineClamp: "2",
+    overflowWrap: "anywhere",
+  },
+});
+
+const LearningPathItem = ({
+  learningPath: { id, createdDate, sharedDate, title },
+  variant,
+  context = "list",
+  link,
+}: Props) => {
+  const { t } = useTranslation();
+
+  // const folderMenuActions = useFolderActions(folder, setFocusId, folders, false, folderRefId, isFavorited);
+
+  // const menu = useMemo(
+  //   () => <SettingsMenu menuItems={folderMenuActions} modalHeader={t("myNdla.tools")} />,
+  //   [folderMenuActions, t],
+  // );
+
+  return (
+    <ListItemRoot context={context} variant={variant} nonInteractive id={id}>
+      <ListItemContent
+        css={{
+          alignItems: "center",
+          flexWrap: "wrap",
+          tabletDown: {
+            flexDirection: "column",
+            alignItems: "flex-start",
+          },
+        }}
+      >
+        <TitleWrapper>
+          <RouteFill aria-hidden={false} aria-label={t("myNdla.iconMeny.learningpath")} />
+          <ListItemHeading asChild consumeCss>
+            <StyledSafeLink to={link} unstyled css={linkOverlay.raw()}>
+              {title}
+            </StyledSafeLink>
+          </ListItemHeading>
+        </TitleWrapper>
+        <LearningPathInfo></LearningPathInfo>
+      </ListItemContent>
+      <MenuWrapper>menu</MenuWrapper>
+    </ListItemRoot>
+  );
+};
+
+export default LearningPathItem;

--- a/src/containers/MyNdla/LearningPath/components/LearningPathItem.tsx
+++ b/src/containers/MyNdla/LearningPath/components/LearningPathItem.tsx
@@ -6,15 +6,12 @@
  *
  */
 
-import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { ListItemContent, ListItemHeading, ListItemRoot, ListItemVariantProps } from "@ndla/primitives";
+import { RouteFill } from "@ndla/icons/common";
+import { ListItemContent, ListItemHeading, ListItemRoot, ListItemVariantProps, Text } from "@ndla/primitives";
 import { SafeLink } from "@ndla/safelink";
 import { styled } from "@ndla/styled-system/jsx";
-import SettingsMenu from "../../../../containers/MyNdla/components/SettingsMenu";
-import { useFolderActions } from "../../../../containers/MyNdla/Folders/components/FolderActionHooks";
 import { linkOverlay } from "@ndla/styled-system/patterns";
-import { RouteFill } from "@ndla/icons/common";
 import { GQLLearningPath } from "./LearningPathList";
 
 interface Props {
@@ -28,6 +25,15 @@ const TitleWrapper = styled("div", {
   base: {
     display: "flex",
     gap: "small",
+    alignItems: "center",
+  },
+});
+
+const TitleAndDateWrapper = styled("div", {
+  base: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "4xsmall",
   },
 });
 
@@ -51,21 +57,15 @@ const StyledSafeLink = styled(SafeLink, {
   },
 });
 
-const LearningPathItem = ({
-  learningPath: { id, createdDate, sharedDate, title },
-  variant,
-  context = "list",
-  link,
-}: Props) => {
+const StyledText = styled(Text, {
+  base: {
+    color: "text.subtle",
+  },
+});
+
+const LearningPathItem = ({ learningPath: { id, created, shared, title }, variant, context = "list", link }: Props) => {
   const { t } = useTranslation();
-
-  // const folderMenuActions = useFolderActions(folder, setFocusId, folders, false, folderRefId, isFavorited);
-
-  // const menu = useMemo(
-  //   () => <SettingsMenu menuItems={folderMenuActions} modalHeader={t("myNdla.tools")} />,
-  //   [folderMenuActions, t],
-  // );
-
+  //Simple component since dnd-component will be updated
   return (
     <ListItemRoot context={context} variant={variant} nonInteractive id={id}>
       <ListItemContent
@@ -80,11 +80,14 @@ const LearningPathItem = ({
       >
         <TitleWrapper>
           <RouteFill aria-hidden={false} aria-label={t("myNdla.iconMeny.learningpath")} />
-          <ListItemHeading asChild consumeCss>
-            <StyledSafeLink to={link} unstyled css={linkOverlay.raw()}>
-              {title}
-            </StyledSafeLink>
-          </ListItemHeading>
+          <TitleAndDateWrapper>
+            <ListItemHeading asChild consumeCss>
+              <StyledSafeLink to={link} unstyled css={linkOverlay.raw()}>
+                {title}
+              </StyledSafeLink>
+            </ListItemHeading>
+            <StyledText textStyle="label.small">{`${t("myNdla.learningpath.created")}: ${created} / ${t("myNdla.folder.sharing.shared")}: ${shared}`}</StyledText>
+          </TitleAndDateWrapper>
         </TitleWrapper>
         <LearningPathInfo></LearningPathInfo>
       </ListItemContent>

--- a/src/containers/MyNdla/LearningPath/components/LearningPathList.tsx
+++ b/src/containers/MyNdla/LearningPath/components/LearningPathList.tsx
@@ -6,16 +6,18 @@
  *
  */
 
+import { ReactNode } from "react";
+import LearningPathItem from "./LearningPathItem";
 import { BlockWrapper } from "../../../../components/MyNdla/BlockWrapper";
 import { PageSpinner } from "../../../../components/PageSpinner";
 import WhileLoading from "../../../../components/WhileLoading";
-import LearningPathItem from "./LearningPathItem";
 
 export type GQLLearningPath = {
   id: string;
-  createdDate: Date;
-  sharedDate: Date;
+  created: string;
+  shared: string;
   title: string;
+  metaImage?: ReactNode;
 };
 
 interface Props {

--- a/src/containers/MyNdla/LearningPath/components/LearningPathList.tsx
+++ b/src/containers/MyNdla/LearningPath/components/LearningPathList.tsx
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2024-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { BlockWrapper } from "../../../../components/MyNdla/BlockWrapper";
+import { PageSpinner } from "../../../../components/PageSpinner";
+import WhileLoading from "../../../../components/WhileLoading";
+import LearningPathItem from "./LearningPathItem";
+
+export type GQLLearningPath = {
+  id: string;
+  createdDate: Date;
+  sharedDate: Date;
+  title: string;
+};
+
+interface Props {
+  loading: boolean;
+  learningPaths: GQLLearningPath[];
+}
+
+function LearningPathList({ loading, learningPaths }: Props) {
+  return (
+    <WhileLoading isLoading={loading} fallback={<PageSpinner />}>
+      {learningPaths.length > 0 && (
+        <BlockWrapper>
+          {learningPaths.map((learningPath) => (
+            <LearningPathItem key={`learningPath-${learningPath.id}`} learningPath={learningPath} link={""} />
+          ))}
+        </BlockWrapper>
+      )}
+    </WhileLoading>
+  );
+}
+
+export default LearningPathList;

--- a/src/containers/MyNdla/LearningPath/components/LearningPathTitleForm.tsx
+++ b/src/containers/MyNdla/LearningPath/components/LearningPathTitleForm.tsx
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2024-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { ReactNode } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { Button, FieldErrorMessage, FieldInput, FieldLabel, FieldRoot, Heading, Text } from "@ndla/primitives";
+import { styled } from "@ndla/styled-system/jsx";
+import { GQLLearningPath } from "./LearningPathList";
+import SearchMetaImage from "./SearchMetaImage";
+import FieldLength from "../../../../containers/MyNdla/components/FieldLength";
+import useValidationTranslation from "../../../../util/useValidationTranslation";
+
+interface Props {
+  learningpath?: GQLLearningPath;
+  onSave: (values: LearningpathFormValues) => Promise<void>;
+  loading?: boolean;
+}
+
+export interface LearningpathFormValues {
+  title: string;
+  metaImage: ReactNode | undefined;
+}
+
+const StyledForm = styled("form", {
+  base: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "small",
+  },
+});
+
+const ContentWrapper = styled("div", {
+  base: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "small",
+  },
+});
+
+const ButtonRow = styled("div", {
+  base: {
+    display: "flex",
+    justifyContent: "space-between",
+    paddingBlockStart: "small",
+  },
+});
+
+const toFormValues = (learningpath: GQLLearningPath | undefined): LearningpathFormValues => {
+  return {
+    title: learningpath?.title ?? "",
+    metaImage: learningpath?.metaImage ?? undefined,
+  };
+};
+
+const nameMaxLength = 64;
+
+function LearningPathTitleForm({ onSave, learningpath, loading }: Props) {
+  const { t } = useTranslation();
+  const { validationT } = useValidationTranslation();
+  const { control, handleSubmit } = useForm({ defaultValues: toFormValues(learningpath) });
+
+  return (
+    <StyledForm onSubmit={handleSubmit(onSave)} noValidate>
+      <ContentWrapper>
+        <Heading textStyle="heading.small">{t("myNdla.learningpath.learningpathTitle.title")}</Heading>
+        <Controller
+          control={control}
+          name="title"
+          rules={{
+            required: validationT({ type: "required", field: "title" }),
+            maxLength: {
+              value: nameMaxLength,
+              message: validationT({
+                type: "maxLength",
+                field: "title",
+                vars: { count: nameMaxLength },
+              }),
+            },
+            // Should we check for duplicate titles?
+            // validate: (name) => {
+            //   const exists = siblings.every((f) => f.name.toLowerCase() !== name.toLowerCase());
+            //   if (!exists) {
+            //     return validationT("validation.notUnique");
+            //   }
+            //   return true;
+            // },
+          }}
+          render={({ field, fieldState }) => (
+            <FieldRoot invalid={!!fieldState.error?.message}>
+              <ContentWrapper>
+                <FieldLabel fontWeight="bold" textStyle="label.large">
+                  {t("title")}
+                </FieldLabel>
+                <Text textStyle="body.large">{t("myNdla.learningpath.learningpathTitle.description")}</Text>
+              </ContentWrapper>
+              <FieldErrorMessage>{fieldState.error?.message}</FieldErrorMessage>
+              <FieldInput {...field} />
+              <FieldLength value={field.value?.length ?? 0} maxLength={nameMaxLength} />
+            </FieldRoot>
+          )}
+        />
+        <Controller
+          control={control}
+          name="metaImage"
+          rules={{
+            required: "Please select an image",
+            validate: (value) => !!value,
+          }}
+          render={({ field: { onChange } }) => (
+            <ContentWrapper>
+              <Text textStyle="label.large">{t("myNdla.learningpath.metaImage.title")}</Text>
+              <Text textStyle="body.large">{t("myNdla.learningpath.metaImage.description")}</Text>
+              <SearchMetaImage onChange={onChange} />
+            </ContentWrapper>
+          )}
+        />
+      </ContentWrapper>
+      <ButtonRow>
+        <Button variant="secondary">{t("cancel")}</Button>
+        <Button loading={loading} disabled={loading} type="submit" aria-label={loading ? t("loading") : undefined}>
+          {t("continue")}
+        </Button>
+      </ButtonRow>
+    </StyledForm>
+  );
+}
+
+export default LearningPathTitleForm;

--- a/src/containers/MyNdla/LearningPath/components/SearchMetaImage.tsx
+++ b/src/containers/MyNdla/LearningPath/components/SearchMetaImage.tsx
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2020-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { useTranslation } from "react-i18next";
+import { ImageSearch } from "@ndla/image-search";
+import { IImageMetaInformationV3, ISearchParams, ISearchResultV3 } from "@ndla/types-backend/image-api";
+import { useImageSearchTranslations } from "@ndla/ui";
+import { LocaleType } from "../../../../interfaces";
+import { apiResourceUrl, fetchAuthorized, resolveJsonOrRejectWithError } from "../../../../util/apiHelpers";
+
+interface Props {
+  onChange: (...event: any[]) => void;
+}
+
+type NdlaErrorFields = {
+  status: number;
+  messages: string;
+  json: any;
+};
+
+//Most functions are copies from ED, move to utils later?
+
+export type NdlaErrorPayload = NdlaErrorFields & Error;
+const baseUrl = apiResourceUrl("/image-api/v3/images");
+
+const fetchImage = (id: number | string, language?: string): Promise<IImageMetaInformationV3> =>
+  fetchAuthorized(`${baseUrl}/${id}?language=${language}`).then((r) =>
+    resolveJsonOrRejectWithError<IImageMetaInformationV3>(r),
+  );
+
+const onError = (err: Response & Error) => {
+  throwErrorPayload(err.status, err.message ?? err.statusText, err);
+};
+
+function buildErrorPayload(status: number, messages: string, json: any): NdlaErrorPayload {
+  return Object.assign({}, { status, json, messages }, new Error(""));
+}
+
+function throwErrorPayload(status: number, messages: string, json: any) {
+  throw buildErrorPayload(status, messages, json);
+}
+
+const postSearchImages = async (body: StringSort<ISearchParams>): Promise<ISearchResultV3> => {
+  const response = await fetchAuthorized(`${baseUrl}/search/`, { method: "POST", body: JSON.stringify(body) });
+  return resolveJsonOrRejectWithError(response);
+};
+
+type StringSort<T> = Omit<T, "sort"> & { sort?: string };
+
+const SearchMetaImage = ({ onChange }: Props) => {
+  const { t, i18n } = useTranslation();
+  const imageSearchTranslations = useImageSearchTranslations();
+  const locale: LocaleType = i18n.language;
+  const fetchImageWithLocale = (id: number) => fetchImage(id, locale);
+  const searchImagesWithParameters = (query?: string, page?: number) => {
+    return postSearchImages({ query, page, pageSize: 16 });
+  };
+
+  return (
+    <ImageSearch
+      fetchImage={fetchImageWithLocale}
+      searchImages={searchImagesWithParameters}
+      locale={locale}
+      translations={imageSearchTranslations}
+      onImageSelect={(image: IImageMetaInformationV3) => onChange(image)}
+      noResults={<div>{t("imageSearch.noResultsText")}</div>}
+      onError={onError}
+    />
+  );
+};
+
+export default SearchMetaImage;

--- a/src/containers/MyNdla/LearningPath/components/SearchMetaImage.tsx
+++ b/src/containers/MyNdla/LearningPath/components/SearchMetaImage.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-present, NDLA.
+ * Copyright (c) 2024-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/containers/MyNdla/MyNdlaLayout.tsx
+++ b/src/containers/MyNdla/MyNdlaLayout.tsx
@@ -214,7 +214,7 @@ export const menuLinks = (t: TFunction, location: Location, user: MyNDLAUserType
     id: "learningpaths",
     to: routes.myNdla.learningpath,
     name: t("myNdla.learningpath.title"),
-    shortName: t("myNdla.iconMeny.learningpath"),
+    shortName: t("myNdla.iconMenu.learningpath"),
     icon: <RouteLine />,
     iconFilled: <RouteFill />,
     shownForUser: (user) => config.learningpathEnabled && user?.role === "employee",

--- a/src/containers/MyNdla/components/MyNdlaBreadcrumb.tsx
+++ b/src/containers/MyNdla/components/MyNdlaBreadcrumb.tsx
@@ -16,7 +16,7 @@ interface Props {
   page: PageType;
 }
 
-type PageType = "folders" | "subjects" | "arena" | "admin";
+type PageType = "folders" | "subjects" | "arena" | "admin" | "learningpath";
 
 const types = {
   folders: {
@@ -34,6 +34,10 @@ const types = {
   admin: {
     to: routes.myNdla.admin,
     name: "myNdla.arena.admin.title",
+  },
+  learningpath: {
+    to: routes.myNdla.learningpath,
+    name: "myNdla.learningpath.title",
   },
 };
 

--- a/src/util/apiHelpers.ts
+++ b/src/util/apiHelpers.ts
@@ -34,10 +34,11 @@ export function apiResourceUrl(path: string) {
   return apiBaseUrl + path;
 }
 
-export function resolveJsonOrRejectWithError<T>(res: Response): Promise<T | undefined> {
+export function resolveJsonOrRejectWithError<T>(res: Response): Promise<T> {
+  //changes were made for testing
   return new Promise((resolve, reject) => {
     if (res.ok) {
-      return res.status === 204 ? resolve(undefined) : resolve(res.json());
+      return resolve(res.json()); //changes were made for testing
     }
     return res
       .json()
@@ -244,6 +245,8 @@ type HttpHeaders = {
   headers?: {
     "Content-Type": string;
   };
+  method?: "POST" | "GET";
+  body?: any;
 };
 
 export const fetchAuthorized = (url: string, config?: HttpHeaders) => fetchWithAuthorization(url, false, config);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3175,6 +3175,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ndla/icons@npm:^8.0.34-alpha.0":
+  version: 8.0.34-alpha.0
+  resolution: "@ndla/icons@npm:8.0.34-alpha.0"
+  dependencies:
+    "@ndla/core": "npm:^5.0.2"
+    "@ndla/styled-system": "npm:^0.0.24"
+  peerDependencies:
+    react: ">= 18"
+    react-dom: ">= 18"
+  checksum: 10c0/47f1fee9bae109c44898f19eb549bfa9c3088dc6e23bdfeb80a09ba49702ed6050ec206f1d69c0a4f57cdf1d3c7e2241158ac62b4ff70a6eb3fa34fa180db979
+  languageName: node
+  linkType: hard
+
+"@ndla/image-search@npm:^11.0.52-alpha.0":
+  version: 11.0.52-alpha.0
+  resolution: "@ndla/image-search@npm:11.0.52-alpha.0"
+  dependencies:
+    "@ndla/icons": "npm:^8.0.34-alpha.0"
+    "@ndla/licenses": "npm:^8.0.3-alpha.0"
+    "@ndla/primitives": "npm:^1.0.49-alpha.0"
+    "@ndla/styled-system": "npm:^0.0.24"
+    pretty-bytes: "npm:^5.6.0"
+  peerDependencies:
+    react: ">= 18"
+    react-dom: ">= 18"
+  checksum: 10c0/431a2fee6d7395932eb9d6e8774fba673d4437bed5c22eb3acb0ded1d6b44232fa797ac898e27daa6a557f5947eee253da97d095773160f5a5e5b4ff7b47faef
+  languageName: node
+  linkType: hard
+
 "@ndla/licenses@npm:^8.0.3-alpha.0":
   version: 8.0.3-alpha.0
   resolution: "@ndla/licenses@npm:8.0.3-alpha.0"
@@ -3200,6 +3229,20 @@ __metadata:
     react: ">= 18"
     react-dom: ">= 18"
   checksum: 10c0/977ead859e4f89b5d9662bd4b511dc3e35d50613a76ad765a914b34f174fcc6897d903b64e412a0866e68d8d7b4e30eaf51268fe7c484de90d684494bd662072
+  languageName: node
+  linkType: hard
+
+"@ndla/primitives@npm:^1.0.49-alpha.0":
+  version: 1.0.49-alpha.0
+  resolution: "@ndla/primitives@npm:1.0.49-alpha.0"
+  dependencies:
+    "@ark-ui/react": "npm:^4.1.2"
+    "@ndla/styled-system": "npm:^0.0.24"
+    "@ndla/util": "npm:^5.0.0-alpha.0"
+  peerDependencies:
+    react: ">= 18"
+    react-dom: ">= 18"
+  checksum: 10c0/8fda024a6c3094da8f419b409942b505340517ee5ee330a95733e0dd4f0a04c8680605a9462bba0acf86b74d13e622401e5c714cf025cb51c609af0f7902c43b
   languageName: node
   linkType: hard
 
@@ -11621,6 +11664,7 @@ __metadata:
     "@ndla/error-reporter": "npm:^2.0.4"
     "@ndla/hooks": "npm:^2.1.9"
     "@ndla/icons": "npm:^8.0.33-alpha.0"
+    "@ndla/image-search": "npm:^11.0.52-alpha.0"
     "@ndla/licenses": "npm:^8.0.3-alpha.0"
     "@ndla/preset-panda": "npm:^0.0.41"
     "@ndla/primitives": "npm:^1.0.48-alpha.0"
@@ -13021,6 +13065,13 @@ __metadata:
   bin:
     prettier: bin/prettier.cjs
   checksum: 10c0/ea327f37a7d46f2324a34ad35292af2ad4c4c3c3355da07313339d7e554320f66f65f91e856add8530157a733c6c4a897dc41b577056be5c24c40f739f5ee8c6
+  languageName: node
+  linkType: hard
+
+"pretty-bytes@npm:^5.6.0":
+  version: 5.6.0
+  resolution: "pretty-bytes@npm:5.6.0"
+  checksum: 10c0/f69f494dcc1adda98dbe0e4a36d301e8be8ff99bfde7a637b2ee2820e7cb583b0fc0f3a63b0e3752c01501185a5cf38602c7be60da41bdf84ef5b70e89c370f3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Draft på det som har blitt gjort hittil:
- viser frem `Mine læringsstier` (dummy data) + dnd mangler siden den skulle oppdateres
- `Ny læringssti` side
- importert `ImageSearch`, må settes opp å gå via graphql?
- validering av `Tittel og beskrivelse`-steg, må utvides med graphql, akk nå er det en enkel console.log
- ligger noe utkommentert kode, der må funksjonalitet avklares