### PR TITLE
Remove AccordionRoot marginInline to keep same width as content

### DIFF
--- a/src/components/Learningpath/Learningpath.tsx
+++ b/src/components/Learningpath/Learningpath.tsx
@@ -131,7 +131,6 @@ const StyledAccordionRoot = styled(AccordionRoot, {
     position: "sticky",
     zIndex: "sticky",
     top: "var(--masthead-height)",
-    marginInline: "small",
   },
   variants: {
     context: {


### PR DESCRIPTION
https://trello.com/c/UN1ZtPNV/1192-litt-bred-ingress-p%C3%A5-forh%C3%A5ndsvisningen-p%C3%A5-l%C3%A6ringsstier