### PR TITLE
Adds sort param to avoid duplicates (maybe)

### DIFF
--- a/src/containers/FilmFrontpage/AllMoviesAlphabetically.tsx
+++ b/src/containers/FilmFrontpage/AllMoviesAlphabetically.tsx
@@ -183,6 +183,7 @@ const allMoviesQuery = gql`
       fallback: "true"
       subjects: "urn:subject:20"
       contextTypes: "standard"
+      sort: "title"
     ) {
       results {
         id

--- a/src/containers/FilmFrontpage/MovieGrid.tsx
+++ b/src/containers/FilmFrontpage/MovieGrid.tsx
@@ -168,6 +168,7 @@ const resourceTypeMoviesQuery = gql`
       fallback: "true"
       subjects: "urn:subject:20"
       contextTypes: "standard"
+      sort: "title"
     ) {
       results {
         id


### PR DESCRIPTION
Vi viser ikkje filmkategorier sortert. Og av og til kjem det duplikater på a-å lista. Ser ut som om dette hadde noe å sei.