### PR TITLE
fix: redirect to my ndla when logging in from menu

### DIFF
--- a/src/containers/Masthead/MastheadMenu.tsx
+++ b/src/containers/Masthead/MastheadMenu.tsx
@@ -392,7 +392,7 @@ const MyNdlaPart = () => {
           </LogoutSafeLinkButton>
         </>
       ) : (
-        <MyNdlaSafeLinkButton variant="secondary" to={`/login?state=${toHref(location)}`} reloadDocument>
+        <MyNdlaSafeLinkButton variant="secondary" to={`/login?state=${routes.myNdla.root}`} reloadDocument>
           <UserLine />
           {t("masthead.menu.myNdla.myNdla")}
         </MyNdlaSafeLinkButton>


### PR DESCRIPTION
Fixes https://trello.com/c/evZcw8c4/1396-menyen-klikker-jeg-p%C3%A5-min-ndla-i-menyen-uten-%C3%A5-v%C3%A6re-innlogget-blir-jeg-sendt-gjennom-innlogging-via-feide-men-s%C3%A5-tilbake-til-for