### PR TITLE
chore: do not split css into chunks.

### DIFF
--- a/src/server/getManifestChunks.tsx
+++ b/src/server/getManifestChunks.tsx
@@ -34,6 +34,10 @@ function getImportedChunks(manifest: Manifest, name: string): ManifestChunk[] {
 export const getRouteChunks = (manifest: Manifest, entryPoint: EntryPointType): ManifestChunk[] => {
   const mainEntry = manifest[entryPoints[entryPoint]];
   if (!mainEntry) return [];
+  const stylesheets = Object.entries(manifest)
+    .filter(([key]) => key.endsWith(".css"))
+    .map(([, value]) => value);
+  mainEntry.css = (mainEntry.css ?? []).concat(stylesheets.map((chunk) => chunk.file));
   const importedChunks = getImportedChunks(manifest, entryPoints[entryPoint]);
   return [mainEntry].concat(importedChunks);
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,6 +40,7 @@ export default defineConfig(() => {
       target: "es2020",
       assetsDir: "static",
       outDir: "build/public",
+      cssCodeSplit: false,
       manifest: true,
       sourcemap: true,
       rollupOptions: {


### PR DESCRIPTION
Our css is atomic, and our component library is used throughout the app. We'll probably save a couple of KB by not splitting it across chunks. This can (and maybe should) be revised at a later point, once we can start chunking by endpoint