### PR TITLE
Opprydning i playwright extension.

### DIFF
--- a/e2e/apiMock.ts
+++ b/e2e/apiMock.ts
@@ -6,32 +6,20 @@
  *
  */
 
-import { readFile, writeFile } from "fs/promises";
-import { Page, test as Ptest, TestInfo } from "@playwright/test";
+import { test as Ptest } from "@playwright/test";
+import { API_REGEX, createCheckpoint, getMockdataFilename, removeSensitiveDataFromHar } from "./utils";
 
-const mockDir = "e2e/apiMocks/";
-
-const apiTestRegex = "https://api.test.ndla.no/(?!image-api/raw.*).*";
-const localhostGraphqlRegex = "http://localhost:4000/graphql-api/graphql";
-
-interface ExtendParams {
+interface ExtendedTestOptions {
   harCheckpoint: () => Promise<void>;
+  waitGraphql: () => Promise<void>;
 }
-const regex = new RegExp(`^(${apiTestRegex}|${localhostGraphqlRegex})$`);
-
-const mockFile = ({ titlePath, title: test_name }: TestInfo) => {
-  const [, SPEC_GROUP, SPEC_NAME] = titlePath[0].split("/");
-  return `${mockDir}${SPEC_GROUP}_${SPEC_NAME}_${test_name.replace(/\s/g, "_")}.har`;
-};
-
-const checkpoint = (index: number) => ({ "x-playwright-checkpoint": `${index}` });
 
 /**
  * Extending the playwright test object with a checkpoint function.
  * The checkpoint function helps us differentiate between subsequent
  * requests, and allows us to more easily mock recurring calls.
  */
-export const test = Ptest.extend<ExtendParams>({
+export const test = Ptest.extend<ExtendedTestOptions>({
   harCheckpoint: [
     async ({ context, page }, use) => {
       let checkpointIndex = 0;
@@ -39,37 +27,45 @@ export const test = Ptest.extend<ExtendParams>({
       // Appending the checkpoint index to the request headers
       // Only appended for the stored headers in the HAR file
       await context.route(
-        regex,
+        API_REGEX,
         async (route, request) =>
           await route.fallback({
             headers: {
               ...request.headers(),
-              ...checkpoint(checkpointIndex),
+              ...createCheckpoint(checkpointIndex),
             },
           }),
       );
 
       // Appending the checkpoint index to the request headers
       if (process.env.RECORD_FIXTURES === "true") {
-        await page.setExtraHTTPHeaders(checkpoint(checkpointIndex));
+        await page.setExtraHTTPHeaders(createCheckpoint(checkpointIndex));
       }
 
       // Appending the new checkpoint index to the request headers
       await use(async () => {
         checkpointIndex += 1;
         if (process.env.RECORD_FIXTURES === "true") {
-          await page.setExtraHTTPHeaders(checkpoint(checkpointIndex));
+          await page.setExtraHTTPHeaders(createCheckpoint(checkpointIndex));
         }
       });
     },
     { auto: true, scope: "test" },
   ],
+  waitGraphql: async ({ page }, use) => {
+    await use(async () => {
+      if (process.env.RECORD_FIXTURES === "true") {
+        await page.waitForResponse("**/graphql-api/graphql");
+      }
+    });
+  },
   page: async ({ page }, use, testInfo) => {
     // Creating the API mocking for the wanted API's
-    await page.routeFromHAR(mockFile(testInfo), {
+    const mockdataFilename = getMockdataFilename(testInfo);
+    await page.routeFromHAR(mockdataFilename, {
       update: process.env.RECORD_FIXTURES === "true",
       updateMode: "minimal",
-      url: regex,
+      url: API_REGEX,
       updateContent: "embed",
     });
 
@@ -84,20 +80,8 @@ export const test = Ptest.extend<ExtendParams>({
 
     // Removing sensitive data from the HAR file after saving. Har files are saved on close.
     if (process.env.RECORD_FIXTURES === "true") {
-      await removeSensitiveData(mockFile(testInfo));
+      const mockdataFilename = getMockdataFilename(testInfo);
+      await removeSensitiveDataFromHar(mockdataFilename);
     }
   },
 });
-
-export const mockWaitResponse = async (page: Page, url: string) => {
-  if (process.env.RECORD_FIXTURES === "true") {
-    await page.waitForResponse(url);
-  }
-};
-
-// Method to remove sensitive data from the HAR file
-// Currently only working to write har file as a single line
-const removeSensitiveData = async (fileName: string) => {
-  const data = JSON.parse(await readFile(fileName, "utf8"));
-  await writeFile(fileName, JSON.stringify(data), "utf8");
-};

--- a/e2e/specs/authenticated/MyNDLAFolder.spec.ts
+++ b/e2e/specs/authenticated/MyNDLAFolder.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { expect } from "@playwright/test";
-import { test, mockWaitResponse } from "../../apiMock";
+import { test } from "../../apiMock";
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/minndla/folders", { waitUntil: "domcontentloaded" });
@@ -39,7 +39,7 @@ test("can copy sharable link to folder", async ({ page }) => {
   await expect(heading).toHaveText(sharedFolderTitle);
 });
 
-test("can add and delete folder", async ({ page, harCheckpoint }) => {
+test("can add and delete folder", async ({ page, harCheckpoint, waitGraphql }) => {
   await expect(page.getByRole("heading").getByText("Mine mapper")).toBeVisible();
   const folderList = page.getByRole("main").getByRole("list").first();
   await expect(folderList).toBeVisible();
@@ -52,7 +52,7 @@ test("can add and delete folder", async ({ page, harCheckpoint }) => {
 
   await harCheckpoint();
   await page.getByRole("button", { name: "Lagre", exact: true }).click();
-  await mockWaitResponse(page, "**/graphql-api/graphql");
+  await waitGraphql();
 
   await expect(page.getByRole("dialog")).not.toBeVisible();
   await page.goBack();
@@ -62,7 +62,7 @@ test("can add and delete folder", async ({ page, harCheckpoint }) => {
   await harCheckpoint();
   await page.getByRole("dialog").getByRole("button", { name: "Slett mappe" }).click();
   await harCheckpoint();
-  await mockWaitResponse(page, "**/graphql-api/graphql");
+  await waitGraphql();
   await expect(page.getByRole("dialog")).not.toBeVisible();
   await expect(page.getByRole("listitem").getByText(name).last()).not.toBeVisible();
   await expect(folderList.getByRole("listitem")).toHaveCount(count);

--- a/e2e/specs/authenticated/MyNDLAMenu.spec.ts
+++ b/e2e/specs/authenticated/MyNDLAMenu.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { expect } from "@playwright/test";
-import { test, mockWaitResponse } from "../../apiMock";
+import { test } from "../../apiMock";
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/minndla");
@@ -37,8 +37,8 @@ test("can navigate to profile", async ({ page }) => {
   await expect(page.getByRole("heading").getByText("Min profil")).toBeVisible();
 });
 
-test("have all options at the different pages", async ({ page }) => {
-  await mockWaitResponse(page, "**/graphql-api/graphql");
+test("have all options at the different pages", async ({ page, waitGraphql }) => {
+  await waitGraphql();
   await expect(page.getByRole("link", { name: "Logg ut" })).toBeVisible({ timeout: 10000 });
   const options = await page.getByTestId("my-ndla-menu").getByRole("listitem").allInnerTexts();
 

--- a/e2e/specs/unauthenticated/frontpage.spec.ts
+++ b/e2e/specs/unauthenticated/frontpage.spec.ts
@@ -7,14 +7,14 @@
  */
 
 import { expect } from "@playwright/test";
-import { test, mockWaitResponse } from "../../apiMock";
+import { test } from "../../apiMock";
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/?disableSSR=true");
 });
 
-test("should have list of valid links on frontpage", async ({ page }) => {
-  await mockWaitResponse(page, "**/graphql-api/*");
+test("should have list of valid links on frontpage", async ({ page, waitGraphql }) => {
+  await waitGraphql();
   const programmes = page.getByTestId("programme-list").getByRole("link");
   await expect(programmes).toHaveCount(15);
 });

--- a/e2e/specs/unauthenticated/iframe.spec.ts
+++ b/e2e/specs/unauthenticated/iframe.spec.ts
@@ -7,27 +7,27 @@
  */
 
 import { expect } from "@playwright/test";
-import { test, mockWaitResponse } from "../../apiMock";
+import { test } from "../../apiMock";
 
-test("topic contains content", async ({ page }) => {
+test("topic contains content", async ({ page, waitGraphql }) => {
   await page.goto("/article-iframe/nb/urn:topic:2:170165/2?disableSSR=true");
-  await mockWaitResponse(page, "**/graphql-api/*");
+  await waitGraphql();
   const heading = page.getByRole("heading").getByText("Samfunnsfaglige tenkemåter");
   expect(heading).toBeDefined();
   expect(await heading.textContent()).toEqual("Samfunnsfaglige tenkemåter");
 });
 
-test("resource contains content", async ({ page }) => {
+test("resource contains content", async ({ page, waitGraphql }) => {
   await page.goto("/article-iframe/nb/urn:resource:1:124037/3?disableSSR=true");
-  await mockWaitResponse(page, "**/graphql-api/*");
+  await waitGraphql();
   const heading = page.getByRole("heading").getByText("Meninger og kunnskap om samfunnet").first();
   expect(heading).toBeDefined();
   expect(await heading.textContent()).toEqual("Meninger og kunnskap om samfunnet");
 });
 
-test("oembed contains content", async ({ page }) => {
+test("oembed contains content", async ({ page, waitGraphql }) => {
   await page.goto("/article-iframe/nb/article/4?disableSSR=true");
-  await mockWaitResponse(page, "**/graphql-api/*");
+  await waitGraphql();
   const heading = page.getByRole("heading").getByText("Medier og informasjonskilder");
   expect(heading).toBeDefined();
   expect(await heading.textContent()).toEqual("Medier og informasjonskilder");

--- a/e2e/specs/unauthenticated/multidisciplinary.spec.ts
+++ b/e2e/specs/unauthenticated/multidisciplinary.spec.ts
@@ -7,17 +7,17 @@
  */
 
 import { expect } from "@playwright/test";
-import { test, mockWaitResponse } from "../../apiMock";
+import { test } from "../../apiMock";
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/?disableSSR=true");
 });
 
-test("contains content", async ({ page }) => {
-  await mockWaitResponse(page, "**/graphql-api/graphql*");
+test("contains content", async ({ page, waitGraphql }) => {
+  await waitGraphql();
   await page.getByRole("button").getByText("Meny").click();
   await page.getByRole("menuitem", { name: "Tverrfaglige tema" }).first().click();
-  await mockWaitResponse(page, "**/graphql-api/graphql*");
+  await waitGraphql();
   await page.waitForLoadState();
   const heading = page.getByRole("heading").getByText("Tverrfaglige temaer");
   expect(heading).toBeDefined();

--- a/e2e/specs/unauthenticated/search.spec.ts
+++ b/e2e/specs/unauthenticated/search.spec.ts
@@ -7,11 +7,11 @@
  */
 
 import { expect } from "@playwright/test";
-import { test, mockWaitResponse } from "../../apiMock";
+import { test } from "../../apiMock";
 
-test("contains search bar", async ({ page }) => {
+test("contains search bar", async ({ page, waitGraphql }) => {
   await page.goto("/search/?disableSSR=true&type=resource");
-  await mockWaitResponse(page, "**/graphql-api/*");
+  await waitGraphql();
 
   const input = page.getByRole("searchbox");
 

--- a/e2e/specs/unauthenticated/subjects.spec.ts
+++ b/e2e/specs/unauthenticated/subjects.spec.ts
@@ -7,15 +7,15 @@
  */
 
 import { expect } from "@playwright/test";
-import { test, mockWaitResponse } from "../../apiMock";
+import { test } from "../../apiMock";
 
-test.beforeEach(async ({ page }) => {
+test.beforeEach(async ({ page, waitGraphql }) => {
   await page.goto("/?disableSSR=true");
 
   await page.getByTestId("programme-list").getByRole("link", { name: "Medier og kommunikasjon" }).click();
-  await mockWaitResponse(page, "**/graphql-api/graphql");
+  await waitGraphql();
   await page.getByRole("link", { name: "Mediesamfunnet 1" }).last().click();
-  await mockWaitResponse(page, "**/graphql-api/graphql");
+  await waitGraphql();
 
   const competenceButton = page.getByRole("button").getByText("Vis kompetansemål");
   await expect(competenceButton).not.toBeDisabled();

--- a/e2e/specs/unauthenticated/toolbox.spec.ts
+++ b/e2e/specs/unauthenticated/toolbox.spec.ts
@@ -7,16 +7,16 @@
  */
 
 import { expect } from "@playwright/test";
-import { test, mockWaitResponse } from "../../apiMock";
+import { test } from "../../apiMock";
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/?disableSSR=true");
 });
 
-test("shows students", async ({ page }) => {
+test("shows students", async ({ page, waitGraphql }) => {
   await page.getByRole("button", { name: "Meny" }).click();
   await page.getByRole("menuitem", { name: "Verktøykassa - for elever" }).click();
-  await mockWaitResponse(page, "**/graphql-api/*");
+  await waitGraphql();
   await expect(page.getByRole("heading", { name: "Verktøykassa – for elever" })).toBeVisible();
 
   const navList = page.getByRole("navigation", { name: "Emner" }).getByRole("list");
@@ -25,10 +25,10 @@ test("shows students", async ({ page }) => {
   await expect(navList.getByRole("link")).toHaveCount(16);
 });
 
-test("shows teachers", async ({ page }) => {
+test("shows teachers", async ({ page, waitGraphql }) => {
   await page.getByRole("button", { name: "Meny" }).click();
   await page.getByRole("menuitem", { name: "Verktøykassa - for lærere" }).click();
-  await mockWaitResponse(page, "**/graphql-api/*");
+  await waitGraphql();
   await expect(page.getByRole("heading", { name: "Verktøykassa – for lærere" })).toBeVisible();
 
   const navList = page.getByRole("navigation", { name: "Emner" }).getByRole("list");

--- a/e2e/specs/unauthenticated/topic.spec.ts
+++ b/e2e/specs/unauthenticated/topic.spec.ts
@@ -7,31 +7,31 @@
  */
 
 import { expect } from "@playwright/test";
-import { test, mockWaitResponse } from "../../apiMock";
+import { test } from "../../apiMock";
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/?disableSSR=true");
 });
 
-test("contains article header and introduction", async ({ page }) => {
-  await mockWaitResponse(page, "**/graphql-api/*");
+test("contains article header and introduction", async ({ page, waitGraphql }) => {
+  await waitGraphql();
   await page.getByRole("button", { name: "Meny" }).click();
   await page.getByRole("menuitem", { name: "Fag", exact: true }).click();
-  await mockWaitResponse(page, "**/graphql-api/*");
+  await waitGraphql();
   await page.getByText("ALLE FAG").last().click();
   await page.getByRole("link", { name: "Medieuttrykk 3" }).last().click();
-  await mockWaitResponse(page, "**/graphql-api/*");
+  await waitGraphql();
   await page
     .getByRole("navigation", { name: "Emner" })
     .getByRole("listitem")
     .getByRole("link", { name: "Idéskaping og mediedesign" })
     .click();
-  await mockWaitResponse(page, "**/graphql-api/*");
+  await waitGraphql();
   await expect(page.getByRole("heading", { name: "Idéskaping og mediedesign", exact: true })).toBeVisible();
 });
 
-test("show have functioning language box", async ({ page }) => {
-  await mockWaitResponse(page, "**/graphql-api/*");
+test("show have functioning language box", async ({ page, waitGraphql }) => {
+  await waitGraphql();
   await page.getByRole("button", { name: "Meny" }).click();
   await page.getByRole("menuitem", { name: "Fag", exact: true }).click();
   await page.getByText("ALLE FAG").last().click();
@@ -42,7 +42,7 @@ test("show have functioning language box", async ({ page }) => {
     .getByRole("link", { name: "Tverrfaglige medieoppdrag" })
     .click();
 
-  await mockWaitResponse(page, "**/graphql-api/*");
+  await waitGraphql();
 
   await expect(page.getByRole("heading", { name: "Tverrfaglige medieoppdrag", exact: true })).toBeVisible();
 });

--- a/e2e/specs/unauthenticated/topicMenu.spec.ts
+++ b/e2e/specs/unauthenticated/topicMenu.spec.ts
@@ -7,18 +7,18 @@
  */
 
 import { expect } from "@playwright/test";
-import { test, mockWaitResponse } from "../../apiMock";
+import { test } from "../../apiMock";
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/?disableSSR=true");
 });
 
-test("menu is displayed", async ({ page }) => {
+test("menu is displayed", async ({ page, waitGraphql }) => {
   await page.getByTestId("programme-list").getByRole("link", { name: "Medier og kommunikasjon" }).click();
-  await mockWaitResponse(page, "**/graphql-api/graphql");
+  await waitGraphql();
   await page.getByRole("link", { name: "Mediesamfunnet 1" }).last().click();
-  await mockWaitResponse(page, "**/graphql-api/graphql");
+  await waitGraphql();
   await page.getByTestId("masthead-menu-button").click();
-  await mockWaitResponse(page, "**/graphql-api/graphql");
+  await waitGraphql();
   expect(page.getByRole("link", { name: "Mediesamfunnet 1" })).toBeDefined();
 });

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2025-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { TestInfo } from "@playwright/test";
+import { readFile, writeFile } from "fs/promises";
+
+const MOCK_DIR = "e2e/apiMocks/";
+const TEST_IMAGE_REGEX = "https://api.test.ndla.no/(?!image-api/raw.*).*";
+const LOCALHOST_GRAPHQL_REGEX = "http://localhost:4000/graphql-api/graphql";
+
+export const API_REGEX = new RegExp(`^(${TEST_IMAGE_REGEX}|${LOCALHOST_GRAPHQL_REGEX})$`);
+
+export const removeSensitiveDataFromHar = async (fileName: string) => {
+  const data = JSON.parse(await readFile(fileName, "utf8"));
+  await writeFile(fileName, JSON.stringify(data), "utf8");
+};
+
+export const getMockdataFilename = ({ titlePath, title: test_name }: TestInfo) => {
+  const [, SPEC_GROUP, SPEC_NAME] = titlePath[0].split("/");
+  return `${MOCK_DIR}${SPEC_GROUP}_${SPEC_NAME}_${test_name.replace(/\s/g, "_")}.har`;
+};
+
+export const createCheckpoint = (index: number) => ({ "x-playwright-checkpoint": `${index}` });


### PR DESCRIPTION
Flytter litt util metoder ut i en util fil for å filen litt ryddigere, refaktorer navnene for å bli mer tydigere. 
Gjør om `mockWaitResponse` til å bli `waitGraphql` for å kunne ta den i bruk gjennom test metoden istedenfor. 