### PR TITLE
fix: encode and decode query parameter to avoid converting whitespace to plus sign

### DIFF
--- a/src/containers/Masthead/components/MastheadSearch.tsx
+++ b/src/containers/Masthead/components/MastheadSearch.tsx
@@ -301,7 +301,7 @@ const MastheadSearch = ({ root }: Props) => {
   }, [query.length, searchResult.search?.results]);
 
   const searchString = queryString.stringify({
-    query: query && query.length > 0 ? query : undefined,
+    query: query && query.length > 0 ? encodeURIComponent(query) : undefined,
   });
 
   const onSearch = (evt?: FormEvent) => {

--- a/src/containers/SearchPage/SearchContainer.tsx
+++ b/src/containers/SearchPage/SearchContainer.tsx
@@ -252,7 +252,7 @@ interface Props {
 
 export const SearchContainer = ({ resourceTypes, resourceTypesLoading }: Props) => {
   const [searchParams, setSearchParams] = useStableSearchPageParams();
-  const [query, setQuery] = useState(searchParams.get("query") ?? "");
+  const [query, setQuery] = useState(decodeURIComponent(searchParams.get("query") ?? ""));
   const [page, setPage] = useState(() => {
     const maybePage = parseInt(searchParams.get("page") ?? "1");
     return maybePage ?? 1;
@@ -307,7 +307,7 @@ export const SearchContainer = ({ resourceTypes, resourceTypesLoading }: Props) 
   const handleSubmit = useCallback(
     (e: FormEvent<HTMLFormElement>) => {
       e.preventDefault();
-      setSearchParams({ query });
+      setSearchParams({ query: encodeURIComponent(query) });
     },
     [query, setSearchParams],
   );
@@ -328,7 +328,7 @@ export const SearchContainer = ({ resourceTypes, resourceTypesLoading }: Props) 
       res.push(t("searchPage.showingResults.query"));
       // TODO: Should we account for the possibility that the query is wrapped in quotes? If so, how should we display it?
       // Keep query out of the translation string to avoid escaping issues
-      res.push(`"${currentQuery}"`);
+      res.push(`"${decodeURIComponent(currentQuery)}"`);
     }
     return res.filter(Boolean).join(" ");
   }, [data?.search, page, searchParams, t]);


### PR DESCRIPTION
Tror dette er en bug i react router!