### PR TITLE
Fix crashing express error handler

### DIFF
--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -178,14 +178,14 @@ router.get("/logout/session", (req, res) => {
   return res.redirect(redirect);
 });
 
-router.get(["/about/*path", "/:lang/about/*path"], (req, res) => {
+router.get(["/about/:path", "/:lang/about/:path"], (req, res) => {
   const { lang, path } = req.params;
   res.redirect(301, lang ? `/${lang}${ABOUT_PATH}/${path}` : `${ABOUT_PATH}/${path}`);
 });
 
-router.get(["/subjects/*path", "/:lang/subjects/*path"], (req, res) => {
-  const { lang, path } = req.params;
-  res.redirect(301, lang ? `/${lang}/${path}` : `/${path}`);
+router.get<{ path: string[]; lang?: string }>(["/subjects/*path", "/:lang/subjects/*path"], (req, res) => {
+  const { lang, path = [] } = req.params;
+  res.redirect(301, lang ? `/${lang}/${path.join("/")}` : `/${path.join("/")}`);
 });
 
 router.get("/lti/config.xml", async (_req, res) => {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -284,13 +284,16 @@ const errorHandler = (err: Error, req: Request, res: Response) => {
   sendInternalServerError(req, res, statusCode);
 };
 
-app.use(errorHandler);
-
 app.get("/*splat", (_req: Request, res: Response) => {
   res.redirect(NOT_FOUND_PAGE_PATH);
 });
 app.post("/*splat", (_req: Request, res: Response) => {
   res.redirect(NOT_FOUND_PAGE_PATH);
 });
+
+// NOTE: The error handler should be defined after all middlewares and routes
+//       according to the express documentation
+//       https://expressjs.com/en/guide/error-handling.html#writing-error-handlers
+app.use(errorHandler);
 
 export default app;


### PR DESCRIPTION
Denne kræsjet tidligere fordi `next("route")` rutet til errorhandleren med litt rare parametere
Hvem prøvde å si at typescript var typesikkert :nerd_face: 


Kan testes ved å se at rare url'er ikke kræsjer applikasjonen.
Feks http://localhost:3000/nb/subject:7509b507-548d-48e1-bef3-a06758e4820c/topic:e387b5d7-62c1-4a14-82d1-999beb95e926/topic:120cf233-a240-44e6-b9ff-651ff97369da/7509b507-548d-48e1-bef3-a06758e4820c/topic:e387b5d7-62c1-4a14-82d1-999beb95e926