### PR TITLE
remove env for reusable workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,5 @@ jobs:
   release:
     uses: ndlano/reusable-workflows/.github/workflows/release.yaml@main
     secrets: inherit
-    env:
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     with:
       component: ndla-frontend


### PR DESCRIPTION
the secret should now be loaded directly in the release workflow