### PR TITLE
External learningpath step form: Validate url before triggering request

### DIFF
--- a/src/containers/MyNdla/Learningpath/components/ExternalForm.tsx
+++ b/src/containers/MyNdla/Learningpath/components/ExternalForm.tsx
@@ -61,7 +61,7 @@ export const ExternalForm = () => {
 
   useEffect(() => {
     const { unsubscribe } = watch(async ({ url, title, introduction }, { name }) => {
-      if (name === "url" && url?.length && url?.length > 0 && (!title || !introduction)) {
+      if (name === "url" && url?.length && url?.match(URL_REGEX) && (!title || !introduction)) {
         const { data } = await fetchOpengraph({ variables: { url } });
         if (!title) {
           setValue("title", data?.opengraph?.title ?? "");


### PR DESCRIPTION
Fikser opp i en kommentar jeg hadde på en annen PR:

> Ikke direkte relatert til denne, så det kan sikkert gjøres i egen PR, men vi burde kanskje sjekke at url er på riktig format før vi sender av gårde requesten i formen for å legge til innhold fra et annet nettsted? Får veldig mange "Invalid URL"- feil fra gql hvis man prøver å skrive noe i input-feltet