### PR TITLE
fix: install awscli from `apk` rather than `pip`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN --mount=type=secret,id=sentry_token \
 ### Run stage
 FROM node:20.19.1-alpine3.20
 
-RUN apk add py-pip jq && pip install awscli
+RUN apk add py-pip jq aws-cli
 COPY run-ndla-frontend.sh /
 
 WORKDIR /home/app/ndla-frontend


### PR DESCRIPTION
Nye alpine versjonen lar oss ikke installere pakker globalt uten et flagg.
Siden det _egentlig_ ikke er anbefalt så kan vi kanskje bare bruke den i repoene :nerd_face: 


noen som vet om vi bruker denne pakken til noe annet enn det som er i `run-ndla-frontend.sh`?
Kanskje vi bare kunne droppet hele greia?