### PR TITLE
refactor: support node search results

### DIFF
--- a/src/containers/FilmFrontpage/AllMoviesAlphabetically.tsx
+++ b/src/containers/FilmFrontpage/AllMoviesAlphabetically.tsx
@@ -63,7 +63,9 @@ const LETTER_REGEXP = /[A-Z\WÆØÅ]+/;
 type MovieType = NonNullable<GQLAllMoviesQuery["searchWithoutPagination"]>["results"][0];
 
 const groupMovies = (movies: MovieType[]) => {
-  const sortedMovies = movies.toSorted((a, b) => a.title.localeCompare(b.title, "nb"));
+  const sortedMovies: Exclude<MovieType, { __typename: "NodeSearchResult" | undefined }>[] = movies
+    .filter((movie) => movie.__typename !== "NodeSearchResult")
+    .toSorted((a, b) => a.title.localeCompare(b.title, "nb"));
 
   const grouped = sortedMovies.reduce<Record<string, MovieType[]>>((acc, movie) => {
     const firstChar = movie.title[0]?.toUpperCase() ?? "";
@@ -152,9 +154,10 @@ const AllMoviesAlphabetically = () => {
             const context = movie.contexts.find((c) => c.rootId === FILM_ID);
             return (
               <StyledSafeLink to={context?.url ?? ""} key={movie.id}>
-                {!!movie.metaImage?.url && (
-                  <MovieImage alt="" loading="lazy" sizes={"100px"} src={movie.metaImage.url} />
-                )}
+                {(movie.__typename === "ArticleSearchResult" || movie.__typename === "LearningpathSearchResult") &&
+                  !!movie.metaImage?.url && (
+                    <MovieImage alt="" loading="lazy" sizes={"100px"} src={movie.metaImage.url} />
+                  )}
                 <MovieTextWrapper>
                   <Heading textStyle="title.small" asChild consumeCss data-title="">
                     <h3>{movie.title}</h3>
@@ -184,8 +187,15 @@ const allMoviesQuery = gql`
       results {
         id
         metaDescription
-        metaImage {
-          url
+        ... on ArticleSearchResult {
+          metaImage {
+            url
+          }
+        }
+        ... on LearningpathSearchResult {
+          metaImage {
+            url
+          }
         }
         title
         contexts {

--- a/src/containers/FilmFrontpage/MovieGrid.tsx
+++ b/src/containers/FilmFrontpage/MovieGrid.tsx
@@ -107,20 +107,23 @@ export const MovieGrid = ({ resourceType }: Props) => {
       ) : (
         <MovieListing>
           {resourceTypeMovies.data?.searchWithoutPagination?.results?.map((movie, index) => {
-            const context = movie.contexts.find((c) => c.contextType === "standard");
-            return (
-              <StyledFilmContentCard
-                style={{ "--index": index } as CSSProperties}
-                key={`${resourceType.id}-${index}`}
-                movie={{
-                  id: movie.id,
-                  metaImage: movie.metaImage,
-                  resourceTypes: [],
-                  title: movie.title,
-                  url: context?.url ?? "",
-                }}
-              />
-            );
+            if (movie.__typename === "ArticleSearchResult" || movie.__typename === "LearningpathSearchResult") {
+              const context = movie.contexts.find((c) => c.contextType === "standard");
+              return (
+                <StyledFilmContentCard
+                  style={{ "--index": index } as CSSProperties}
+                  key={`${resourceType.id}-${index}`}
+                  movie={{
+                    id: movie.id,
+                    metaImage: movie.metaImage,
+                    resourceTypes: [],
+                    title: movie.title,
+                    url: context?.url ?? "",
+                  }}
+                />
+              );
+            }
+            return null;
           })}
         </MovieListing>
       )}
@@ -169,8 +172,15 @@ const resourceTypeMoviesQuery = gql`
       results {
         id
         metaDescription
-        metaImage {
-          url
+        ... on ArticleSearchResult {
+          metaImage {
+            url
+          }
+        }
+        ... on LearningpathSearchResult {
+          metaImage {
+            url
+          }
         }
         title
         contexts {

--- a/src/containers/Masthead/components/MastheadSearch.tsx
+++ b/src/containers/Masthead/components/MastheadSearch.tsx
@@ -213,7 +213,10 @@ const MastheadSearch = () => {
         const contentType = contentTypeMapping?.[context?.resourceTypes?.[0]?.id ?? "default"];
         return {
           ...result,
-          id: result.id.toString(),
+          htmlTitle:
+            result.__typename === "ArticleSearchResult" || result.__typename === "LearningpathSearchResult"
+              ? parse(result.htmlTitle)
+              : result.title,
           resourceType: context?.resourceTypes?.[0]?.id,
           contentType,
           path: context?.url ?? result.url,
@@ -349,7 +352,7 @@ const MastheadSearch = () => {
                         <TextWrapper>
                           <ComboboxItemText>
                             <SafeLink to={resource.path} onClick={onNavigate} unstyled css={linkOverlay.raw()}>
-                              {parse(resource.htmlTitle)}
+                              {resource.htmlTitle}
                             </SafeLink>
                           </ComboboxItemText>
                           {!!resource.contexts[0] && (

--- a/src/containers/MyNdla/Learningpath/components/ResourcePicker.tsx
+++ b/src/containers/MyNdla/Learningpath/components/ResourcePicker.tsx
@@ -261,7 +261,12 @@ export const ResourcePicker = ({ setResource }: Props) => {
               <StyledComboboxItem key={collection.getItemValue(resource)} item={resource} className="peer" asChild>
                 <StyledListItemRoot context="list">
                   <StyledListItemContent>
-                    <ComboboxItemText>{parse(resource.htmlTitle)}</ComboboxItemText>
+                    <ComboboxItemText>
+                      {resource.__typename === "ArticleSearchResult" ||
+                      resource.__typename === "LearningpathSearchResult"
+                        ? parse(resource.htmlTitle)
+                        : resource.title}
+                    </ComboboxItemText>
                     {!!resource.contexts[0] && (
                       <Text
                         textStyle="label.small"

--- a/src/containers/TopicPage/MovedTopicPage.tsx
+++ b/src/containers/TopicPage/MovedTopicPage.tsx
@@ -14,10 +14,17 @@ import { HelmetWithTracker } from "@ndla/tracker";
 import { PageContainer } from "../../components/Layout/PageContainer";
 import { MovedNodeCard } from "../../components/MovedNodeCard";
 import { SKIP_TO_CONTENT_ID } from "../../constants";
-import { GQLMovedTopicPage_NodeFragment, GQLSearchResult } from "../../graphqlTypes";
+import {
+  GQLArticleSearchResult,
+  GQLLearningpathSearchResult,
+  GQLMovedTopicPage_NodeFragment,
+} from "../../graphqlTypes";
 
 interface GQLSearchResultExtended
-  extends Omit<GQLSearchResult, "id" | "contexts" | "metaDescription" | "supportedLanguages" | "traits"> {
+  extends Omit<
+    GQLLearningpathSearchResult | GQLArticleSearchResult,
+    "id" | "contexts" | "metaDescription" | "supportedLanguages" | "traits"
+  > {
   subjects?: {
     url?: string;
     title: string;

--- a/src/graphqlTypes.ts
+++ b/src/graphqlTypes.ts
@@ -111,7 +111,7 @@ export type GQLArticleSearchResult = GQLSearchResult & {
   context?: Maybe<GQLSearchContext>;
   contexts: Array<GQLSearchContext>;
   htmlTitle: Scalars["String"]["output"];
-  id: Scalars["Int"]["output"];
+  id: Scalars["String"]["output"];
   metaDescription: Scalars["String"]["output"];
   metaImage?: Maybe<GQLMetaImage>;
   supportedLanguages: Array<Scalars["String"]["output"]>;
@@ -782,7 +782,7 @@ export type GQLLearningpathSearchResult = GQLSearchResult & {
   context?: Maybe<GQLSearchContext>;
   contexts: Array<GQLSearchContext>;
   htmlTitle: Scalars["String"]["output"];
-  id: Scalars["Int"]["output"];
+  id: Scalars["String"]["output"];
   metaDescription: Scalars["String"]["output"];
   metaImage?: Maybe<GQLMetaImage>;
   supportedLanguages: Array<Scalars["String"]["output"]>;
@@ -1223,6 +1223,19 @@ export type GQLNodeChildrenArgs = {
   recursive?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
+export type GQLNodeSearchResult = GQLSearchResult & {
+  __typename?: "NodeSearchResult";
+  context?: Maybe<GQLSearchContext>;
+  contexts: Array<GQLSearchContext>;
+  htmlTitle: Scalars["String"]["output"];
+  id: Scalars["String"]["output"];
+  metaDescription: Scalars["String"]["output"];
+  metaImage?: Maybe<GQLMetaImage>;
+  supportedLanguages: Array<Scalars["String"]["output"]>;
+  title: Scalars["String"]["output"];
+  url: Scalars["String"]["output"];
+};
+
 export type GQLOwner = {
   __typename?: "Owner";
   name: Scalars["String"]["output"];
@@ -1430,10 +1443,12 @@ export type GQLQueryGroupSearchArgs = {
   language?: InputMaybe<Scalars["String"]["input"]>;
   levels?: InputMaybe<Scalars["String"]["input"]>;
   license?: InputMaybe<Scalars["String"]["input"]>;
+  nodeTypes?: InputMaybe<Scalars["String"]["input"]>;
   page?: InputMaybe<Scalars["Int"]["input"]>;
   pageSize?: InputMaybe<Scalars["Int"]["input"]>;
   query?: InputMaybe<Scalars["String"]["input"]>;
   resourceTypes?: InputMaybe<Scalars["String"]["input"]>;
+  resultTypes?: InputMaybe<Scalars["String"]["input"]>;
   subjects?: InputMaybe<Scalars["String"]["input"]>;
 };
 
@@ -1536,11 +1551,13 @@ export type GQLQuerySearchArgs = {
   languageFilter?: InputMaybe<Scalars["String"]["input"]>;
   levels?: InputMaybe<Scalars["String"]["input"]>;
   license?: InputMaybe<Scalars["String"]["input"]>;
+  nodeTypes?: InputMaybe<Scalars["String"]["input"]>;
   page?: InputMaybe<Scalars["Int"]["input"]>;
   pageSize?: InputMaybe<Scalars["Int"]["input"]>;
   query?: InputMaybe<Scalars["String"]["input"]>;
   relevance?: InputMaybe<Scalars["String"]["input"]>;
   resourceTypes?: InputMaybe<Scalars["String"]["input"]>;
+  resultTypes?: InputMaybe<Scalars["String"]["input"]>;
   sort?: InputMaybe<Scalars["String"]["input"]>;
   subjects?: InputMaybe<Scalars["String"]["input"]>;
   traits?: InputMaybe<Array<Scalars["String"]["input"]>>;
@@ -1554,9 +1571,11 @@ export type GQLQuerySearchWithoutPaginationArgs = {
   languageFilter?: InputMaybe<Scalars["String"]["input"]>;
   levels?: InputMaybe<Scalars["String"]["input"]>;
   license?: InputMaybe<Scalars["String"]["input"]>;
+  nodeTypes?: InputMaybe<Scalars["String"]["input"]>;
   query?: InputMaybe<Scalars["String"]["input"]>;
   relevance?: InputMaybe<Scalars["String"]["input"]>;
   resourceTypes?: InputMaybe<Scalars["String"]["input"]>;
+  resultTypes?: InputMaybe<Scalars["String"]["input"]>;
   sort?: InputMaybe<Scalars["String"]["input"]>;
   subjects?: InputMaybe<Scalars["String"]["input"]>;
 };
@@ -1691,9 +1710,7 @@ export type GQLSearchContext = {
   contextType: Scalars["String"]["output"];
   isActive: Scalars["Boolean"]["output"];
   isPrimary: Scalars["Boolean"]["output"];
-  isVisible: Scalars["Boolean"]["output"];
   language: Scalars["String"]["output"];
-  parentIds: Array<Scalars["String"]["output"]>;
   path: Scalars["String"]["output"];
   publicId: Scalars["String"]["output"];
   relevance: Scalars["String"]["output"];
@@ -1714,15 +1731,14 @@ export type GQLSearchContextResourceTypes = {
 export type GQLSearchResult = {
   context?: Maybe<GQLSearchContext>;
   contexts: Array<GQLSearchContext>;
-  htmlTitle: Scalars["String"]["output"];
-  id: Scalars["Int"]["output"];
+  id: Scalars["String"]["output"];
   metaDescription: Scalars["String"]["output"];
-  metaImage?: Maybe<GQLMetaImage>;
   supportedLanguages: Array<Scalars["String"]["output"]>;
   title: Scalars["String"]["output"];
-  traits: Array<Scalars["String"]["output"]>;
   url: Scalars["String"]["output"];
 };
+
+export type GQLSearchResultUnion = GQLArticleSearchResult | GQLLearningpathSearchResult | GQLNodeSearchResult;
 
 export type GQLSearchSuggestion = {
   __typename?: "SearchSuggestion";
@@ -2112,8 +2128,8 @@ export type GQLLearningpath_LearningpathStepFragment = {
   title: string;
   description?: string;
   license?: { __typename?: "License"; license: string };
-} & GQLLearningpathEmbed_LearningpathStepFragment &
-  GQLLearningpathMenu_LearningpathStepFragment;
+} & GQLLearningpathMenu_LearningpathStepFragment &
+  GQLLearningpathStep_LearningpathStepFragment;
 
 export type GQLLearningpath_LearningpathFragment = {
   __typename?: "Learningpath";
@@ -2150,7 +2166,7 @@ export type GQLLearningpathEmbed_ArticleFragment = {
 } & GQLStructuredArticleDataFragment &
   GQLArticle_ArticleFragment;
 
-export type GQLLearningpathEmbed_LearningpathStepFragment = {
+export type GQLArticleStep_LearningpathStepFragment = {
   __typename?: "LearningpathStep";
   id: number;
   title: string;
@@ -2192,6 +2208,10 @@ export type GQLLearningpathStepQuery = {
     resourceTypes?: Array<{ __typename?: "ResourceType"; id: string; name: string }>;
   };
 };
+
+export type GQLLearningpathStep_LearningpathStepFragment = {
+  __typename?: "LearningpathStep";
+} & GQLArticleStep_LearningpathStepFragment;
 
 export type GQLSubjectLinks_SubjectPageFragment = {
   __typename?: "SubjectPage";
@@ -2447,7 +2467,7 @@ export type GQLAllMoviesQuery = {
     results: Array<
       | {
           __typename?: "ArticleSearchResult";
-          id: number;
+          id: string;
           metaDescription: string;
           title: string;
           metaImage?: { __typename?: "MetaImage"; url: string };
@@ -2462,10 +2482,24 @@ export type GQLAllMoviesQuery = {
         }
       | {
           __typename?: "LearningpathSearchResult";
-          id: number;
+          id: string;
           metaDescription: string;
           title: string;
           metaImage?: { __typename?: "MetaImage"; url: string };
+          contexts: Array<{
+            __typename?: "SearchContext";
+            contextId: string;
+            contextType: string;
+            path: string;
+            url: string;
+            rootId: string;
+          }>;
+        }
+      | {
+          __typename?: "NodeSearchResult";
+          id: string;
+          metaDescription: string;
+          title: string;
           contexts: Array<{
             __typename?: "SearchContext";
             contextId: string;
@@ -2541,7 +2575,7 @@ export type GQLResourceTypeMoviesQuery = {
     results: Array<
       | {
           __typename?: "ArticleSearchResult";
-          id: number;
+          id: string;
           metaDescription: string;
           title: string;
           metaImage?: { __typename?: "MetaImage"; url: string };
@@ -2555,10 +2589,23 @@ export type GQLResourceTypeMoviesQuery = {
         }
       | {
           __typename?: "LearningpathSearchResult";
-          id: number;
+          id: string;
           metaDescription: string;
           title: string;
           metaImage?: { __typename?: "MetaImage"; url: string };
+          contexts: Array<{
+            __typename?: "SearchContext";
+            contextId: string;
+            contextType: string;
+            url: string;
+            rootId: string;
+          }>;
+        }
+      | {
+          __typename?: "NodeSearchResult";
+          id: string;
+          metaDescription: string;
+          title: string;
           contexts: Array<{
             __typename?: "SearchContext";
             contextId: string;
@@ -3936,33 +3983,44 @@ export type GQLGroupSearchResourceFragment = {
 
 type GQLSearchResource_ArticleSearchResult_Fragment = {
   __typename?: "ArticleSearchResult";
-  id: number;
-  title: string;
   htmlTitle: string;
+  traits: Array<string>;
+  id: string;
+  title: string;
   supportedLanguages: Array<string>;
   url: string;
   metaDescription: string;
-  traits: Array<string>;
   metaImage?: { __typename?: "MetaImage"; url: string; alt: string };
   contexts: Array<{ __typename?: "SearchContext" } & GQLSearchContextFragment>;
 };
 
 type GQLSearchResource_LearningpathSearchResult_Fragment = {
   __typename?: "LearningpathSearchResult";
-  id: number;
-  title: string;
   htmlTitle: string;
+  traits: Array<string>;
+  id: string;
+  title: string;
   supportedLanguages: Array<string>;
   url: string;
   metaDescription: string;
-  traits: Array<string>;
   metaImage?: { __typename?: "MetaImage"; url: string; alt: string };
+  contexts: Array<{ __typename?: "SearchContext" } & GQLSearchContextFragment>;
+};
+
+type GQLSearchResource_NodeSearchResult_Fragment = {
+  __typename?: "NodeSearchResult";
+  id: string;
+  title: string;
+  supportedLanguages: Array<string>;
+  url: string;
+  metaDescription: string;
   contexts: Array<{ __typename?: "SearchContext" } & GQLSearchContextFragment>;
 };
 
 export type GQLSearchResourceFragment =
   | GQLSearchResource_ArticleSearchResult_Fragment
-  | GQLSearchResource_LearningpathSearchResult_Fragment;
+  | GQLSearchResource_LearningpathSearchResult_Fragment
+  | GQLSearchResource_NodeSearchResult_Fragment;
 
 export type GQLSearchQueryVariables = Exact<{
   query?: InputMaybe<Scalars["String"]["input"]>;
@@ -3996,6 +4054,7 @@ export type GQLSearchQuery = {
     results: Array<
       | ({ __typename?: "ArticleSearchResult" } & GQLSearchResource_ArticleSearchResult_Fragment)
       | ({ __typename?: "LearningpathSearchResult" } & GQLSearchResource_LearningpathSearchResult_Fragment)
+      | ({ __typename?: "NodeSearchResult" } & GQLSearchResource_NodeSearchResult_Fragment)
     >;
     suggestions: Array<{
       __typename?: "SuggestionResult";

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -72,15 +72,25 @@ const searchResultFragment = gql`
   fragment SearchResource on SearchResult {
     id
     title
-    htmlTitle
     supportedLanguages
     url
     metaDescription
-    metaImage {
-      url
-      alt
+    ... on ArticleSearchResult {
+      htmlTitle
+      traits
+      metaImage {
+        url
+        alt
+      }
     }
-    traits
+    ... on LearningpathSearchResult {
+      htmlTitle
+      traits
+      metaImage {
+        url
+        alt
+      }
+    }
     contexts {
       ...SearchContext
     }

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -72,7 +72,7 @@ type ArticleSearchResult implements SearchResult {
   context: SearchContext
   contexts: [SearchContext!]!
   htmlTitle: String!
-  id: Int!
+  id: String!
   metaDescription: String!
   metaImage: MetaImage
   supportedLanguages: [String!]!
@@ -681,7 +681,7 @@ type LearningpathSearchResult implements SearchResult {
   context: SearchContext
   contexts: [SearchContext!]!
   htmlTitle: String!
-  id: Int!
+  id: String!
   metaDescription: String!
   metaImage: MetaImage
   supportedLanguages: [String!]!
@@ -983,6 +983,18 @@ type Node implements TaxBase & TaxonomyEntity & WithArticle {
   url: String
 }
 
+type NodeSearchResult implements SearchResult {
+  context: SearchContext
+  contexts: [SearchContext!]!
+  htmlTitle: String!
+  id: String!
+  metaDescription: String!
+  metaImage: MetaImage
+  supportedLanguages: [String!]!
+  title: String!
+  url: String!
+}
+
 type Owner {
   name: String!
 }
@@ -1092,10 +1104,12 @@ type Query {
     language: String
     levels: String
     license: String
+    nodeTypes: String
     page: Int
     pageSize: Int
     query: String
     resourceTypes: String
+    resultTypes: String
     subjects: String
   ): [GroupSearch!]
   image(id: String!): ImageMetaInformationV2
@@ -1137,11 +1151,13 @@ type Query {
     languageFilter: String
     levels: String
     license: String
+    nodeTypes: String
     page: Int
     pageSize: Int
     query: String
     relevance: String
     resourceTypes: String
+    resultTypes: String
     sort: String
     subjects: String
     traits: [String!]
@@ -1154,9 +1170,11 @@ type Query {
     languageFilter: String
     levels: String
     license: String
+    nodeTypes: String
     query: String
     relevance: String
     resourceTypes: String
+    resultTypes: String
     sort: String
     subjects: String
   ): SearchWithoutPagination
@@ -1253,9 +1271,7 @@ type SearchContext {
   contextType: String!
   isActive: Boolean!
   isPrimary: Boolean!
-  isVisible: Boolean!
   language: String!
-  parentIds: [String!]!
   path: String!
   publicId: String!
   relevance: String!
@@ -1275,15 +1291,14 @@ type SearchContextResourceTypes {
 interface SearchResult {
   context: SearchContext
   contexts: [SearchContext!]!
-  htmlTitle: String!
-  id: Int!
+  id: String!
   metaDescription: String!
-  metaImage: MetaImage
   supportedLanguages: [String!]!
   title: String!
-  traits: [String!]!
   url: String!
 }
+
+union SearchResultUnion = ArticleSearchResult | LearningpathSearchResult | NodeSearchResult
 
 type SearchSuggestion {
   length: Int!

--- a/src/util/apiHelpers.ts
+++ b/src/util/apiHelpers.ts
@@ -92,7 +92,7 @@ const mergeGroupSearch = (existing: GQLGroupSearch[], incoming: GQLGroupSearch[]
 
 const possibleTypes = {
   TaxonomyEntity: ["Resource", "Topic"],
-  SearchResult: ["ArticleSearchResult", "LearningpathSearchResult"],
+  SearchResult: ["ArticleSearchResult", "LearningpathSearchResult", "NodeSearchResult"],
   FolderResourceMeta: ["ArticleFolderResourceMeta", "LearningpathFolderResourceMeta"],
 };
 
@@ -154,6 +154,9 @@ const typePolicies: TypePolicies = {
   },
   SearchContext: {
     keyFields: ["contextId"],
+  },
+  SearchResult: {
+    keyFields: ["id", "__typename"],
   },
   GroupSearchResult: {
     keyFields: ["url"],


### PR DESCRIPTION
Unions og interfaces er ordentlig rotete i GQL. Avhengig av https://github.com/NDLANO/graphql-api/pull/559