### PR TITLE
fix: do not wrap switch in form

### DIFF
--- a/src/containers/Resources/Resources.tsx
+++ b/src/containers/Resources/Resources.tsx
@@ -80,7 +80,7 @@ const ListWrapper = styled("div", {
   },
 });
 
-const StyledForm = styled("form", {
+const StyledSwitchRoot = styled(SwitchRoot, {
   base: {
     marginInlineStart: "auto",
   },
@@ -187,15 +187,13 @@ const Resources = ({
           <Text textStyle="label.medium">{node?.name}</Text>
         </StyledHGroup>
         {!!hasSupplementaryResources && (
-          <StyledForm>
-            <SwitchRoot checked={showAdditionalResources} onCheckedChange={toggleAdditionalResources}>
-              <SwitchLabel>{t("resource.activateAdditionalResources")}</SwitchLabel>
-              <SwitchControl>
-                <SwitchThumb />
-              </SwitchControl>
-              <SwitchHiddenInput />
-            </SwitchRoot>
-          </StyledForm>
+          <StyledSwitchRoot checked={showAdditionalResources} onCheckedChange={toggleAdditionalResources}>
+            <SwitchLabel>{t("resource.activateAdditionalResources")}</SwitchLabel>
+            <SwitchControl>
+              <SwitchThumb />
+            </SwitchControl>
+            <SwitchHiddenInput />
+          </StyledSwitchRoot>
         )}
       </TitleWrapper>
       <ResourceContainer>


### PR DESCRIPTION
Monsido klager på at vi må gi mer info om switchen da den ligger i et form. Tenker vi fikser problemet ved å slette form-elementet.