### PR TITLE
Added height to styledpagecontainer learningpath

### DIFF
--- a/src/components/Learningpath/Learningpath.tsx
+++ b/src/components/Learningpath/Learningpath.tsx
@@ -55,6 +55,7 @@ const StyledPageContainer = styled(PageContainer, {
   base: {
     position: "relative",
     background: "background.subtle",
+    height: "100vh",
     gap: "large",
   },
   variants: {

--- a/src/components/Learningpath/Learningpath.tsx
+++ b/src/components/Learningpath/Learningpath.tsx
@@ -55,7 +55,7 @@ const StyledPageContainer = styled(PageContainer, {
   base: {
     position: "relative",
     background: "background.subtle",
-    height: "100vh",
+    minHeight: "100vh",
     gap: "large",
   },
   variants: {


### PR DESCRIPTION
Bakgrunnen til læringsstier fylte ikke siden lenger.

[test.ndla.no/learningpaths/3393/steps/19708](test.ndla.no)

/learningpaths/3393/steps/19708 på instansen for å se løsningen