### PR TITLE
refactor: do not rely on matchPath for old subject paths

### DIFF
--- a/src/server/routes/oembedArticleRoute.ts
+++ b/src/server/routes/oembedArticleRoute.ts
@@ -67,10 +67,10 @@ const getHTMLandTitle = async (match: Params<MatchParams>, req: express.Request)
 
   const height = req.query.height || 480;
   const width = req.query.width || 854;
-  const nodeId = topicId && !resourceId ? `urn:topic${topicId}` : `urn:resource${resourceId}`;
+  const nodeId = topicId && !resourceId ? topicId : resourceId;
   const node = contextId
     ? await queryNodeByContexts(contextId, lang)
-    : await fetchNode(match.nodeId ? match.nodeId : nodeId, lang);
+    : await fetchNode(match.nodeId ? match.nodeId : nodeId!, lang);
   if (node.contentUri?.includes("learningpath")) {
     return {};
   }

--- a/src/util/__tests__/urlHelper-test.ts
+++ b/src/util/__tests__/urlHelper-test.ts
@@ -12,69 +12,63 @@ describe("parseAndMatchUrl", () => {
   it("should parse a valid article url with old URL scheme", () => {
     const validArticleUrl1 = "https://www.ndla.no/subject:3/topic:1:55163/topic:1:168398/resource:1:1682";
     expect(parseOembedUrl(validArticleUrl1)).toEqual({
-      resourceId: ":1:1682",
-      subjectId: ":3",
-      topic1: ":1:55163",
-      topicId: ":1:168398",
+      resourceId: "urn:resource:1:1682",
+      subjectId: "urn:subject:3",
+      topicId: "urn:topic:1:168398",
     });
   });
   it("should parse a valid environment article url with old URL scheme", () => {
     const validArticleUrl1 = "https://www.test.ndla.no/subject:3/topic:1:55163/topic:1:168398/resource:1:1682";
     expect(parseOembedUrl(validArticleUrl1)).toEqual({
-      resourceId: ":1:1682",
-      subjectId: ":3",
-      topic1: ":1:55163",
-      topicId: ":1:168398",
+      resourceId: "urn:resource:1:1682",
+      subjectId: "urn:subject:3",
+      topicId: "urn:topic:1:168398",
     });
   });
   it("supports omitting www with old URL scheme", () => {
     const result = "https://ndla.no/subject:3/topic:1:55163/topic:1:168398/resource:1:1682";
     expect(parseOembedUrl(result)).toEqual({
-      resourceId: ":1:1682",
-      subjectId: ":3",
-      topic1: ":1:55163",
-      topicId: ":1:168398",
+      resourceId: "urn:resource:1:1682",
+      subjectId: "urn:subject:3",
+      topicId: "urn:topic:1:168398",
     });
   });
   it("supports localhost with old URL scheme", () => {
     const result = "https://localhost:3000/subject:3/topic:1:55163/topic:1:168398/resource:1:1682";
     expect(parseOembedUrl(result)).toEqual({
-      resourceId: ":1:1682",
-      subjectId: ":3",
-      topic1: ":1:55163",
-      topicId: ":1:168398",
+      resourceId: "urn:resource:1:1682",
+      subjectId: "urn:subject:3",
+      topicId: "urn:topic:1:168398",
     });
   });
   it("supports topic articles with old URL scheme", () => {
     const result = parseOembedUrl("https://www.test.ndla.no/subject:3/topic:1:55163");
     expect(result).toEqual({
-      subjectId: ":3",
-      topicId: ":1:55163",
+      subjectId: "urn:subject:3",
+      topicId: "urn:topic:1:55163",
     });
   });
   it("supports language prefix with old URL scheme", () => {
     const result = parseOembedUrl("https://www.test.ndla.no/nn/subject:3/topic:1:55163");
     expect(result).toEqual({
-      subjectId: ":3",
-      topicId: ":1:55163",
+      subjectId: "urn:subject:3",
+      topicId: "urn:topic:1:55163",
       lang: "nn",
     });
   });
   it("defaults to nb language prefix when encountering unknown languages with old URL scheme", () => {
     const result = parseOembedUrl("https://www.test.ndla.no/unknown/subject:3/topic:1:55163");
     expect(result).toEqual({
-      subjectId: ":3",
-      topicId: ":1:55163",
+      subjectId: "urn:subject:3",
+      topicId: "urn:topic:1:55163",
       lang: "nb",
     });
   });
   it("supports nesting of topics with old URL scheme", () => {
     const result = parseOembedUrl("https://www.test.ndla.no/subject:3/topic:1:55163/topic:1:168398/topic:1:168554");
     expect(result).toEqual({
-      subjectId: ":3",
-      topic1: ":1:55163",
-      topic2: ":1:168398",
-      topicId: ":1:168554",
+      subjectId: "urn:subject:3",
+      topicId: "urn:topic:1:168554",
     });
   });
   it("does not support subjects with old URL scheme", () => {


### PR DESCRIPTION
Litt kjipere logikk, men løsriver oss fra funksjonalitet som ikke støttes i react router 7