### PR TITLE
fix: redirect to correct locale server-side

### DIFF
--- a/src/server/render/defaultRender.tsx
+++ b/src/server/render/defaultRender.tsx
@@ -41,7 +41,7 @@ export const defaultRender: RenderFunc = async (req) => {
 
   const { basename, basepath, abbreviation } = getLocaleInfoFromPath(req.originalUrl);
   const locale = getCookieLocaleOrFallback(resCookie, abbreviation);
-  if (locale !== basename && locale !== "nb" && basename !== "") {
+  if ((basename === "" && locale !== "nb") || (basename && basename !== locale)) {
     return {
       status: TEMPORARY_REDIRECT,
       location: `/${locale}${basepath}`,


### PR DESCRIPTION
La merke til at dette ikke funket helt som det skulle. `test.ndla.no/en` med locale satt som "nb" redirecter kun på klient, og ikke på server. 