### PR TITLE
Add redirect functionality to short urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@ndla/scripts": "^2.1.2",
     "@ndla/types-backend": "^0.2.88",
     "@ndla/types-embed": "^5.0.4-alpha.0",
-    "@ndla/types-taxonomy": "^1.0.26",
+    "@ndla/types-taxonomy": "^1.0.33",
     "@pandacss/dev": "^0.46.1",
     "@playwright/test": "^1.43.1",
     "@sentry/vite-plugin": "^2.22.4",

--- a/src/config.ts
+++ b/src/config.ts
@@ -131,6 +131,7 @@ export type ConfigType = {
   enablePrettyUrls: boolean;
   externalArena: boolean;
   arenaDomain: string;
+  enablePrettyUrlRedirect: boolean;
 };
 
 const getServerSideConfig = (): ConfigType => {
@@ -172,6 +173,7 @@ const getServerSideConfig = (): ConfigType => {
     enablePrettyUrls: getEnvironmentVariabel("ENABLE_PRETTY_URLS", false),
     externalArena: getEnvironmentVariabel("EXTERNAL_ARENA", false),
     arenaDomain: arenaDomain(ndlaEnvironment),
+    enablePrettyUrlRedirect: getEnvironmentVariabel("ENABLE_PRETTY_URL_REDIRECT", false),
   };
 };
 

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -14,6 +14,7 @@ import { getCookie } from "@ndla/util";
 import { generateOauthData } from "./helpers/oauthHelper";
 import { feideLogout, getFeideToken, getRedirectUrl } from "./helpers/openidHelper";
 import ltiConfig from "./ltiConfig";
+import { contextRedirectRoute } from "./routes/contextRedirectRoute";
 import { forwardingRoute } from "./routes/forwardingRoute";
 import { oembedArticleRoute } from "./routes/oembedArticleRoute";
 import { podcastFeedRoute } from "./routes/podcastFeedRoute";
@@ -206,6 +207,14 @@ router.post("/lti/oauth", async (req, res) => {
     );
   },
 );
+
+router.get(["/subject*splat", "/:lang/subject*splat"], async (req, res, next) => {
+  if (config.enablePrettyUrlRedirect) {
+    contextRedirectRoute(req, res, next);
+  } else {
+    next();
+  }
+});
 
 router.get("/*splat/search/apachesolr_search*secondsplat", (_, res) => {
   sendResponse(res, undefined, 410);

--- a/src/server/routes/contextRedirectRoute.ts
+++ b/src/server/routes/contextRedirectRoute.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2018-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { NextFunction, Request, Response } from "express";
+import { Query } from "express-serve-static-core";
+import { ResolvedUrl } from "@ndla/types-taxonomy";
+import { resolveJsonOrRejectWithError, apiResourceUrl } from "../../util/apiHelpers";
+
+async function resolve(path: string, lang?: string) {
+  const baseUrl = apiResourceUrl("/taxonomy/v1/url/resolve");
+  const langPart = lang ? `&language=${lang}` : "";
+  const response = await fetch(`${baseUrl}?path=${path}${langPart}`);
+  return resolveJsonOrRejectWithError<ResolvedUrl>(response);
+}
+
+export const redirectPath = async (path: string, lang?: string) => {
+  const resource = await resolve(path);
+  const languagePrefix = lang && lang !== "nb" ? lang : ""; // send urls with nb to root/default lang
+  return `${languagePrefix ? `/${languagePrefix}` : ""}${resource!.url}`;
+};
+
+type SplatRequest = Request<{ splat: string[]; lang?: string }, any, any, Query, Record<string, any>>;
+
+export async function contextRedirectRoute(req: SplatRequest, res: Response, next: NextFunction) {
+  try {
+    const path = await redirectPath(`/subject${req.params.splat?.join("/")}`, req.params.lang);
+    res.redirect(301, path);
+  } catch (e) {
+    next();
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3277,10 +3277,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ndla/types-taxonomy@npm:^1.0.26":
-  version: 1.0.26
-  resolution: "@ndla/types-taxonomy@npm:1.0.26"
-  checksum: 10c0/6d50a6a80aff8140b6fbcccfdf9a05372100a9b57fde5b6a338ea13ac9eb4b0d28dbc9d1dca0058a64211561d35d1ccec3321b9b7ef935fed2fd9df6a7c8f7e1
+"@ndla/types-taxonomy@npm:^1.0.33":
+  version: 1.0.33
+  resolution: "@ndla/types-taxonomy@npm:1.0.33"
+  checksum: 10c0/7e309ae9f2ee2935da02491f768985d9e8bc088eb084a0e440bef3e56ec81b4f6a9b2abf5f5e471fa727ce32170be7a406c795ad7492f3df2d80176f06322076
   languageName: node
   linkType: hard
 
@@ -11638,7 +11638,7 @@ __metadata:
     "@ndla/tracker": "npm:^5.0.11-alpha.0"
     "@ndla/types-backend": "npm:^0.2.88"
     "@ndla/types-embed": "npm:^5.0.4-alpha.0"
-    "@ndla/types-taxonomy": "npm:^1.0.26"
+    "@ndla/types-taxonomy": "npm:^1.0.33"
     "@ndla/ui": "npm:^56.0.67-alpha.0"
     "@ndla/util": "npm:^5.0.0-alpha.0"
     "@pandacss/dev": "npm:^0.46.1"


### PR DESCRIPTION
Dette fungerer som det skal men kompileringa feiler:
```bashs
[0] src/server/api.ts(213,26): error TS2345: Argument of type 'Request<ParamsDictionary, any, any, ParsedQs, Record<string, any>>' is not assignable to parameter of type 'SplatRequest'.
[0]   Types of property 'params' are incompatible.
[0]     Property 'splat' is missing in type 'ParamsDictionary' but required in type '{ splat: string[]; lang?: string | undefined; }'.

``` 

Curl på http://localhost:3000/subject:1:cd3a3bb8-eed2-4d02-8c21-b3dca5a2a11b/topic:39a85e43-bb2b-4ff0-8cb2-eeb38c644571/resource:20598a4c-2070-4066-8f03-ac8d8f2275cb

gir meg 301 til /r/bransje-og-arbeidsliv-rmrmf-vg1/faguttrykk:-servitor/be0e269d18