### PR TITLE
fix: return 400 if `/oembed` gets non-valid url

### DIFF
--- a/src/iframe/embedIframeIndex.tsx
+++ b/src/iframe/embedIframeIndex.tsx
@@ -51,7 +51,7 @@ initSentry(config);
 
 const language = initialProps.locale ?? config.defaultLocale;
 
-const client = createApolloClient(language, undefined, window.location.pathname);
+const client = createApolloClient(language, undefined, `${window.location.pathname}${window.location.search}`);
 const i18n = initializeI18n(i18nInstance, language);
 
 const renderOrHydrate = (container: Element | Document, children: ReactNode) => {

--- a/src/server/podcastRssFeed.ts
+++ b/src/server/podcastRssFeed.ts
@@ -19,7 +19,7 @@ const getApolloClient = (locale: string, req: Request) => {
   if (apolloClient && locale === storedLocale) {
     return apolloClient;
   } else {
-    apolloClient = createApolloClient(locale, undefined, req.path);
+    apolloClient = createApolloClient(locale, undefined, req.url);
     storedLocale = locale;
     return apolloClient;
   }

--- a/src/server/render/defaultRender.tsx
+++ b/src/server/render/defaultRender.tsx
@@ -60,7 +60,7 @@ export const defaultRender: RenderFunc = async (req, chunks) => {
     };
   }
 
-  const client = createApolloClient(locale, versionHash, req.path);
+  const client = createApolloClient(locale, versionHash, req.url);
   const i18n = initializeI18n(i18nInstance, locale);
   const redirectContext: RedirectInfo = {};
   const responseContext: ResponseInfo = {};

--- a/src/server/render/iframeArticleRender.tsx
+++ b/src/server/render/iframeArticleRender.tsx
@@ -63,7 +63,7 @@ export const iframeArticleRender: RenderFunc = async (req, chunks) => {
     };
   }
 
-  const client = createApolloClient(locale, undefined, req.path);
+  const client = createApolloClient(locale, undefined, req.url);
   const i18n = initializeI18n(i18nInstance, locale ?? config.defaultLocale);
   const context: RedirectInfo = {};
 

--- a/src/server/render/iframeEmbedRender.tsx
+++ b/src/server/render/iframeEmbedRender.tsx
@@ -54,7 +54,7 @@ export const iframeEmbedRender: RenderFunc = async (req, chunks) => {
     };
   }
 
-  const client = createApolloClient(locale, undefined, req.path);
+  const client = createApolloClient(locale, undefined, req.url);
   const i18n = initializeI18n(i18nInstance, locale ?? (config.defaultLocale as LocaleType));
   const context: RedirectInfo = {};
 

--- a/src/server/routes/oembedArticleRoute.ts
+++ b/src/server/routes/oembedArticleRoute.ts
@@ -68,7 +68,7 @@ const getApolloClient = (locale: string, req: express.Request) => {
   if (apolloClient && locale === storedLocale) {
     return apolloClient;
   } else {
-    apolloClient = createApolloClient(locale, undefined, req.path);
+    apolloClient = createApolloClient(locale, undefined, req.url);
     storedLocale = locale;
     return apolloClient;
   }
@@ -197,7 +197,7 @@ export async function oembedArticleRoute(req: express.Request): Promise<OembedRo
     }
     return getOembedResponse(req, title, iframeSrc);
   } catch (error) {
-    handleError(ensureError(error), req.path);
+    handleError(ensureError(error), req.url);
 
     const typedError = error as { status?: number; message?: string };
     const status = typedError.status || INTERNAL_SERVER_ERROR;


### PR DESCRIPTION
Tidligere så kræsjet vi med 500 dersom oembed ruten fikk en ikke-gyldig oembed url.
Legger også til query parametere til `requestPath` i loggene.