### PR TITLE
fix: let article-converter handle mathjax rendering to avoid bug when navigating back to previously typeset page

### DIFF
--- a/src/containers/AboutPage/AboutPageContent.tsx
+++ b/src/containers/AboutPage/AboutPageContent.tsx
@@ -110,16 +110,6 @@ const AboutPageContent = ({ article: _article, frontpage }: Props) => {
     ];
   }, [_article, i18n.language])!;
 
-  useEffect(() => {
-    if (window.MathJax && typeof window.MathJax.typeset === "function") {
-      try {
-        window.MathJax.typeset();
-      } catch (err) {
-        // do nothing
-      }
-    }
-  });
-
   const licenseProps = licenseAttributes(article.copyright?.license?.license, i18n.language, undefined);
 
   return (

--- a/src/containers/ArticlePage/ArticlePage.tsx
+++ b/src/containers/ArticlePage/ArticlePage.tsx
@@ -132,16 +132,6 @@ const ArticlePage = ({ resource, errors, skipToContentId, loading }: Props) => {
 
   useNavigateToHash(article?.transformedContent.content);
 
-  useEffect(() => {
-    if (window.MathJax && typeof window.MathJax.typeset === "function") {
-      try {
-        window.MathJax.typeset();
-      } catch (err) {
-        // do nothing
-      }
-    }
-  });
-
   if (resource && isLearningPathResource(resource)) {
     const url = getLearningPathUrlFromResource(resource);
     return (

--- a/src/containers/LearningpathPage/LearningpathPage.tsx
+++ b/src/containers/LearningpathPage/LearningpathPage.tsx
@@ -41,15 +41,6 @@ const LearningpathPage = ({ data, skipToContentId, stepId, loading }: Props) => 
   const { user, authContextLoaded } = useContext(AuthContext);
   const { t } = useTranslation();
   const { trackPageView } = useTracker();
-  useEffect(() => {
-    if (window.MathJax && typeof window.MathJax.typeset === "function") {
-      try {
-        window.MathJax.typeset();
-      } catch (err) {
-        // do nothing
-      }
-    }
-  });
 
   useEffect(() => {
     if (loading || !data || !authContextLoaded) return;

--- a/src/containers/PlainArticlePage/PlainArticleContainer.tsx
+++ b/src/containers/PlainArticlePage/PlainArticleContainer.tsx
@@ -35,15 +35,6 @@ const PlainArticleContainer = ({ article: propArticle, skipToContentId }: Props)
   const { user, authContextLoaded } = useContext(AuthContext);
   const { t, i18n } = useTranslation();
   const { trackPageView } = useTracker();
-  useEffect(() => {
-    if (window.MathJax && typeof window.MathJax.typeset === "function") {
-      try {
-        window.MathJax.typeset();
-      } catch (err) {
-        // do nothing
-      }
-    }
-  });
 
   useEffect(() => {
     if (!propArticle || !authContextLoaded) return;

--- a/src/containers/PlainLearningpathPage/PlainLearningpathContainer.tsx
+++ b/src/containers/PlainLearningpathPage/PlainLearningpathContainer.tsx
@@ -35,16 +35,6 @@ const PlainLearningpathContainer = ({ learningpath, skipToContentId, stepId }: P
   const steps = learningpath.learningsteps;
 
   useEffect(() => {
-    if (window.MathJax && typeof window.MathJax.typeset === "function") {
-      try {
-        window.MathJax.typeset();
-      } catch (err) {
-        // do nothing
-      }
-    }
-  });
-
-  useEffect(() => {
     if (learningpath && authContextLoaded) {
       const dimensions = getAllDimensions({ user });
       trackPageView({ dimensions, title: getDocumentTitle(learningpath, t) });


### PR DESCRIPTION
Fixes https://github.com/ndlano/issues/issues/4254
Depends on https://github.com/NDLANO/frontend-packages/pull/2740

NB: Bygger på toppen av ark V5-pr'en så man kan linke med frontend-packages.

Dette er kanskje litt for magisk til alle smaker, men det funker! Første gang man laster inn en artikkel med mathjax laster vi inn mathjax-scriptet. Jeg mistenker at mathjax automatisk typesetter dokumentet første gang den lastes. Deretter vil de neste typesettingene skje når et matte-element mountes. 