### PR TITLE
feat: send more error context data to sentry

### DIFF
--- a/src/util/error/NDLAApolloErrors.ts
+++ b/src/util/error/NDLAApolloErrors.ts
@@ -50,6 +50,7 @@ export class NDLANetworkError extends NDLAError {
     const operationInfo = {
       operationName: operation.operationName,
       variables: operation.variables,
+      extensions: operation.extensions,
     };
 
     this.logContext = {

--- a/src/util/handleError.ts
+++ b/src/util/handleError.ts
@@ -184,9 +184,15 @@ const logServerError = async (
   }
 };
 
+const sendToSentry = (error: ErrorType, requestPath: string | undefined, extraContext: Record<string, unknown>) => {
+  const errorContext = { error, requestPath, ...extraContext };
+  Sentry.setContext("NDLA Context", errorContext);
+  Sentry.captureException(error);
+};
+
 const handleError = async (error: ErrorType, requestPath?: string, extraContext: Record<string, unknown> = {}) => {
   if (config.runtimeType === "production" && config.isClient) {
-    Sentry.captureException(error);
+    sendToSentry(error, requestPath, extraContext);
   } else if (!config.isClient) {
     await logServerError(error, requestPath, extraContext);
   } else {

--- a/src/util/sentry.ts
+++ b/src/util/sentry.ts
@@ -110,6 +110,7 @@ export const initSentry = (config: ConfigType) => {
   Sentry.init({
     dsn: config.sentrydsn,
     environment: config.ndlaEnvironment,
+    normalizeDepth: 20,
     release,
     beforeSend,
     integrations: [],


### PR DESCRIPTION
Akkurat graphql feil vil nok være litt klønete uansett siden stacktracene ikke er fra der queryen er (wtf apollo)

men vi vil i alle fall få med samme type kontekster som i loggene:
![image](https://github.com/user-attachments/assets/e58f0975-1326-4bc0-8b65-e5c2ed178700)
