### PR TITLE
useQuery uses the watchQuery default options....

### DIFF
--- a/src/util/apiHelpers.ts
+++ b/src/util/apiHelpers.ts
@@ -205,6 +205,9 @@ export const createApolloClient = (language = "nb", versionHash?: string, path?:
     cache,
     ssrMode: true,
     defaultOptions: {
+      watchQuery: {
+        errorPolicy: "all",
+      },
       query: {
         errorPolicy: "all",
       },


### PR DESCRIPTION
Man skulle trodd useQuery bruker query objektet i defaultoptions MEN NEI DET GJØR DET IKKE! 🍡 

Lar oss partial fetche data selv om noe som skal resolves feiler! 😄 

`Note: The useQuery hook uses Apollo Client's watchQuery function. To set defaultOptions when using the useQuery hook, make sure to set them under the defaultOptions.watchQuery property.`