### PR TITLE
fix: filter out OneNote errors

### DIFF
--- a/src/util/sentry.ts
+++ b/src/util/sentry.ts
@@ -96,6 +96,11 @@ export const beforeSend = (event: Sentry.ErrorEvent, hint: Sentry.EventHint) => 
     return null;
   }
 
+  // OneNote can fail in a million ways. They are probably not our problem.
+  if (document.referrer && document.referrer.includes("noc-onenote.officeapps.live.com")) {
+    return null;
+  }
+
   return event;
 };
 


### PR DESCRIPTION
Mistenker at brorparten av feilene vi sender til Sentry kommer fra OneNote, uten at jeg helt skjønner hvorfor det tryner. Virker som at OneNote til tider har problemer med å vise frem gamle lenker (les: lenker som har blitt limt inn for en stund siden, ikke gammelt lenke-format). Vi tester allerede både oembed og article-iframe, så det skader vel ikke å filtrere ut disse feilene.