### PR TITLE
fix: return 404 for non-numeric embed id

### DIFF
--- a/src/containers/ResourceEmbed/AudioPage.tsx
+++ b/src/containers/ResourceEmbed/AudioPage.tsx
@@ -13,7 +13,7 @@ import { NotFoundPage } from "../NotFoundPage/NotFoundPage";
 const AudioPage = () => {
   const { audioId } = useParams();
 
-  if (!audioId) {
+  if (!audioId || !parseInt(audioId)) {
     return <NotFoundPage />;
   }
 

--- a/src/containers/ResourceEmbed/ConceptPage.tsx
+++ b/src/containers/ResourceEmbed/ConceptPage.tsx
@@ -12,7 +12,7 @@ import { NotFoundPage } from "../NotFoundPage/NotFoundPage";
 
 const ConceptPage = () => {
   const { conceptId } = useParams();
-  if (!conceptId) {
+  if (!conceptId || !parseInt(conceptId)) {
     return <NotFoundPage />;
   }
 

--- a/src/containers/ResourceEmbed/ImagePage.tsx
+++ b/src/containers/ResourceEmbed/ImagePage.tsx
@@ -13,7 +13,7 @@ import { NotFoundPage } from "../NotFoundPage/NotFoundPage";
 const ImagePage = () => {
   const { imageId } = useParams();
 
-  if (!imageId) {
+  if (!imageId || !parseInt(imageId)) {
     return <NotFoundPage />;
   }
 


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/4385.

Tror Brightcove alltid er numerisk?