### PR TITLE
Add error on learningpath oembed

### DIFF
--- a/e2e/specs/authenticated/MyNDLAMenu.spec.ts
+++ b/e2e/specs/authenticated/MyNDLAMenu.spec.ts
@@ -33,7 +33,7 @@ test("can navigate to profile", async ({ page }) => {
 
 test("have all options at the different pages", async ({ page }) => {
   await mockWaitResponse(page, "**/graphql-api/graphql");
-  await expect(page.getByRole("link", { name: "Logg ut" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Logg ut" })).toBeVisible({ timeout: 10000 });
   const options = await page.getByTestId("my-ndla-menu").getByRole("listitem").allInnerTexts();
   await page.getByRole("listitem").getByRole("link", { name: "Mine mapper" }).click();
   await expect(page.getByRole("heading").getByText("Mine mapper")).toBeVisible();

--- a/src/server/routes/__tests__/__snapshots__/oembedArticleRoute-test.ts.snap
+++ b/src/server/routes/__tests__/__snapshots__/oembedArticleRoute-test.ts.snap
@@ -2,7 +2,14 @@
 
 exports[`oembedArticleRoute invalid url 1`] = `
 {
-  "data": "Bad request. Invalid url.",
+  "data": "Bad request. Url not recognized",
+  "status": 400,
+}
+`;
+
+exports[`oembedArticleRoute learningpath fail 1`] = `
+{
+  "data": "No oembed support for learningpaths",
   "status": 400,
 }
 `;

--- a/src/server/routes/__tests__/__snapshots__/oembedArticleRoute-test.ts.snap
+++ b/src/server/routes/__tests__/__snapshots__/oembedArticleRoute-test.ts.snap
@@ -9,8 +9,8 @@ exports[`oembedArticleRoute invalid url 1`] = `
 
 exports[`oembedArticleRoute learningpath fail 1`] = `
 {
-  "data": "No oembed support for learningpaths",
-  "status": 400,
+  "data": "Not found",
+  "status": 404,
 }
 `;
 

--- a/src/server/routes/__tests__/oembedArticleRoute-test.ts
+++ b/src/server/routes/__tests__/oembedArticleRoute-test.ts
@@ -13,6 +13,7 @@ import { oembedArticleRoute } from "../oembedArticleRoute";
 const validArticleUrl1 = "https://test.ndla.no/subject:3/topic:1:55163/topic:1:168398/resource:1:1682";
 const validArticleUrl2 = "https://test.ndla.no/subjects/subject:3/topic:1:55163/topic:1:168398/resource:1:1682";
 const unvalidArticleUrl = "https://test.ndla.no/subject:3";
+const validLearningpathUrl = "https://test.ndla.no/subject:3/topic:1:55163/topic:1:168398/resource:1:9876";
 
 test("oembedArticleRoute success", async () => {
   nock("http://ndla-api").get("/taxonomy/v1/nodes/urn:resource:1:1682?language=nb").times(2).reply(200, {
@@ -36,6 +37,24 @@ test("oembedArticleRoute success", async () => {
   } as any as Request);
 
   expect(response2).toMatchSnapshot();
+  expect(nock.pendingMocks()).toStrictEqual([]);
+});
+
+test("oembedArticleRoute learningpath fail", async () => {
+  nock("http://ndla-api").get("/taxonomy/v1/nodes/urn:resource:1:9876?language=nb").reply(200, {
+    id: "urn:resource:1:9876",
+    contentUri: "urn:learningpath:123",
+    name: "Learningpath title",
+  });
+
+  const response = await oembedArticleRoute({
+    query: {
+      url: validLearningpathUrl,
+    },
+  } as any as Request);
+
+  expect(response).toMatchSnapshot();
+
   expect(nock.pendingMocks()).toStrictEqual([]);
 });
 

--- a/src/statusCodes.ts
+++ b/src/statusCodes.ts
@@ -5,9 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-export const MOVED_PERMANENTLY = 301;
 export const OK = 200;
-export const INTERNAL_SERVER_ERROR = 500;
-export const BAD_REQUEST = 400;
+export const MOVED_PERMANENTLY = 301;
 export const TEMPORARY_REDIRECT = 307;
+export const BAD_REQUEST = 400;
+export const NOT_FOUND = 404;
 export const GONE = 410;
+export const INTERNAL_SERVER_ERROR = 500;


### PR DESCRIPTION
Fant mange innslag av henting av artikkel med id undefined. Det er fordi oembed-endepunktet om kalla med en kontekst som er læringssti returnerer iframe-url med undefined i seg.

Eks
```
{"type":"rich","version":"1.0","height":480,"width":854,"title":"Ein enkel veg til heilt grei nynorsk","html":"<iframe aria-label=\"Ein enkel veg til heilt grei nynorsk\" src=\"https://ndla.no/article-iframe/nb/urn:resource:2937bdb1-564f-4352-be34-512bcfeff644/undefined\" height=\"480\" width=\"854\" frameborder=\"0\" allowFullscreen=\"\" />"}
```
