### PR TITLE
fix: only strip language prefix at start of pathname

### DIFF
--- a/src/components/Learningpath/components/LearningpathStep.tsx
+++ b/src/components/Learningpath/components/LearningpathStep.tsx
@@ -26,7 +26,7 @@ const urlIsNDLAEnvUrl = (url: string) => /^(http|https):\/\/(www.)?([a-zA-Z]+.)?
 const urlIsLocalNdla = (url: string) => /^http:\/\/(proxy.ndla-local|localhost):30017/.test(url);
 const urlIsNDLAUrl = (url: string) => urlIsNDLAApiUrl(url) || urlIsNDLAEnvUrl(url) || urlIsLocalNdla(url);
 
-const regex = new RegExp(`\\/(${supportedLanguages.join("|")})($|\\/)`, "");
+const regex = new RegExp(`^\\/(${supportedLanguages.join("|")})($|\\/)`, "");
 
 const getIdFromIframeUrl = (_url: string): [string | undefined, string | undefined] => {
   const url = _url.split("/article-iframe")?.[1]?.replace(regex, "")?.replace("article/", "")?.split("?")?.[0];

--- a/src/util/urlHelper.ts
+++ b/src/util/urlHelper.ts
@@ -89,7 +89,7 @@ export const toHref = (location: Location) => {
   return `${location.pathname}${location.search}`;
 };
 
-const LANGUAGE_REGEXP = new RegExp(`\\/(${supportedLanguages.join("|")})($|\\/)`, "");
+const LANGUAGE_REGEXP = new RegExp(`^\\/(${supportedLanguages.join("|")})($|\\/)`, "");
 
 export const constructNewPath = (pathname: string, newLocale?: string) => {
   const path = pathname.replace(LANGUAGE_REGEXP, "");


### PR DESCRIPTION
Fixes https://trello.com/c/Pm1q1WzG/1413-d%C3%B8d-lenke-i-ressurser-p%C3%A5-nordsamisk

Tror ikke dette skal ha noen store konsekvenser? Det eneste jeg kan se for meg er iframe, der man også kan ha to språksegmenter