### PR TITLE
Reintroduce overflowX: 'hidden' to prevent page overflow

### DIFF
--- a/src/containers/AboutPage/AboutPageContent.tsx
+++ b/src/containers/AboutPage/AboutPageContent.tsx
@@ -48,6 +48,18 @@ const StyledHeroContent = styled(HeroContent, {
   },
 });
 
+const StyledPageContent = styled(PageContent, {
+  base: {
+    overflowX: "clip",
+  },
+});
+
+const StyledArticleContent = styled(ArticleContent, {
+  base: {
+    overflowX: "visible",
+  },
+});
+
 export const findBreadcrumb = (
   menu: GQLAboutPage_FrontpageMenuFragment[],
   slug: string | undefined,
@@ -153,7 +165,7 @@ const AboutPageContent = ({ article: _article, frontpage }: Props) => {
             <HomeBreadcrumb items={crumbs} />
           </StyledHeroContent>
         </PageContent>
-        <PageContent variant="article" gutters="tabletUp">
+        <StyledPageContent variant="article" gutters="tabletUp">
           <PageContent variant="content" asChild>
             <ArticleWrapper {...licenseProps}>
               <ArticleHeader>
@@ -164,7 +176,7 @@ const AboutPageContent = ({ article: _article, frontpage }: Props) => {
                   <Text textStyle="body.xlarge">{article.transformedContent.introduction}</Text>
                 )}
               </ArticleHeader>
-              <ArticleContent>{article.transformedContent.content}</ArticleContent>
+              <StyledArticleContent>{article.transformedContent.content}</StyledArticleContent>
               <ArticleFooter>
                 <AccordionRoot multiple>
                   <ArticleBylineAccordionItem accordionTitle={t("article.useContent")} value="rulesForUse">
@@ -179,7 +191,7 @@ const AboutPageContent = ({ article: _article, frontpage }: Props) => {
               </ArticleFooter>
             </ArticleWrapper>
           </PageContent>
-        </PageContent>
+        </StyledPageContent>
       </Hero>
     </main>
   );


### PR DESCRIPTION
Dette er en reversering av denne: https://github.com/NDLANO/ndla-frontend/pull/2334/files#diff-7931196238d57c50b5d545aa690b836511c19be71364e0bee0f589250dd46925 for å fikse at footeren overflower på om-ndla-sider nå!

Vet ikke om dette brekker noe av parallax oppførselen? @gunnarvelle 