### PR TITLE
Enable search for nodes in masthead. Show correct resourcetype.

### DIFF
--- a/src/containers/Masthead/components/MastheadSearch.tsx
+++ b/src/containers/Masthead/components/MastheadSearch.tsx
@@ -43,7 +43,6 @@ import { linkOverlay } from "@ndla/styled-system/patterns";
 import { constants, ContentTypeBadge, useComboboxTranslations } from "@ndla/ui";
 import { GQLMastheadDrawer_RootFragment, GQLSearchQuery, GQLSearchQueryVariables } from "../../../graphqlTypes";
 import { searchQuery } from "../../../queries";
-import { contentTypeMapping } from "../../../util/getContentType";
 
 const debounceCall = debounce((fun: (func?: VoidFunction) => void) => fun(), 250);
 
@@ -256,7 +255,7 @@ const MastheadSearch = ({ root }: Props) => {
       runSearch({
         variables: {
           query: delayedSearchQuery,
-          contextTypes: "standard,learningpath,topic-article",
+          contextTypes: "standard,learningpath,topic-article,node",
           fallback: "true",
           filterInactive: true,
           license: "all",
@@ -285,10 +284,15 @@ const MastheadSearch = ({ root }: Props) => {
     return (
       searchResult.search?.results.map((result) => {
         const context = result.contexts.find((context) => context.isPrimary) ?? result.contexts[0];
-        const contentType =
-          result.__typename === "NodeSearchResult"
-            ? constants.contentTypes.SUBJECT
-            : contentTypeMapping?.[context?.resourceTypes?.[0]?.id ?? "default"];
+        let contentType = undefined;
+        if (result.__typename === "NodeSearchResult") {
+          contentType = constants.contentTypes.SUBJECT;
+        }
+        if (context?.resourceTypes?.length) {
+          contentType = constants.contentTypeMapping?.[context.resourceTypes[0]?.id ?? "default"];
+        } else if (context?.url.startsWith("/e")) {
+          contentType = constants.contentTypeMapping[constants.contentTypes.TOPIC] ?? "default";
+        }
         return {
           ...result,
           htmlTitle:

--- a/src/containers/Masthead/components/MastheadSearch.tsx
+++ b/src/containers/Masthead/components/MastheadSearch.tsx
@@ -202,7 +202,6 @@ const StyledMoreHitsButton = styled(Button, {
 const getActiveSubjectUrl = (id: string, query: string): string => {
   const stripped = id.replace("urn:subject:", "");
   const searchParams = new URLSearchParams({
-    type: "resource",
     subjects: stripped,
     query: query,
   });

--- a/src/containers/SearchPage/SubjectFilter.tsx
+++ b/src/containers/SearchPage/SubjectFilter.tsx
@@ -40,7 +40,7 @@ import { styled } from "@ndla/styled-system/jsx";
 import { constants } from "@ndla/ui";
 import { groupBy, sortBy } from "@ndla/util";
 import { FilterContainer } from "./FilterContainer";
-import { RESOURCE_NODE_TYPE, SUBJECT_NODE_TYPE, TOPIC_NODE_TYPE } from "./searchUtils";
+import { ALL_NODE_TYPES, defaultNodeType, RESOURCE_NODE_TYPE, SUBJECT_NODE_TYPE, TOPIC_NODE_TYPE } from "./searchUtils";
 import { useStableSearchPageParams } from "./useStableSearchPageParams";
 import { DialogCloseButton } from "../../components/DialogCloseButton";
 import { TAXONOMY_CUSTOM_FIELD_SUBJECT_CATEGORY } from "../../constants";
@@ -81,10 +81,10 @@ type SubjectCategoryType = "active" | "archived" | "beta" | "other";
 export const SubjectFilter = () => {
   const { t } = useTranslation();
   const [searchParams, setSearchParams] = useStableSearchPageParams();
-  const nodeType = searchParams.get("type");
   const isLti = useLtiContext();
+  const nodeType = useMemo(() => searchParams.get("type") ?? defaultNodeType(isLti), [isLti, searchParams]);
   const validNodeTypes: (string | null)[] = useMemo(
-    () => (isLti ? [null] : [RESOURCE_NODE_TYPE, TOPIC_NODE_TYPE]),
+    () => (isLti ? [null] : [RESOURCE_NODE_TYPE, TOPIC_NODE_TYPE, ALL_NODE_TYPES]),
     [isLti],
   );
 


### PR DESCRIPTION
I dag vises emner som Fagstoff. Dette fikser det, samt legger inn fag i lista.