### PR TITLE
chore: remove unused loc field

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,3 +1,14 @@
 module.exports = {
-  plugins: ["graphql-tag"],
+  plugins: [
+    [
+      "graphql-tag",
+      {
+        strip: true,
+        transform: (_, ast) => {
+          delete ast.loc;
+          return ast;
+        },
+      },
+    ],
+  ],
 };


### PR DESCRIPTION
babel-plugin-graphql-tag legger på et `loc`-felt vi ikke trenger. Vi sparer litt (1-2kb) på å fjerne det.