### PR TITLE
Update revision in cache when step is deleted

### DIFF
--- a/src/mutations/learningpathMutations.ts
+++ b/src/mutations/learningpathMutations.ts
@@ -234,6 +234,16 @@ export const useDeleteLearningpathStep = (
           fieldName: "learningpath",
           args: { pathId: methodOptions?.variables?.learningpathId?.toString() },
         });
+        client.cache.modify({
+          id: client.cache.identify({
+            __ref: `MyNdlaLearningpath:${methodOptions?.variables?.learningpathId}`,
+          }),
+          fields: {
+            revision: () => {
+              return methodOptions?.variables?.revision;
+            },
+          },
+        });
         const normalizedId = client.cache.identify({
           __ref: `MyNdlaLearningpathStep:${methodOptions?.variables?.learningstepId}`,
         });


### PR DESCRIPTION
Hvis man sletter et læringsstisteg  så kan man nå redigere andre steg etterpå