### PR TITLE
Fix hydration error on access denied error pages

### DIFF
--- a/src/client.tsx
+++ b/src/client.tsx
@@ -31,7 +31,7 @@ import "@fontsource/source-serif-pro/index.css";
 import { i18nInstance } from "@ndla/ui";
 import { getCookie, setCookie } from "@ndla/util";
 import App from "./App";
-import ResponseContext from "./components/ResponseContext";
+import ResponseContext, { ResponseInfo } from "./components/ResponseContext";
 import { VersionHashProvider } from "./components/VersionHashContext";
 import { STORED_LANGUAGE_COOKIE_KEY } from "./constants";
 import { getLocaleInfoFromPath, initializeI18n, isValidLocale, supportedLanguages } from "./i18n";
@@ -179,13 +179,14 @@ const renderOrHydrate = (container: HTMLElement, children: ReactNode) => {
     hydrateRoot(container, children);
   }
 };
+const responseContext = new ResponseInfo(serverResponse);
 
 renderOrHydrate(
   document.getElementById("root")!,
   <HelmetProvider>
     <I18nextProvider i18n={i18n}>
       <ApolloProvider client={client}>
-        <ResponseContext.Provider value={{ status: serverResponse }}>
+        <ResponseContext.Provider value={responseContext}>
           <VersionHashProvider value={versionHash}>
             <LanguageWrapper basename={basename} />
           </VersionHashProvider>

--- a/src/components/ResponseContext.tsx
+++ b/src/components/ResponseContext.tsx
@@ -8,8 +8,17 @@
 
 import { createContext } from "react";
 
-export interface ResponseInfo {
+export class ResponseInfo {
   status?: number;
+
+  constructor(status?: number) {
+    this.status = status;
+  }
+
+  isAccessDeniedError(): boolean {
+    return this.status === 401 || this.status === 403;
+  }
 }
+
 const ResponseContext = createContext<ResponseInfo | undefined>(undefined);
 export default ResponseContext;

--- a/src/components/ResponseContext.tsx
+++ b/src/components/ResponseContext.tsx
@@ -18,6 +18,10 @@ export class ResponseInfo {
   isAccessDeniedError(): boolean {
     return this.status === 401 || this.status === 403;
   }
+
+  isGoneError(): boolean {
+    return this.status === 410;
+  }
 }
 
 const ResponseContext = createContext<ResponseInfo | undefined>(undefined);

--- a/src/containers/PlainArticlePage/PlainArticlePage.tsx
+++ b/src/containers/PlainArticlePage/PlainArticlePage.tsx
@@ -58,12 +58,9 @@ const PlainArticlePage = () => {
   if (loading) {
     return <ContentPlaceholder variant="article" />;
   }
-  if (error?.graphQLErrors.some((err) => err.extensions.status === 410) && redirectContext) {
-    redirectContext.status = 410;
-    return <UnpublishedResourcePage />;
-  }
-
-  if (responseContext?.status === 410) {
+  const has410Error = error?.graphQLErrors.some((err) => err.extensions.status === 410);
+  if (has410Error || responseContext?.isGoneError()) {
+    if (redirectContext) redirectContext.status = 410;
     return <UnpublishedResourcePage />;
   }
 

--- a/src/containers/ResourcePage/ResourcePage.tsx
+++ b/src/containers/ResourcePage/ResourcePage.tsx
@@ -102,12 +102,12 @@ const ResourcePage = () => {
   }
 
   const accessDeniedErrors = findAccessDeniedErrors(error);
-  if (accessDeniedErrors) {
+  if (accessDeniedErrors || responseContext?.isAccessDeniedError()) {
     const nonRecoverableError = accessDeniedErrors.some(
       (e) => !e.path?.includes("coreResources") && !e.path?.includes("supplementaryResources"),
     );
 
-    if (nonRecoverableError) {
+    if (nonRecoverableError || responseContext?.isAccessDeniedError()) {
       return <AccessDeniedPage />;
     }
   }

--- a/src/server/render/defaultRender.tsx
+++ b/src/server/render/defaultRender.tsx
@@ -69,7 +69,7 @@ export const defaultRender: RenderFunc = async (req) => {
   const client = createApolloClient(locale, versionHash, req.path);
   const i18n = initializeI18n(i18nInstance, locale);
   const redirectContext: RedirectInfo = {};
-  const responseContext: ResponseInfo = {};
+  const responseContext: ResponseInfo = new ResponseInfo();
   // @ts-ignore
   const helmetContext: FilledContext = {};
 


### PR DESCRIPTION
Fikser hydreringsfeil på resourcepage dersom vi finner en tilgangsfeil.

"Problemet" er at apollo ikke tar med feil i cachen sin så alle feil vil bare rendres på server dersom vi baserer oss på `error` objektet i queryen.

Denne PR'en fikser det ved å sende feil fra server til klient (og å hente det ut i `useGraphQuery` gjennom en context.

Eksempel hvis en læringssti er privat: http://localhost:3000/subject:20/topic:1:194565/resource:1:179189
Eksempel på en 410: http://localhost:3000/nb/article/9645