### PR TITLE
fix: do not render source/origin links

### DIFF
--- a/src/components/MediaList/MediaList.tsx
+++ b/src/components/MediaList/MediaList.tsx
@@ -18,7 +18,6 @@ import {
   type MetaType,
 } from "@ndla/licenses";
 import { Heading, Text } from "@ndla/primitives";
-import { SafeLink } from "@ndla/safelink";
 import { styled } from "@ndla/styled-system/jsx";
 import { LicenseLink } from "@ndla/ui";
 import LicenseBylineDescriptionList from "./LicenseBylineDescriptionList";
@@ -162,35 +161,13 @@ export const MediaListItemActions = styled("div", {
   },
 });
 
-const isLink = (url: string) => url.startsWith("http") || url.startsWith("https");
-
-interface HandleLinkProps {
-  url: string;
-  children: ReactNode;
-  type: ItemTypeWithDescription["metaType"];
-}
-
-const licenceTag = (type: ItemTypeWithDescription["metaType"], url: boolean): string | undefined =>
-  ({
-    title: "dct:title",
-    author: "cc:attributionName",
-    copyrightHolder: "cc:copyrightHolder",
-    contributor: "cc:contributor",
-    other: url ? "cc:attributionURL" : undefined,
-  })[type];
-
-export const HandleLink = ({ url, children, type }: HandleLinkProps) => {
-  const tag = licenceTag(type, isLink(url));
-
-  if (isLink(url)) {
-    return (
-      <SafeLink to={url} target="_blank" rel={`noopener noreferrer ${tag}`}>
-        {children}
-      </SafeLink>
-    );
-  }
-  // eslint-disable-next-line react/no-unknown-property
-  return <span property={tag}>{children}</span>;
+const licenseMap: Record<MetaType, string | undefined> = {
+  title: "dct:title",
+  author: "cc:attributionName",
+  copyrightHolder: "cc:copyrightHolder",
+  contributor: "cc:contributor",
+  other: undefined,
+  otherWithoutDescription: undefined,
 };
 
 export type ItemType = ItemTypeWithDescription | DescriptionlessItemType;
@@ -221,9 +198,8 @@ const ItemText = ({ item }: { item: ItemType }) => {
   return (
     <Text textStyle="body.medium">
       {`${item.label}: `}
-      <HandleLink url={item.description} type={item.metaType}>
-        {item.description}
-      </HandleLink>
+      {/* eslint-disable-next-line react/no-unknown-property */}
+      <span property={licenseMap[item.metaType]}>{item.description}</span>
     </Text>
   );
 };


### PR DESCRIPTION
Fixes https://trello.com/c/keAmeaVD/1283-lenker-i-kildefelt-skal-ikke-v%C3%A6re-klikkbare
Kommer ikke på noen andre felter som kan være lenker sånn i farta.