### PR TITLE
fix: only show resources if both parent and root exists

### DIFF
--- a/src/components/Learningpath/LastLearningpathStepInfo.tsx
+++ b/src/components/Learningpath/LastLearningpathStepInfo.tsx
@@ -77,13 +77,13 @@ const LastLearningpathStepInfo = ({ resource, seqNo, numberOfLearningSteps, titl
           </Text>
         )}
       </LinksWrapper>
-      {!!parent && (
+      {!!parent && !!root && (
         <NoSSR fallback={null}>
           <Resources
             headingType="h2"
             key="resources"
             parentId={parent.id}
-            rootId={root?.id}
+            rootId={root.id}
             subHeadingType="h3"
             currentResourceId={resource?.id}
           />


### PR DESCRIPTION
Fixes https://ndlano.sentry.io/issues/12881342/?project=4508018776735824&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=24h&stream_index=12