### PR TITLE
Improve exception logging

### DIFF
--- a/src/containers/TopicPage/TopicPage.tsx
+++ b/src/containers/TopicPage/TopicPage.tsx
@@ -98,7 +98,7 @@ export const TopicPage = () => {
     return <MovedTopicPage nodes={query.data.node.alternateNodes} />;
   }
 
-  if (!query.data || query.error) {
+  if (query.error) {
     handleError(query.error);
     const accessDeniedErrors = findAccessDeniedErrors(query.error);
     if (accessDeniedErrors.length) {
@@ -106,17 +106,13 @@ export const TopicPage = () => {
         (e) => !e.path?.includes("resources") && !e.path?.includes("children"),
       );
 
-      if (nonRecoverableError) {
-        return <ForbiddenPage />;
-      }
-    } else if (isNotFoundError(query.error)) {
-      return <NotFoundPage />;
-    } else return <DefaultErrorMessagePage />;
+      if (nonRecoverableError) return <ForbiddenPage />;
+    }
+
+    if (isNotFoundError(query.error)) return <NotFoundPage />;
   }
 
-  if (!query.data?.node) {
-    return <DefaultErrorMessagePage />;
-  }
+  if (!query.data?.node) return <DefaultErrorMessagePage />;
 
   if (query.error?.graphQLErrors.some((err) => err.extensions?.status === 404)) {
     return <NotFoundPage />;

--- a/src/containers/TopicPage/TopicPage.tsx
+++ b/src/containers/TopicPage/TopicPage.tsx
@@ -112,13 +112,11 @@ export const TopicPage = () => {
     if (isNotFoundError(query.error)) return <NotFoundPage />;
   }
 
-  if (!query.data?.node) return <DefaultErrorMessagePage />;
-
   if (query.error?.graphQLErrors.some((err) => err.extensions?.status === 404)) {
     return <NotFoundPage />;
   }
 
-  if (!query.data?.node.article) {
+  if (!query.data?.node?.article) {
     return <NotFoundPage />;
   }
 

--- a/src/server/routes/oembedArticleRoute.ts
+++ b/src/server/routes/oembedArticleRoute.ts
@@ -17,7 +17,7 @@ import { getArticleIdFromResource } from "../../containers/Resources/resourceHel
 import { GQLEmbedOembedQuery, GQLEmbedOembedQueryVariables } from "../../graphqlTypes";
 import { BAD_REQUEST, INTERNAL_SERVER_ERROR, NOT_FOUND } from "../../statusCodes";
 import { apiResourceUrl, createApolloClient, resolveJsonOrRejectWithError } from "../../util/apiHelpers";
-import handleError from "../../util/handleError";
+import handleError, { ensureError } from "../../util/handleError";
 import { parseOembedUrl } from "../../util/urlHelper";
 
 const baseUrl = apiResourceUrl("/taxonomy/v1");
@@ -188,7 +188,7 @@ export async function oembedArticleRoute(req: express.Request) {
     }
     return getOembedObject(req, title, html);
   } catch (error) {
-    handleError(error, req.path);
+    handleError(ensureError(error), req.path);
 
     const typedError = error as { status?: number; message?: string };
     const status = typedError.status || INTERNAL_SERVER_ERROR;

--- a/src/util/error/index.ts
+++ b/src/util/error/index.ts
@@ -9,4 +9,5 @@
 import { ApolloError } from "@apollo/client";
 import { NDLAError } from "./NDLAError";
 
-export type ErrorType = ApolloError | Error | NDLAError | string | unknown;
+export type ErrorType = ApolloError | Error | NDLAError;
+export type UnknownError = ErrorType | unknown;


### PR DESCRIPTION
Passer på at vi ikke kan sende inn ikke-feil til `handleError`.
Har sett en del av disse i loggene:

```json
{
  "level": "error",
  "message": "Unknown error: undefined",
  "service": "ndla-frontend",
  "timestamp": "2025-05-16T06:25:18.818Z"
}
```

mistenker at det ikke er faktiske feil, men bare vi som logger litt mye når vi får 404 eller manglende data.