### PR TITLE
chore: put quotes inside template string to be more explicit about intent

### DIFF
--- a/src/components/MyNdla/AddResourceToFolder.tsx
+++ b/src/components/MyNdla/AddResourceToFolder.tsx
@@ -100,7 +100,7 @@ const ResourceAddedSnack = ({ folder }: ResourceAddedSnackProps) => {
   return (
     <div>
       {t("myNdla.resource.addedToFolder")}
-      <SafeLink to={routes.myNdla.folder(folder.id)}>"{folder.name}"</SafeLink>
+      <SafeLink to={routes.myNdla.folder(folder.id)}>{`"${folder.name}"`}</SafeLink>
     </div>
   );
 };


### PR DESCRIPTION
Regelen var skrudd av før, men den er egentlig fin. Forteller oss bare om tilfeller der vi f.eks kan ende opp med `text}` i DOM