### PR TITLE
fix/hide toold when empty with new arena changes

### DIFF
--- a/src/containers/MyNdla/components/Toolbar.tsx
+++ b/src/containers/MyNdla/components/Toolbar.tsx
@@ -85,7 +85,7 @@ const Toolbar = ({ menuItems, showButtons }: Props) => {
   const { user } = useContext(AuthContext);
 
   return (
-    <ToolbarContainer data-visible={!!menuItems?.length || !!user?.arenaEnabled}>
+    <ToolbarContainer data-visible={!!menuItems?.length || (!!user?.arenaEnabled && !config.externalArena)}>
       <StyledPageContent>
         <Wrapper>
           <div>


### PR DESCRIPTION
Toolbar ble vist selv om den var tom i læringsstier så nå ern borte 🍡 