### PR TITLE
fix: do not show edit form when accessing a shared learningpath you do not own

### DIFF
--- a/src/containers/MyNdla/Learningpath/EditLearningpathStepsPage.tsx
+++ b/src/containers/MyNdla/Learningpath/EditLearningpathStepsPage.tsx
@@ -18,6 +18,7 @@ import MyNdlaBreadcrumb from "../../../components/MyNdla/MyNdlaBreadcrumb";
 import { SKIP_TO_CONTENT_ID } from "../../../constants";
 import { routes } from "../../../routeHelpers";
 import { getAllDimensions } from "../../../util/trackingUtil";
+import { NotFoundPage } from "../../NotFoundPage/NotFoundPage";
 import MyNdlaPageWrapper from "../components/MyNdlaPageWrapper";
 
 const EditLearningpathStepsPageContent = lazy(() => import("./EditLearningpathStepsPageContent"));
@@ -46,6 +47,10 @@ export const EditLearningpathStepsPage = () => {
 
   if (!data?.myNdlaLearningpath) {
     return <Navigate to={routes.myNdla.learningpath} />;
+  }
+
+  if (!data.myNdlaLearningpath.canEdit) {
+    return <NotFoundPage />;
   }
 
   return (

--- a/src/containers/MyNdla/Learningpath/EditLearningpathTitlePage.tsx
+++ b/src/containers/MyNdla/Learningpath/EditLearningpathTitlePage.tsx
@@ -21,6 +21,7 @@ import { SKIP_TO_CONTENT_ID } from "../../../constants";
 import { useUpdateLearningpath } from "../../../mutations/learningpathMutations";
 import { routes } from "../../../routeHelpers";
 import { getAllDimensions } from "../../../util/trackingUtil";
+import { NotFoundPage } from "../../NotFoundPage/NotFoundPage";
 import MyNdlaPageWrapper from "../components/MyNdlaPageWrapper";
 
 export const EditLearningpathTitlePage = () => {
@@ -71,6 +72,10 @@ export const EditLearningpathTitlePage = () => {
 
   if (!data?.myNdlaLearningpath) {
     return <Navigate to={routes.myNdla.learningpath} />;
+  }
+
+  if (!data.myNdlaLearningpath.canEdit) {
+    return <NotFoundPage />;
   }
 
   return (

--- a/src/containers/MyNdla/Learningpath/PreviewLearningpathPage.tsx
+++ b/src/containers/MyNdla/Learningpath/PreviewLearningpathPage.tsx
@@ -40,6 +40,7 @@ const previewLearningpathQuery = gql`
   query previewLearningpath($pathId: String!, $transformArgs: TransformedArticleContentInput) {
     learningpath(pathId: $pathId) {
       id
+      canEdit
       ...Learningpath_Learningpath
       learningsteps {
         ...Learningpath_LearningpathStep
@@ -90,7 +91,7 @@ export const PreviewLearningpathPage = () => {
     : learningpath.learningsteps[0];
 
   // stepId is defined, but not found within the learningpath
-  if (numericStepId && numericStepId > 0 && !learningpathStep) {
+  if (!learningpath.canEdit || (numericStepId && numericStepId > 0 && !learningpathStep)) {
     return <NotFoundPage />;
   }
 

--- a/src/containers/MyNdla/Learningpath/SaveLearningpathPage.tsx
+++ b/src/containers/MyNdla/Learningpath/SaveLearningpathPage.tsx
@@ -30,6 +30,7 @@ import { getAllDimensions } from "../../../util/trackingUtil";
 import MyNdlaPageWrapper from "../components/MyNdlaPageWrapper";
 import { LearningpathShareLink } from "./components/LearningpathShareLink";
 import { useUpdateLearningpathStatus } from "../../../mutations/learningpathMutations";
+import { NotFoundPage } from "../../NotFoundPage/NotFoundPage";
 
 const TextWrapper = styled("div", {
   base: {
@@ -110,6 +111,10 @@ export const SaveLearningpathPage = () => {
 
   if (!learningpathQuery.data?.myNdlaLearningpath) {
     return <DefaultErrorMessagePage />;
+  }
+
+  if (!learningpathQuery.data.myNdlaLearningpath.canEdit) {
+    return <NotFoundPage />;
   }
 
   const learningpath = learningpathQuery.data.myNdlaLearningpath;

--- a/src/fragments/learningpathFragments.ts
+++ b/src/fragments/learningpathFragments.ts
@@ -77,6 +77,7 @@ export const learningpathFragment = gql`
     title
     description
     created
+    canEdit
     status
     madeAvailable
     revision

--- a/src/graphqlTypes.ts
+++ b/src/graphqlTypes.ts
@@ -2788,6 +2788,7 @@ export type GQLPreviewLearningpathQuery = {
   learningpath?: {
     __typename?: "Learningpath";
     id: number;
+    canEdit: boolean;
     learningsteps: Array<{ __typename?: "LearningpathStep" } & GQLLearningpath_LearningpathStepFragment>;
   } & GQLLearningpath_LearningpathFragment;
 };
@@ -3558,6 +3559,7 @@ export type GQLMyNdlaLearningpathFragment = {
   title: string;
   description: string;
   created: string;
+  canEdit: boolean;
   status: string;
   madeAvailable?: string;
   revision: number;


### PR DESCRIPTION
Bare en visuell bug. Kan teste ved å dele en læringssti fra en bruker, logge inn på en annen og lime inn redigeringslenke til stien du delte. F.eks http://localhost:3000/nb/minndla/learningpaths/3394/edit/title på alle andre brukere enn Daniel.