### PR TITLE
fix: properly render quotes in missing results text

### DIFF
--- a/src/containers/Masthead/components/MastheadSearch.tsx
+++ b/src/containers/Masthead/components/MastheadSearch.tsx
@@ -325,7 +325,7 @@ const MastheadSearch = () => {
               {!loading && !!query && (
                 <div>
                   {!(searchHits.length > 1) ? (
-                    <Text textStyle="label.small">{t("searchPage.noHitsShort", { query: query })}</Text>
+                    <Text textStyle="label.small">{`${t("searchPage.noHitsShort", { query: "" })} ${query}`}</Text>
                   ) : (
                     <Text textStyle="label.small">{`${t("searchPage.resultType.showingSearchPhrase")} "${query}"`}</Text>
                   )}

--- a/src/containers/SearchPage/components/SearchHeader.tsx
+++ b/src/containers/SearchPage/components/SearchHeader.tsx
@@ -169,11 +169,11 @@ const SearchHeader = ({
             <div>
               {noResults ? (
                 <Text textStyle="label.small">
-                  {t("searchPage.noHitsShort", { query: query })}
+                  {`${t("searchPage.noHitsShort", { query: "" })}${query}`}
                   {activeSubjectFilters.length ? `. ${t("searchPage.removeFilterSuggestion")}` : undefined}
                 </Text>
               ) : (
-                <Text textStyle="label.small">{`${t("searchPage.resultType.showingSearchPhrase")} "${query}"`}</Text>
+                <Text textStyle="label.small">{`${t("searchPage.resultType.showingSearchPhrase")} ${query}`}</Text>
               )}
               {!!suggestion && (
                 <Text textStyle="label.small">


### PR DESCRIPTION
Fikser https://trello.com/c/TO7O1Wkw/1148-hermetegn-blir-quot-i-s%C3%B8k

i18next escaper automatisk quotes. Utnytter oppbyggningen av oversettelsen til å droppe å sende inn query som et parameter, og legger det heller til på slutten av oversettelsesstrengen. Da slipper vi å skru av escaping i i18next.