### PR TITLE
Use CET timezone when rendering timezones

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "@ndla/util": "^5.0.0-alpha.0",
     "@sentry/react": "^8.32.0",
     "cross-env": "^7.0.3",
-    "date-fns": "^4.1.0",
     "express": "^5.0.0",
     "express-prom-bundle": "^8.0.0",
     "graphql": "^16.8.1",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
   "dependencies": {
     "@apollo/client": "^3.9.11",
     "@ark-ui/react": "^4.1.2",
+    "@date-fns/tz": "^1.2.0",
     "@dnd-kit/core": "^6.0.8",
     "@dnd-kit/modifiers": "^6.0.1",
     "@dnd-kit/sortable": "7.0.2",
@@ -101,7 +102,7 @@
     "@ndla/util": "^5.0.0-alpha.0",
     "@sentry/react": "^8.32.0",
     "cross-env": "^7.0.3",
-    "date-fns": "^2.30.0",
+    "date-fns": "^4.1.0",
     "express": "^5.0.0",
     "express-prom-bundle": "^8.0.0",
     "graphql": "^16.8.1",

--- a/src/containers/MyNdla/Arena/components/FlagCard.tsx
+++ b/src/containers/MyNdla/Arena/components/FlagCard.tsx
@@ -6,13 +6,11 @@
  *
  */
 
-import { formatDistanceStrict } from "date-fns";
 import { useTranslation } from "react-i18next";
 import { SwitchControl, SwitchHiddenInput, SwitchLabel, SwitchRoot, SwitchThumb, Text } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
 import { GQLArenaFlagFragment } from "../../../../graphqlTypes";
-import { DateFNSLocales } from "../../../../i18n";
-import { formatDateTime } from "../../../../util/formatDate";
+import { formatDateTime, formatDistanceToNow } from "../../../../util/formatDate";
 import { useResolveFlagMutation } from "../../arenaMutations";
 import UserProfileTag from "../../components/UserProfileTag";
 import { capitalizeFirstLetter } from "../utils";
@@ -45,12 +43,7 @@ const FlagRow = styled("div", {
 
 const TimedistanceField = ({ date, disableCapitalization }: { date: string; disableCapitalization?: boolean }) => {
   const { i18n } = useTranslation();
-
-  const timeDistance = formatDistanceStrict(Date.parse(date), Date.now(), {
-    addSuffix: true,
-    locale: DateFNSLocales[i18n.language],
-    roundingMethod: "floor",
-  });
+  const timeDistance = formatDistanceToNow(date, i18n.language);
 
   return (
     <Text asChild consumeCss textStyle="body.small">

--- a/src/containers/MyNdla/Arena/components/FlagCard.tsx
+++ b/src/containers/MyNdla/Arena/components/FlagCard.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from "react-i18next";
 import { SwitchControl, SwitchHiddenInput, SwitchLabel, SwitchRoot, SwitchThumb, Text } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
 import { GQLArenaFlagFragment } from "../../../../graphqlTypes";
-import { formatDateTime, formatDistanceToNow } from "../../../../util/formatDate";
+import { formatDateTime, useFormatDistance } from "../../../../util/formatDate";
 import { useResolveFlagMutation } from "../../arenaMutations";
 import UserProfileTag from "../../components/UserProfileTag";
 import { capitalizeFirstLetter } from "../utils";
@@ -43,7 +43,7 @@ const FlagRow = styled("div", {
 
 const TimedistanceField = ({ date, disableCapitalization }: { date: string; disableCapitalization?: boolean }) => {
   const { i18n } = useTranslation();
-  const timeDistance = formatDistanceToNow(date, i18n.language);
+  const timeDistance = useFormatDistance(date);
 
   return (
     <Text asChild consumeCss textStyle="body.small">

--- a/src/containers/MyNdla/Arena/components/FlaggedPostCard.tsx
+++ b/src/containers/MyNdla/Arena/components/FlaggedPostCard.tsx
@@ -14,7 +14,7 @@ import { Stack, styled } from "@ndla/styled-system/jsx";
 import { SKIP_TO_CONTENT_ID } from "../../../../constants";
 import { GQLArenaPostV2Fragment, GQLArenaTopicByIdV2Query } from "../../../../graphqlTypes";
 import { routes } from "../../../../routeHelpers";
-import { formatDateTime, formatDistanceToNow } from "../../../../util/formatDate";
+import { formatDateTime, useFormatDistance } from "../../../../util/formatDate";
 import UserProfileTag from "../../components/UserProfileTag";
 import { capitalizeFirstLetter } from "../utils";
 
@@ -47,9 +47,8 @@ const StyledBottomRow = styled("div", {
 
 const PostCard = ({ topic, post }: Props) => {
   const { id: postId, topicId, created, contentAsHTML } = post;
-
   const { t, i18n } = useTranslation();
-  const timeDistance = formatDistanceToNow(created, i18n.language);
+  const timeDistance = useFormatDistance(created);
 
   return (
     <PostCardWrapper id={`post-${postId}`}>

--- a/src/containers/MyNdla/Arena/components/FlaggedPostCard.tsx
+++ b/src/containers/MyNdla/Arena/components/FlaggedPostCard.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import { formatDistanceStrict } from "date-fns";
 import parse from "html-react-parser";
 import { useTranslation } from "react-i18next";
 import { Heading, Text } from "@ndla/primitives";
@@ -14,9 +13,8 @@ import { SafeLinkButton } from "@ndla/safelink";
 import { Stack, styled } from "@ndla/styled-system/jsx";
 import { SKIP_TO_CONTENT_ID } from "../../../../constants";
 import { GQLArenaPostV2Fragment, GQLArenaTopicByIdV2Query } from "../../../../graphqlTypes";
-import { DateFNSLocales } from "../../../../i18n";
 import { routes } from "../../../../routeHelpers";
-import { formatDateTime } from "../../../../util/formatDate";
+import { formatDateTime, formatDistanceToNow } from "../../../../util/formatDate";
 import UserProfileTag from "../../components/UserProfileTag";
 import { capitalizeFirstLetter } from "../utils";
 
@@ -51,12 +49,7 @@ const PostCard = ({ topic, post }: Props) => {
   const { id: postId, topicId, created, contentAsHTML } = post;
 
   const { t, i18n } = useTranslation();
-
-  const timeDistance = formatDistanceStrict(Date.parse(created), Date.now(), {
-    addSuffix: true,
-    locale: DateFNSLocales[i18n.language],
-    roundingMethod: "floor",
-  });
+  const timeDistance = formatDistanceToNow(created, i18n.language);
 
   return (
     <PostCardWrapper id={`post-${postId}`}>

--- a/src/containers/MyNdla/Arena/components/MainPostCard.tsx
+++ b/src/containers/MyNdla/Arena/components/MainPostCard.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import { formatDistanceStrict } from "date-fns";
 import parse from "html-react-parser";
 import { Dispatch, SetStateAction, useState, useCallback, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
@@ -30,10 +29,9 @@ import VotePost from "./VotePost";
 import { useToast } from "../../../../components/ToastContext";
 import { SKIP_TO_CONTENT_ID } from "../../../../constants";
 import { GQLArenaPostV2Fragment, GQLArenaTopicByIdV2Query } from "../../../../graphqlTypes";
-import { DateFNSLocales } from "../../../../i18n";
 import { routes } from "../../../../routeHelpers";
 import { useUserAgent } from "../../../../UserAgentContext";
-import { formatDateTime } from "../../../../util/formatDate";
+import { formatDateTime, formatDistanceToNow } from "../../../../util/formatDate";
 import UserProfileTag from "../../components/UserProfileTag";
 import { capitalizeFirstLetter } from "../utils";
 
@@ -122,11 +120,7 @@ const MainPostCard = ({ topic, post, onFollowChange, setFocusId, setReplyingTo, 
     },
     [deleteTopic, topicId, toast, t, topic?.categoryId, navigate],
   );
-  const timeDistance = formatDistanceStrict(Date.parse(created), Date.now(), {
-    addSuffix: true,
-    locale: DateFNSLocales[i18n.language],
-    roundingMethod: "floor",
-  });
+  const timeDistance = formatDistanceToNow(created, i18n.language);
 
   const followSwitch = useMemo(
     () => (

--- a/src/containers/MyNdla/Arena/components/MainPostCard.tsx
+++ b/src/containers/MyNdla/Arena/components/MainPostCard.tsx
@@ -31,7 +31,7 @@ import { SKIP_TO_CONTENT_ID } from "../../../../constants";
 import { GQLArenaPostV2Fragment, GQLArenaTopicByIdV2Query } from "../../../../graphqlTypes";
 import { routes } from "../../../../routeHelpers";
 import { useUserAgent } from "../../../../UserAgentContext";
-import { formatDateTime, formatDistanceToNow } from "../../../../util/formatDate";
+import { formatDateTime, useFormatDistance } from "../../../../util/formatDate";
 import UserProfileTag from "../../components/UserProfileTag";
 import { capitalizeFirstLetter } from "../utils";
 
@@ -120,7 +120,7 @@ const MainPostCard = ({ topic, post, onFollowChange, setFocusId, setReplyingTo, 
     },
     [deleteTopic, topicId, toast, t, topic?.categoryId, navigate],
   );
-  const timeDistance = formatDistanceToNow(created, i18n.language);
+  const timeDistance = useFormatDistance(created);
 
   const followSwitch = useMemo(
     () => (

--- a/src/containers/MyNdla/Arena/components/PostCard.tsx
+++ b/src/containers/MyNdla/Arena/components/PostCard.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import { formatDistanceStrict } from "date-fns";
 import parse from "html-react-parser";
 import { Dispatch, SetStateAction, useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -20,9 +19,8 @@ import { useArenaDeletePost, useArenaUpdatePost } from "./temporaryNodebbHooks";
 import VotePost from "./VotePost";
 import { useToast } from "../../../../components/ToastContext";
 import { GQLArenaPostV2Fragment, GQLArenaTopicByIdV2Query } from "../../../../graphqlTypes";
-import { DateFNSLocales } from "../../../../i18n";
 import { useUserAgent } from "../../../../UserAgentContext";
-import { formatDateTime } from "../../../../util/formatDate";
+import { formatDateTime, formatDistanceToNow } from "../../../../util/formatDate";
 import UserProfileTag from "../../components/UserProfileTag";
 import { capitalizeFirstLetter } from "../utils";
 
@@ -69,11 +67,7 @@ const PostCard = ({ nextPostId, post, topic, setFocusId, setIsReplying, isReplyi
     [deletePost, postId, toast, t, setFocusId, nextPostId],
   );
 
-  const timeDistance = formatDistanceStrict(Date.parse(created), Date.now(), {
-    addSuffix: true,
-    locale: DateFNSLocales[i18n.language],
-    roundingMethod: "floor",
-  });
+  const timeDistance = formatDistanceToNow(created, i18n.language);
 
   const postTime = useMemo(
     () => (

--- a/src/containers/MyNdla/Arena/components/PostCard.tsx
+++ b/src/containers/MyNdla/Arena/components/PostCard.tsx
@@ -20,7 +20,7 @@ import VotePost from "./VotePost";
 import { useToast } from "../../../../components/ToastContext";
 import { GQLArenaPostV2Fragment, GQLArenaTopicByIdV2Query } from "../../../../graphqlTypes";
 import { useUserAgent } from "../../../../UserAgentContext";
-import { formatDateTime, formatDistanceToNow } from "../../../../util/formatDate";
+import { formatDateTime, useFormatDistance } from "../../../../util/formatDate";
 import UserProfileTag from "../../components/UserProfileTag";
 import { capitalizeFirstLetter } from "../utils";
 
@@ -54,6 +54,7 @@ const PostCard = ({ nextPostId, post, topic, setFocusId, setIsReplying, isReplyi
   const userAgent = useUserAgent();
   const { updatePost } = useArenaUpdatePost(topicId);
   const { deletePost } = useArenaDeletePost(topicId);
+  const timeDistance = useFormatDistance(created);
 
   const deletePostCallback = useCallback(
     async (close: VoidFunction) => {
@@ -66,8 +67,6 @@ const PostCard = ({ nextPostId, post, topic, setFocusId, setIsReplying, isReplyi
     },
     [deletePost, postId, toast, t, setFocusId, nextPostId],
   );
-
-  const timeDistance = formatDistanceToNow(created, i18n.language);
 
   const postTime = useMemo(
     () => (

--- a/src/containers/MyNdla/MyNdlaPage.tsx
+++ b/src/containers/MyNdla/MyNdlaPage.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import format from "date-fns/format";
 import keyBy from "lodash/keyBy";
 import { useContext, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
@@ -32,6 +31,7 @@ import config from "../../config";
 import { myndlaLanguages } from "../../i18n";
 import { routes } from "../../routeHelpers";
 import { getResourceTypesForResource } from "../../util/folderHelpers";
+import { getNdlaRobotDateFormat } from "../../util/formatDate";
 import { getAllDimensions } from "../../util/trackingUtil";
 import { GridList } from "../AllSubjectsPage/SubjectCategory";
 import SubjectLink from "../AllSubjectsPage/SubjectLink";
@@ -107,7 +107,7 @@ const MyNdlaPage = () => {
 
   const aiLang = i18n.language === "nn" ? "" : ""; // TODO: Readd nn when Jan says so
 
-  const dateString = format(new Date(), "Y-MM-dd HH:mm:ss");
+  const dateString = getNdlaRobotDateFormat(new Date());
   const token = btoa(dateString);
   const aiUrl =
     user?.organization === "Rogaland fylkeskommune" ? `https://ndlarobot.org/${token}` : `https://ai.ndla.no/${aiLang}`;

--- a/src/containers/MyNdla/components/NotificationList.tsx
+++ b/src/containers/MyNdla/components/NotificationList.tsx
@@ -75,7 +75,7 @@ interface Props {
 }
 
 const NotificationList = ({ notifications, close }: Props) => {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const now = new Date();
 
   const notifcationsToShow = useMemo(
@@ -105,7 +105,7 @@ const NotificationList = ({ notifications, close }: Props) => {
                   />
                 </Text>
                 <Text color="text.default">
-                  {`${capitalizeFirstLetter(formatDistanceToNow(notification.notificationTime, i18n.language, now))}`}
+                  {`${capitalizeFirstLetter(formatDistanceToNow(notification.notificationTime, t, now))}`}
                 </Text>
               </TextWrapper>
             </Notification>

--- a/src/containers/MyNdla/components/NotificationList.tsx
+++ b/src/containers/MyNdla/components/NotificationList.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import { formatDistanceStrict } from "date-fns";
 import { useMemo } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { CircleFill, CornerDownLeftLine } from "@ndla/icons/common";
@@ -14,8 +13,8 @@ import { Text } from "@ndla/primitives";
 import { SafeLinkButton } from "@ndla/safelink";
 import { styled } from "@ndla/styled-system/jsx";
 import { GQLArenaNotificationV2Fragment } from "../../../graphqlTypes";
-import { DateFNSLocales } from "../../../i18n";
 import { routes } from "../../../routeHelpers";
+import { formatDistanceToNow } from "../../../util/formatDate";
 import { capitalizeFirstLetter } from "../Arena/utils";
 
 const StyledSafeLinkButton = styled(SafeLinkButton, {
@@ -106,13 +105,7 @@ const NotificationList = ({ notifications, close }: Props) => {
                   />
                 </Text>
                 <Text color="text.default">
-                  {`${capitalizeFirstLetter(
-                    formatDistanceStrict(Date.parse(notification.notificationTime), now, {
-                      addSuffix: true,
-                      locale: DateFNSLocales[i18n.language],
-                      roundingMethod: "floor",
-                    }),
-                  )}`}
+                  {`${capitalizeFirstLetter(formatDistanceToNow(notification.notificationTime, i18n.language, now))}`}
                 </Text>
               </TextWrapper>
             </Notification>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -6,7 +6,6 @@
  *
  */
 
-import * as datefnslocale from "date-fns/locale";
 import { i18n } from "i18next";
 import config from "./config";
 import { LocaleType } from "./interfaces";
@@ -86,11 +85,4 @@ export const initializeI18n = (i18n: i18n, language: string): i18n => {
   i18n.addResourceBundle("nn", "translation", nn, true, true);
   i18n.addResourceBundle("se", "translation", se, true, true);
   return instance;
-};
-
-export const DateFNSLocales = {
-  nn: datefnslocale.nn,
-  nb: datefnslocale.nb,
-  en: datefnslocale.enGB,
-  se: datefnslocale.nb,
 };

--- a/src/messages/messagesEN.ts
+++ b/src/messages/messagesEN.ts
@@ -207,6 +207,24 @@ const messages = {
     title: `Resources in $t(languages.{{language}})`,
     noSubjects: "We do not have any resources in this language yet.",
   },
+  date: {
+    ago: "ago",
+    now: "Just now",
+    units: {
+      day: "day",
+      days: "days",
+      hour: "hour",
+      hours: "hours",
+      minute: "minute",
+      minutes: "minutes",
+      month: "month",
+      months: "months",
+      second: "second",
+      seconds: "seconds",
+      year: "year",
+      years: "years",
+    },
+  },
 };
 
 export default messages;

--- a/src/messages/messagesNB.ts
+++ b/src/messages/messagesNB.ts
@@ -207,6 +207,24 @@ const messages = {
     title: `Ressurser på $t(languages.{{language}})`,
     noSubjects: "Vi har ikke noen ressurser på dette språket enda.",
   },
+  date: {
+    ago: "siden",
+    now: "Akkurat nå",
+    units: {
+      day: "dag",
+      days: "dager",
+      hour: "time",
+      hours: "timer",
+      minute: "minutt",
+      minutes: "minutter",
+      month: "måned",
+      months: "måneder",
+      second: "sekund",
+      seconds: "sekunder",
+      year: "år",
+      years: "år",
+    },
+  },
 };
 
 export default messages;

--- a/src/messages/messagesNN.ts
+++ b/src/messages/messagesNN.ts
@@ -207,6 +207,24 @@ const messages = {
     title: `Ressursar på $t(languages.{{language}})`,
     noSubjects: "Vi har ikkje nokon ressursar på dette språket enda.",
   },
+  date: {
+    ago: "sidan",
+    now: "Akkurat no",
+    units: {
+      day: "dag",
+      days: "dagar",
+      hour: "time",
+      hours: "timar",
+      minute: "minutt",
+      minutes: "minutt",
+      month: "månad",
+      months: "månader",
+      second: "sekund",
+      seconds: "sekund",
+      year: "år",
+      years: "år",
+    },
+  },
 };
 
 export default messages;

--- a/src/messages/messagesSE.ts
+++ b/src/messages/messagesSE.ts
@@ -203,6 +203,24 @@ const messages = {
     title: `Ressursar på $t(languages.{{language}})`,
     noSubjects: "Vi har ikkje nokon ressursar på dette språket enda.",
   },
+  date: {
+    ago: "siden",
+    now: "Akkurat nå",
+    units: {
+      day: "dag",
+      days: "dager",
+      hour: "time",
+      hours: "timer",
+      minute: "minutt",
+      minutes: "minutter",
+      month: "måned",
+      months: "måneder",
+      second: "sekund",
+      seconds: "sekunder",
+      year: "år",
+      years: "år",
+    },
+  },
 };
 
 export default messages;

--- a/src/util/__tests__/formatDate-test.ts
+++ b/src/util/__tests__/formatDate-test.ts
@@ -6,7 +6,8 @@
  *
  */
 
-import formatDate from "../formatDate";
+import nb from "../../messages/messagesNB";
+import formatDate, { formatDistanceToNowObject, getNdlaRobotDateFormat } from "../formatDate";
 
 test("util/formatDate norwegian format", () => {
   expect(typeof formatDate).toBe("function");
@@ -20,4 +21,71 @@ test("util/formatDate default to English format", () => {
 
   expect(formatDate("2014-12-24T10:44:06Z", "en")).toBe("12/24/2014");
   expect(formatDate("1978-03-07T15:00:00Z", "en")).toBe("03/07/1978");
+});
+
+const fakeTranslationFunction: any = (key: string) => {
+  let current: any = nb;
+  const parts = key.split(".");
+  for (const part of parts) {
+    current = current[part];
+    if (typeof current === "string") return current;
+  }
+  return key;
+};
+
+test("util/formatDistanceToNow returns seconds", () => {
+  expect(formatDistanceToNowObject(new Date(0), fakeTranslationFunction, new Date(1000 * 30))).toBe(
+    "30 sekunder siden",
+  );
+  expect(formatDistanceToNowObject(new Date(0), fakeTranslationFunction, new Date(1000))).toBe("1 sekund siden");
+});
+
+test("util/formatDistanceToNow returns minutes", () => {
+  expect(formatDistanceToNowObject(new Date(0), fakeTranslationFunction, new Date(1000 * 60 * 3))).toBe(
+    "3 minutter siden",
+  );
+  expect(formatDistanceToNowObject(new Date(0), fakeTranslationFunction, new Date(1000 * 60))).toBe("1 minutt siden");
+});
+
+test("util/formatDistanceToNow returns hours", () => {
+  expect(formatDistanceToNowObject(new Date(0), fakeTranslationFunction, new Date(1000 * 60 * 60 * 3))).toBe(
+    "3 timer siden",
+  );
+  expect(formatDistanceToNowObject(new Date(0), fakeTranslationFunction, new Date(1000 * 60 * 60))).toBe(
+    "1 time siden",
+  );
+});
+
+test("util/formatDistanceToNow returns days", () => {
+  expect(formatDistanceToNowObject(new Date(0), fakeTranslationFunction, new Date(1000 * 60 * 60 * 3 * 24))).toBe(
+    "3 dager siden",
+  );
+  expect(formatDistanceToNowObject(new Date(0), fakeTranslationFunction, new Date(1000 * 60 * 60 * 24))).toBe(
+    "1 dag siden",
+  );
+});
+
+test("util/formatDistanceToNow returns months", () => {
+  expect(formatDistanceToNowObject(new Date(0), fakeTranslationFunction, new Date(1000 * 60 * 60 * 3 * 24 * 31))).toBe(
+    "3 måneder siden",
+  );
+  expect(formatDistanceToNowObject(new Date(0), fakeTranslationFunction, new Date(1000 * 60 * 60 * 24 * 31))).toBe(
+    "1 måned siden",
+  );
+});
+
+test("util/formatDistanceToNow returns years", () => {
+  expect(
+    formatDistanceToNowObject(new Date(0), fakeTranslationFunction, new Date(1000 * 60 * 60 * 3 * 24 * 31 * 12)),
+  ).toBe("3 år siden");
+  expect(formatDistanceToNowObject(new Date(0), fakeTranslationFunction, new Date(1000 * 60 * 60 * 24 * 31 * 12))).toBe(
+    "1 år siden",
+  );
+});
+
+test("That getNdlaRobotDate returns date in correct format", () => {
+  const expectedFormat = "1970-01-01 01:00:00";
+  const date = new Date(0);
+
+  expect(getNdlaRobotDateFormat(date)).toBe(expectedFormat);
 });

--- a/src/util/formatDate.ts
+++ b/src/util/formatDate.ts
@@ -6,27 +6,29 @@
  *
  */
 
-import format from "date-fns/format";
 import { LocaleType } from "../interfaces";
 
 export default function formatDate(date: string, locale: LocaleType) {
-  if (locale === "nb" || locale === "nn") {
-    return format(new Date(date), "dd.MM.yyyy");
-  }
-  return format(new Date(date), "MM/dd/yyyy");
+  return new Intl.DateTimeFormat(locale, {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    timeZone: "CET",
+  }).format(new Date(date));
 }
-
-const timeFormatOptions = {
-  nn: "dd.MM.yyyy HH:mm:ss",
-  nb: "dd.MM.yyyy HH:mm:ss",
-  en: "dd/MM/yyyy HH:mm:ss",
-  se: "dd/MM/yyyy HH:mm:ss",
-};
 
 export function formatDateTime(timestamp: string, locale: LocaleType) {
   return formateDateObject(new Date(timestamp), locale);
 }
 
 export function formateDateObject(date: Date, locale: LocaleType) {
-  return format(date, timeFormatOptions[locale] ?? "dd/MM/yyyy HH:mm:ss");
+  return new Intl.DateTimeFormat(locale, {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    timeZone: "CET",
+  }).format(date);
 }

--- a/src/util/formatDate.ts
+++ b/src/util/formatDate.ts
@@ -6,14 +6,18 @@
  *
  */
 
+import { formatDistanceStrict } from "date-fns";
+import { TZDate } from "@date-fns/tz";
+import { DateFNSLocales } from "../i18n";
 import { LocaleType } from "../interfaces";
 
+const timeZone = "CET";
 export default function formatDate(date: string, locale: LocaleType) {
   return new Intl.DateTimeFormat(locale, {
     year: "numeric",
     month: "2-digit",
     day: "2-digit",
-    timeZone: "CET",
+    timeZone,
   }).format(new Date(date));
 }
 
@@ -29,6 +33,16 @@ export function formateDateObject(date: Date, locale: LocaleType) {
     hour: "2-digit",
     minute: "2-digit",
     second: "2-digit",
-    timeZone: "CET",
+    timeZone,
   }).format(date);
+}
+
+export function formatDistanceToNow(date: string, locale: LocaleType, nowDate?: Date): string {
+  const tzDate = new TZDate(date, "CET");
+  const now = nowDate ? nowDate : new Date();
+  return formatDistanceStrict(tzDate, now, {
+    addSuffix: true,
+    locale: DateFNSLocales[locale],
+    roundingMethod: "floor",
+  });
 }

--- a/src/util/formatDate.ts
+++ b/src/util/formatDate.ts
@@ -6,12 +6,20 @@
  *
  */
 
-import { formatDistanceStrict } from "date-fns";
-import { TZDate } from "@date-fns/tz";
-import { DateFNSLocales } from "../i18n";
+import { TFunction } from "i18next";
+import { useTranslation } from "react-i18next";
 import { LocaleType } from "../interfaces";
 
 const timeZone = "CET";
+const timeUnits = [
+  { unit: "year", ms: 1000 * 60 * 60 * 24 * 365 },
+  { unit: "month", ms: 1000 * 60 * 60 * 24 * 30 },
+  { unit: "day", ms: 1000 * 60 * 60 * 24 },
+  { unit: "hour", ms: 1000 * 60 * 60 },
+  { unit: "minute", ms: 1000 * 60 },
+  { unit: "second", ms: 1000 },
+];
+
 export default function formatDate(date: string, locale: LocaleType) {
   return new Intl.DateTimeFormat(locale, {
     year: "numeric",
@@ -37,12 +45,43 @@ export function formateDateObject(date: Date, locale: LocaleType) {
   }).format(date);
 }
 
-export function formatDistanceToNow(date: string, locale: LocaleType, nowDate?: Date): string {
-  const tzDate = new TZDate(date, "CET");
-  const now = nowDate ? nowDate : new Date();
-  return formatDistanceStrict(tzDate, now, {
-    addSuffix: true,
-    locale: DateFNSLocales[locale],
-    roundingMethod: "floor",
-  });
+export const getNdlaRobotDateFormat = (date: Date) => {
+  return new Intl.DateTimeFormat("en-CA", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    timeZone,
+    hour12: false,
+  })
+    .format(date)
+    .replace(",", "");
+};
+
+export function useFormatDistance(date: string, toDate?: Date): string {
+  const { t } = useTranslation();
+  return formatDistanceToNow(date, t, toDate);
+}
+
+export function formatDistanceToNowObject(date1: Date, t: TFunction, nowDate?: Date): string {
+  const date2 = nowDate ?? new Date();
+  const differenceInMs: number = date2.getTime() - date1.getTime();
+  for (const { unit, ms } of timeUnits) {
+    const diff = differenceInMs / ms;
+    const absDiff = Math.floor(Math.abs(diff));
+    if (absDiff >= 1) {
+      const translationKey = absDiff === 1 ? `date.units.${unit}` : `date.units.${unit}s`;
+      const unitTranslated = t(translationKey);
+      return `${absDiff} ${unitTranslated} ${t("date.ago")}`;
+    }
+  }
+
+  return t("date.now");
+}
+
+export function formatDistanceToNow(date: string, t: TFunction, nowDate?: Date): string {
+  const date1 = new Date(date);
+  return formatDistanceToNowObject(date1, t, nowDate);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1335,6 +1335,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@date-fns/tz@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@date-fns/tz@npm:1.2.0"
+  checksum: 10c0/411e9d4303b10951f6fd0189d18fb845f0d934a575df2176bc10daf664282c765fb6b057a977e446bbb1229151d89e7788978600a019f1fc24b5c75276d496bd
+  languageName: node
+  linkType: hard
+
 "@dnd-kit/accessibility@npm:^3.0.0":
   version: 3.0.1
   resolution: "@dnd-kit/accessibility@npm:3.0.1"
@@ -7353,6 +7360,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"date-fns@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "date-fns@npm:4.1.0"
+  checksum: 10c0/b79ff32830e6b7faa009590af6ae0fb8c3fd9ffad46d930548fbb5acf473773b4712ae887e156ba91a7b3dc30591ce0f517d69fd83bd9c38650fdc03b4e0bac8
+  languageName: node
+  linkType: hard
+
 "debounce@npm:^1.2.0":
   version: 1.2.1
   resolution: "debounce@npm:1.2.1"
@@ -11603,6 +11617,7 @@ __metadata:
     "@apollo/client": "npm:^3.9.11"
     "@ark-ui/react": "npm:^4.1.2"
     "@babel/core": "npm:^7.24.5"
+    "@date-fns/tz": "npm:^1.2.0"
     "@dnd-kit/core": "npm:^6.0.8"
     "@dnd-kit/modifiers": "npm:^6.0.1"
     "@dnd-kit/sortable": "npm:7.0.2"
@@ -11648,7 +11663,7 @@ __metadata:
     babel-plugin-graphql-tag: "npm:^3.3.0"
     concurrently: "npm:^8.2.2"
     cross-env: "npm:^7.0.3"
-    date-fns: "npm:^2.30.0"
+    date-fns: "npm:^4.1.0"
     esbuild: "npm:^0.20.2"
     eslint: "npm:^8.57.0"
     eslint-config-ndla: "npm:^5.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7360,13 +7360,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-fns@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "date-fns@npm:4.1.0"
-  checksum: 10c0/b79ff32830e6b7faa009590af6ae0fb8c3fd9ffad46d930548fbb5acf473773b4712ae887e156ba91a7b3dc30591ce0f517d69fd83bd9c38650fdc03b4e0bac8
-  languageName: node
-  linkType: hard
-
 "debounce@npm:^1.2.0":
   version: 1.2.1
   resolution: "debounce@npm:1.2.1"
@@ -11663,7 +11656,6 @@ __metadata:
     babel-plugin-graphql-tag: "npm:^3.3.0"
     concurrently: "npm:^8.2.2"
     cross-env: "npm:^7.0.3"
-    date-fns: "npm:^4.1.0"
     esbuild: "npm:^0.20.2"
     eslint: "npm:^8.57.0"
     eslint-config-ndla: "npm:^5.0.3"


### PR DESCRIPTION
Fikser en hydrerings feil på https://test.ndla.no/about/utlysninger
Kan testes lokalt med `TZ="UTC" yarn start`

Ideelt sett så burde vi sikkert droppet serverside rendering for alle datoer (eller i alle fall gjort en oppdatering på klient om tidssonen er forskjellig), men kanskje litt for mye hassle?