### PR TITLE
Show external step even if opengraph fails

### DIFF
--- a/src/components/Learningpath/components/ExternalStep.tsx
+++ b/src/components/Learningpath/components/ExternalStep.tsx
@@ -43,7 +43,7 @@ export const ExternalStep = ({ learningpathStep, skipToContentId, learningpath }
             <ResourceBox
               title={learningpathStep.opengraph?.title ?? ""}
               caption={learningpathStep.opengraph?.description ?? ""}
-              url={learningpathStep.opengraph?.url ?? ""}
+              url={learningpathStep.opengraph?.url ?? learningpathStep.embedUrl?.url ?? ""}
               buttonText={t("learningpathPage.externalLink")}
             />
           </section>

--- a/src/components/Learningpath/components/LearningpathStep.tsx
+++ b/src/components/Learningpath/components/LearningpathStep.tsx
@@ -118,7 +118,7 @@ export const LearningpathStep = ({
     );
   }
 
-  if (learningpathStep.opengraph) {
+  if (learningpathStep.embedUrl?.embedType === "external") {
     return (
       <ExternalStep learningpathStep={learningpathStep} skipToContentId={skipToContentId} learningpath={learningpath} />
     );


### PR DESCRIPTION
Om du legger inn en url som feiler i opengraph så vises ikkje eksternt steg. Dette fikser det.

Eks: http://localhost:3000/nb/minndla/learningpaths/3538/preview/20137 som frank_foreleser