### PR TITLE
fix: Safari expects top-level json-ld to be an object, not an array

### DIFF
--- a/src/containers/PodcastPage/PodcastSeriesPage.tsx
+++ b/src/containers/PodcastPage/PodcastSeriesPage.tsx
@@ -136,7 +136,10 @@ const PodcastSeriesPage = () => {
         ...getCopyrightData(episode.copyright),
       };
     });
-    const data = [seriesData, ...(episodes || [])];
+    const data = {
+      ...seriesData,
+      "@graph": episodes ?? [],
+    };
     return JSON.stringify(data);
   };
 


### PR DESCRIPTION
Tror dette skal tolkes likt som det vi hadde før. Fikser en feil som kun oppstod i Safari.