### PR TITLE
fix: update `newFolderParentId` when selection is changed

### DIFF
--- a/src/components/MyNdla/TreeStructure.tsx
+++ b/src/components/MyNdla/TreeStructure.tsx
@@ -188,6 +188,9 @@ export const TreeStructure = ({
     onSelectionChange: (details) => {
       const val = details.selectedValue[0];
       if (!val) return;
+      if (newFolderParentId) {
+        setNewFolderParentId(val);
+      }
       setSelectedValue(val);
       onSelectFolder?.(val);
     },


### PR DESCRIPTION
Fikser problem rapportert i trello.