### PR TITLE
feat: preload route chunks for faster initial page load

### DIFF
--- a/src/Document.tsx
+++ b/src/Document.tsx
@@ -103,7 +103,10 @@ export const Document = ({ language, children, chunks = [], devEntrypoint }: Pro
         <Scripts />
         {!!entryPoint && <script type="module" src={`/${entryPoint.file}`}></script>}
         {css.map((file) => (
-          <link rel="stylesheet" href={`/${file}`} key={file} />
+          <>
+            <link rel="preload" href={`/${file}`} key={`${file}-preload`} as="stylesheet" />
+            <link rel="stylesheet" href={`/${file}`} key={file} />
+          </>
         ))}
         {importedChunks.map((chunk) => (
           <link rel="modulepreload" href={`/${chunk.file}`} key={chunk.file}></link>

--- a/src/appRoutes.tsx
+++ b/src/appRoutes.tsx
@@ -9,9 +9,10 @@
 import { RouteObject } from "react-router";
 import ErrorPage from "./containers/ErrorPage";
 import Layout from "./containers/Page/Layout";
+import { RouteObjectWithImportPath } from "./interfaces";
 import { ErrorElement } from "./RouteErrorElement";
 
-export const routes: RouteObject[] = [
+export const routes: RouteObjectWithImportPath[] = [
   {
     path: "/",
     errorElement: <ErrorElement />,
@@ -19,22 +20,27 @@ export const routes: RouteObject[] = [
     children: [
       {
         index: true,
+        importPath: "src/containers/WelcomePage/WelcomePage.tsx",
         lazy: () => import("./containers/WelcomePage/WelcomePage"),
       },
       {
         path: "subjects",
+        importPath: "src/containers/AllSubjectsPage/AllSubjectsPage.tsx",
         lazy: () => import("./containers/AllSubjectsPage/AllSubjectsPage"),
       },
       {
         path: "search",
+        importPath: "src/containers/SearchPage/SearchPage.tsx",
         lazy: () => import("./containers/SearchPage/SearchPage"),
       },
       {
         path: "utdanning/:programme/:contextId/:grade?",
+        importPath: "src/containers/ProgrammePage/ProgrammePage.tsx",
         lazy: () => import("./containers/ProgrammePage/ProgrammePage"),
       },
       {
         path: "samling/:collectionId",
+        importPath: "src/containers/CollectionPage/CollectionPage.tsx",
         lazy: () => import("./containers/CollectionPage/CollectionPage"),
       },
       {
@@ -42,16 +48,19 @@ export const routes: RouteObject[] = [
         children: [
           {
             index: true,
+            importPath: "src/containers/PodcastPage/PodcastSeriesListPage.tsx",
             lazy: () => import("./containers/PodcastPage/PodcastSeriesListPage"),
           },
           {
             path: ":id",
+            importPath: "src/containers/PodcastPage/PodcastSeriesPage.tsx",
             lazy: () => import("./containers/PodcastPage/PodcastSeriesPage"),
           },
         ],
       },
       {
         path: "article/:articleId",
+        importPath: "src/containers/PlainArticlePage/PlainArticlePage.tsx",
         lazy: () => import("./containers/PlainArticlePage/PlainArticlePage"),
       },
       {
@@ -59,10 +68,12 @@ export const routes: RouteObject[] = [
         children: [
           {
             index: true,
+            importPath: "src/containers/PlainLearningpathPage/PlainLearningpathPage.tsx",
             lazy: () => import("./containers/PlainLearningpathPage/PlainLearningpathPage"),
           },
           {
             path: "steps/:stepId",
+            importPath: "src/containers/PlainLearningpathPage/PlainLearningpathPage.tsx",
             lazy: () => import("./containers/PlainLearningpathPage/PlainLearningpathPage"),
           },
         ],
@@ -72,10 +83,12 @@ export const routes: RouteObject[] = [
         children: [
           {
             path: ":contextId/:stepId?",
+            importPath: "src/containers/ResourcePage/ResourcePage.tsx",
             lazy: () => import("./containers/ResourcePage/ResourcePage"),
           },
           {
             path: ":root/:name/:contextId/:stepId?",
+            importPath: "src/containers/ResourcePage/ResourcePage.tsx",
             lazy: () => import("./containers/ResourcePage/ResourcePage"),
           },
         ],
@@ -85,64 +98,79 @@ export const routes: RouteObject[] = [
         children: [
           {
             path: ":contextId",
+            importPath: "src/containers/TopicPage/TopicPage.tsx",
             lazy: () => import("./containers/TopicPage/TopicPage"),
           },
           {
             path: ":root/:name/:contextId",
+            importPath: "src/containers/TopicPage/TopicPage.tsx",
             lazy: () => import("./containers/TopicPage/TopicPage"),
           },
         ],
       },
       {
         path: "f/:root?/:name?/:contextId",
+        importPath: "src/containers/SubjectPage/SubjectPage.tsx",
         lazy: () => import("./containers/SubjectPage/SubjectPage"),
       },
       {
         path: "video/:videoId",
+        importPath: "src/containers/ResourceEmbed/VideoPage.tsx",
         lazy: () => import("./containers/ResourceEmbed/VideoPage"),
       },
       {
         path: "image/:imageId",
+        importPath: "src/containers/ResourceEmbed/ImagePage.tsx",
         lazy: () => import("./containers/ResourceEmbed/ImagePage"),
       },
       {
         path: "concept/:conceptId",
+        importPath: "src/containers/ResourceEmbed/ConceptPage.tsx",
         lazy: () => import("./containers/ResourceEmbed/ConceptPage"),
       },
       {
         path: "audio/:audioId",
+        importPath: "src/containers/ResourceEmbed/AudioPage.tsx",
         lazy: () => import("./containers/ResourceEmbed/AudioPage"),
       },
       {
         path: "h5p/:h5pId",
+        importPath: "src/containers/ResourceEmbed/H5pPage.tsx",
         lazy: () => import("./containers/ResourceEmbed/H5pPage"),
       },
       {
         path: "minndla",
+        importPath: "src/containers/MyNdla/MyNdlaLayout.tsx",
         lazy: () => import("./containers/MyNdla/MyNdlaLayout"),
         children: [
           {
             index: true,
+            importPath: "src/containers/MyNdla/MyNdlaPage.tsx",
             lazy: () => import("./containers/MyNdla/MyNdlaPage"),
           },
           {
             path: "folders/:folderId?",
+            importPath: "src/containers/MyNdla/Folders/FoldersPage.tsx",
             lazy: () => import("./containers/MyNdla/Folders/FoldersPage"),
           },
           {
             path: "folders/tag/:tag",
+            importPath: "src/containers/MyNdla/Folders/FoldersTagPage.tsx",
             lazy: () => import("./containers/MyNdla/Folders/FoldersTagPage"),
           },
           {
             path: "learningpaths",
+            importPath: "src/containers/MyNdla/Learningpath/LearningpathCheck.tsx",
             lazy: () => import("./containers/MyNdla/Learningpath/LearningpathCheck"),
             children: [
               {
                 index: true,
+                importPath: "src/containers/MyNdla/Learningpath/LearningpathPage.tsx",
                 lazy: () => import("./containers/MyNdla/Learningpath/LearningpathPage"),
               },
               {
                 path: "new",
+                importPath: "src/containers/MyNdla/Learningpath/NewLearningpathPage.tsx",
                 lazy: () => import("./containers/MyNdla/Learningpath/NewLearningpathPage"),
               },
               {
@@ -150,18 +178,22 @@ export const routes: RouteObject[] = [
                 children: [
                   {
                     path: "title",
+                    importPath: "src/containers/MyNdla/Learningpath/EditLearningpathTitlePage.tsx",
                     lazy: () => import("./containers/MyNdla/Learningpath/EditLearningpathTitlePage"),
                   },
                   {
                     path: "steps",
+                    importPath: "src/containers/MyNdla/Learningpath/EditLearningpathStepsPage.tsx",
                     lazy: () => import("./containers/MyNdla/Learningpath/EditLearningpathStepsPage"),
                     children: [
                       {
                         index: true,
+                        importPath: "src/containers/MyNdla/Learningpath/components/EditLearningpathNewStepLink.tsx",
                         lazy: () => import("./containers/MyNdla/Learningpath/components/EditLearningpathNewStepLink"),
                       },
                       {
                         path: "new",
+                        importPath: "src/containers/MyNdla/Learningpath/components/LearningpathStepForm.tsx",
                         lazy: () => import("./containers/MyNdla/Learningpath/components/LearningpathStepForm"),
                       },
                       {
@@ -174,50 +206,61 @@ export const routes: RouteObject[] = [
               },
               {
                 path: ":learningpathId/save",
+                importPath: "src/containers/MyNdla/Learningpath/SaveLearningpathPage.tsx",
                 lazy: () => import("./containers/MyNdla/Learningpath/SaveLearningpathPage"),
               },
               {
                 path: ":learningpathId/preview/:stepId?",
+                importPath: "src/containers/MyNdla/Learningpath/PreviewLearningpathPage.tsx",
                 lazy: () => import("./containers/MyNdla/Learningpath/PreviewLearningpathPage"),
               },
             ],
           },
           {
             path: "subjects",
+            importPath: "src/containers/MyNdla/Learningpath/FavoriteSubjectsPage.tsx",
             lazy: () => import("./containers/MyNdla/FavoriteSubjects/FavoriteSubjectsPage"),
           },
           {
             path: "profile",
+            importPath: "src/containers/MyNdla/MyProfile/MyProfilePage.tsx",
             lazy: () => import("./containers/MyNdla/MyProfile/MyProfilePage"),
           },
         ],
       },
       {
         path: "om/:slug",
+        importPath: "src/containers/AboutPage/AboutPage.tsx",
         lazy: () => import("./containers/AboutPage/AboutPage"),
       },
       {
         path: "folder/:folderId",
+        importPath: "src/containers/SharedFolderPage/SharedFolderPage.tsx",
         lazy: () => import("./containers/SharedFolderPage/SharedFolderPage"),
       },
       {
         path: "film",
+        importPath: "src/containers/FilmRedirect/FilmRedirectPage.tsx",
         lazy: () => import("./containers/FilmRedirect/FilmRedirectPage"),
       },
       {
         path: "404",
+        importPath: "src/containers/NotFoundPage/NotFoundPage.tsx",
         lazy: () => import("./containers/NotFoundPage/NotFoundPage"),
       },
       {
         path: "403",
+        importPath: "src/containers/AccessDeniedPage/AccessDeniedPage.tsx",
         lazy: () => import("./containers/AccessDeniedPage/AccessDeniedPage"),
       },
       {
         path: "*",
+        importPath: "src/containers/NotFoundPage/NotFoundPage.tsx",
         lazy: () => import("./containers/NotFoundPage/NotFoundPage"),
       },
       {
         path: "p/:articleId",
+        importPath: "src/containers/PlainArticlePage/PlainArticlePage.tsx",
         lazy: () => import("./containers/PlainArticlePage/PlainArticlePage"),
       },
     ],

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -10,6 +10,7 @@ import { NormalizedCacheObject } from "@apollo/client";
 import { ConfigType } from "./config";
 import { LocaleValues } from "./constants";
 import type { ManifestChunk } from "vite";
+import { RouteObject } from "react-router";
 
 export type InitialProps = {
   articleId?: string;
@@ -87,3 +88,8 @@ export interface OembedResponse {
 }
 
 export type LogLevel = "error" | "warn" | "info";
+
+export type RouteObjectWithImportPath = RouteObject & {
+  importPath?: string;
+  children?: RouteObjectWithImportPath[];
+};

--- a/src/server/render/__tests__/ltiRender-test.ts
+++ b/src/server/render/__tests__/ltiRender-test.ts
@@ -18,18 +18,21 @@ test("ltiRender 200 OK ", async () => {
     launch_presentation_height: "800",
     launch_presentation_width: "1200",
   };
-  const response = await ltiRender({
-    params: {
-      lang: "nb",
-      articleId: "26050",
-      resourceId: "urn:resource:123",
-    },
-    body,
-    method: "POST",
-    headers: {
-      "user-agent": "Mozilla/5.0 Gecko/20100101 Firefox/58.0",
-    },
-  } as any as Request);
+  const response = await ltiRender(
+    {
+      params: {
+        lang: "nb",
+        articleId: "26050",
+        resourceId: "urn:resource:123",
+      },
+      body,
+      method: "POST",
+      headers: {
+        "user-agent": "Mozilla/5.0 Gecko/20100101 Firefox/58.0",
+      },
+    } as any as Request,
+    {},
+  );
 
   expect(response.status).toBe(200);
 });
@@ -39,18 +42,21 @@ test("ltiRender 200 OK only required params", async () => {
     lti_message_type: "basic-lti-launch-request",
     lti_version: "LTI-1p0",
   };
-  const response = await ltiRender({
-    params: {
-      lang: "nb",
-      articleId: "26050",
-      resourceId: "urn:resource:123",
-    },
-    body,
-    method: "POST",
-    headers: {
-      "user-agent": "Mozilla/5.0 Gecko/20100101 Firefox/58.0",
-    },
-  } as any as Request);
+  const response = await ltiRender(
+    {
+      params: {
+        lang: "nb",
+        articleId: "26050",
+        resourceId: "urn:resource:123",
+      },
+      body,
+      method: "POST",
+      headers: {
+        "user-agent": "Mozilla/5.0 Gecko/20100101 Firefox/58.0",
+      },
+    } as any as Request,
+    {},
+  );
 
   expect(response.status).toBe(200);
 });
@@ -63,18 +69,21 @@ test("ltiRender 400 BAD REQUEST", async () => {
     launch_presentation_height: "800",
     launch_presentation_width: "1200",
   };
-  const response = await ltiRender({
-    params: {
-      lang: "nb",
-      articleId: "26050",
-      resourceId: "urn:resource:123",
-    },
-    method: "POST",
-    body,
-    headers: {
-      "user-agent": "Mozilla/5.0 Gecko/20100101 Firefox/58.0",
-    },
-  } as any as Request);
+  const response = await ltiRender(
+    {
+      params: {
+        lang: "nb",
+        articleId: "26050",
+        resourceId: "urn:resource:123",
+      },
+      method: "POST",
+      body,
+      headers: {
+        "user-agent": "Mozilla/5.0 Gecko/20100101 Firefox/58.0",
+      },
+    } as any as Request,
+    {},
+  );
 
   expect(response).toMatchSnapshot();
 });
@@ -88,18 +97,21 @@ test("ltiRender 400 BAD REQUEST wrong values", async () => {
     launch_presentation_height: "800",
     launch_presentation_width: "1200",
   };
-  const response = await ltiRender({
-    params: {
-      lang: "nb",
-      articleId: "26050",
-      resourceId: "urn:resource:123",
-    },
-    method: "POST",
-    body,
-    headers: {
-      "user-agent": "Mozilla/5.0 Gecko/20100101 Firefox/58.0",
-    },
-  } as any as Request);
+  const response = await ltiRender(
+    {
+      params: {
+        lang: "nb",
+        articleId: "26050",
+        resourceId: "urn:resource:123",
+      },
+      method: "POST",
+      body,
+      headers: {
+        "user-agent": "Mozilla/5.0 Gecko/20100101 Firefox/58.0",
+      },
+    } as any as Request,
+    {},
+  );
 
   expect(response).toMatchSnapshot();
 });

--- a/src/server/render/defaultRender.tsx
+++ b/src/server/render/defaultRender.tsx
@@ -8,7 +8,7 @@
 
 import { renderToString } from "react-dom/server";
 import { I18nextProvider } from "react-i18next";
-import { createStaticHandler, createStaticRouter, StaticRouterProvider } from "react-router";
+import { createStaticHandler, createStaticRouter, matchRoutes, StaticRouterProvider } from "react-router";
 import { ApolloProvider } from "@apollo/client";
 import { renderToStringWithData } from "@apollo/client/react/ssr";
 import { disableSSR } from "./renderHelpers";
@@ -28,11 +28,12 @@ import { LocaleType } from "../../interfaces";
 import { MOVED_PERMANENTLY, OK, TEMPORARY_REDIRECT } from "../../statusCodes";
 import { createApolloClient } from "../../util/apiHelpers";
 import { getSiteTheme } from "../../util/siteTheme";
+import { getRouteChunks } from "../getManifestChunks";
 import { initializeI18n } from "../locales/locales";
 import { createFetchRequest } from "../request";
 import { RenderFunc } from "../serverHelpers";
 
-export const defaultRender: RenderFunc = async (req, chunks) => {
+export const defaultRender: RenderFunc = async (req, manifest) => {
   const { basename, basepath, abbreviation } = getLocaleInfoFromPath(req.originalUrl);
   const locale = isValidLocale(abbreviation) ? abbreviation : (config.defaultLocale as LocaleType);
   if ((basename === "" && locale !== "nb") || (basename && basename !== locale)) {
@@ -43,6 +44,13 @@ export const defaultRender: RenderFunc = async (req, chunks) => {
   }
 
   const siteTheme = getSiteTheme();
+
+  const lazyMatches = matchRoutes(routes, req.path)?.filter((m) => m.route.lazy);
+  const chunks = getRouteChunks(
+    manifest,
+    "default",
+    (lazyMatches?.map((m) => m.route.importPath).filter((ip) => !!ip) ?? []) as string[],
+  );
 
   const versionHash = typeof req.query.versionHash === "string" ? req.query.versionHash : undefined;
   const noSSR = disableSSR(req);

--- a/src/server/render/errorRender.tsx
+++ b/src/server/render/errorRender.tsx
@@ -19,13 +19,14 @@ import { entryPoints } from "../../entrypoints";
 import { getHtmlLang, getLocaleInfoFromPath, getLocaleObject } from "../../i18n";
 import { MOVED_PERMANENTLY, OK } from "../../statusCodes";
 import { getSiteTheme } from "../../util/siteTheme";
+import { getRouteChunks } from "../getManifestChunks";
 import { initializeI18n } from "../locales/locales";
 import { createFetchRequest } from "../request";
 import { RenderFunc } from "../serverHelpers";
 
 const { query, dataRoutes } = createStaticHandler(errorRoutes);
 
-export const errorRender: RenderFunc = async (req, chunks) => {
+export const errorRender: RenderFunc = async (req, manifest) => {
   const context: RedirectInfo = {};
 
   const lang = getHtmlLang(req.params.lang ?? "");
@@ -42,6 +43,7 @@ export const errorRender: RenderFunc = async (req, chunks) => {
   }
 
   const router = createStaticRouter(dataRoutes, routerContext);
+  const chunks = getRouteChunks(manifest, "error", []);
 
   const Page = (
     <Document language={locale} chunks={chunks} devEntrypoint={entryPoints.error}>

--- a/src/server/render/iframeArticleRender.tsx
+++ b/src/server/render/iframeArticleRender.tsx
@@ -24,19 +24,21 @@ import { iframeArticleRoutes } from "../../iframe/iframeArticleRoutes";
 import { LocaleType } from "../../interfaces";
 import { MOVED_PERMANENTLY, OK } from "../../statusCodes";
 import { createApolloClient } from "../../util/apiHelpers";
+import { getRouteChunks } from "../getManifestChunks";
 import { initializeI18n } from "../locales/locales";
 import { createFetchRequest } from "../request";
 import { RenderFunc } from "../serverHelpers";
 
 const { query, dataRoutes } = createStaticHandler(iframeArticleRoutes);
 
-export const iframeArticleRender: RenderFunc = async (req, chunks) => {
+export const iframeArticleRender: RenderFunc = async (req, manifest) => {
   const lang = req.params.lang ?? "";
   const htmlLang = getHtmlLang(lang);
   const locale = isValidLocale(htmlLang) ? htmlLang : undefined;
   const { articleId, taxonomyId } = req.params;
 
   const noSSR = disableSSR(req);
+  const chunks = getRouteChunks(manifest, "iframeArticle", []);
 
   const initialProps = {
     basename: lang,

--- a/src/server/render/iframeEmbedRender.tsx
+++ b/src/server/render/iframeEmbedRender.tsx
@@ -23,19 +23,22 @@ import { iframeEmbedRoutes } from "../../iframe/embedIframeRoutes";
 import { LocaleType } from "../../interfaces";
 import { MOVED_PERMANENTLY, OK } from "../../statusCodes";
 import { createApolloClient } from "../../util/apiHelpers";
+import { getRouteChunks } from "../getManifestChunks";
 import { initializeI18n } from "../locales/locales";
 import { createFetchRequest } from "../request";
 import { RenderFunc } from "../serverHelpers";
 
 const { query, dataRoutes } = createStaticHandler(iframeEmbedRoutes);
 
-export const iframeEmbedRender: RenderFunc = async (req, chunks) => {
+export const iframeEmbedRender: RenderFunc = async (req, manifest) => {
   const lang = req.params.lang ?? "";
   const htmlLang = getHtmlLang(lang);
   const locale = isValidLocale(htmlLang) ? htmlLang : undefined;
   const { embedType, embedId } = req.params;
 
   const noSSR = disableSSR(req);
+
+  const chunks = getRouteChunks(manifest, "iframeEmbed", []);
 
   const initialProps = { basename: lang, embedType, embedId, locale };
 

--- a/src/server/render/ltiRender.tsx
+++ b/src/server/render/ltiRender.tsx
@@ -12,6 +12,7 @@ import { Document } from "../../Document";
 import { entryPoints } from "../../entrypoints";
 import { getHtmlLang, getLocaleObject } from "../../i18n";
 import { BAD_REQUEST, OK } from "../../statusCodes";
+import { getRouteChunks } from "../getManifestChunks";
 import { RenderFunc } from "../serverHelpers";
 
 const bodyFields: Record<string, { required: boolean; value?: any }> = {
@@ -54,7 +55,7 @@ export function parseAndValidateParameters(body: any) {
     : { valid: false, messages: errorMessages };
 }
 
-export const ltiRender: RenderFunc = async (req, chunks) => {
+export const ltiRender: RenderFunc = async (req, manifest) => {
   const isPostRequest = req.method === "POST";
   const validParameters = isPostRequest ? parseAndValidateParameters(req.body) : undefined;
   const lang = getHtmlLang(req.params.lang ?? "");
@@ -71,6 +72,8 @@ export const ltiRender: RenderFunc = async (req, chunks) => {
       };
     }
   }
+
+  const chunks = getRouteChunks(manifest, "lti", []);
 
   const htmlContent = renderToString(
     <Document language={locale} chunks={chunks} devEntrypoint={entryPoints.lti}>

--- a/src/server/server.render.ts
+++ b/src/server/server.render.ts
@@ -15,20 +15,20 @@ import { ltiRender } from "./render/ltiRender";
 import { RootRenderFunc } from "./serverHelpers";
 import { withCtx } from "./middleware/loggerContextMiddleware";
 
-const render: RootRenderFunc = (req: Request, _res, renderer: string, chunks, ctx) => {
+const render: RootRenderFunc = (req: Request, _res, renderer: string, manifest, ctx) => {
   return withCtx(ctx, () => {
     if (renderer === "default") {
-      return defaultRender(req, chunks);
+      return defaultRender(req, manifest);
     } else if (renderer === "lti") {
-      return ltiRender(req, chunks);
+      return ltiRender(req, manifest);
     } else if (renderer === "iframeEmbed") {
-      return iframeEmbedRender(req, chunks);
+      return iframeEmbedRender(req, manifest);
     } else if (renderer === "iframeArticle") {
-      return iframeArticleRender(req, chunks);
+      return iframeArticleRender(req, manifest);
     } else if (renderer === "error") {
-      return errorRender(req, chunks);
+      return errorRender(req, manifest);
     } else {
-      return defaultRender(req, chunks);
+      return defaultRender(req, manifest);
     }
   });
 };

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -12,7 +12,7 @@ import promBundle from "express-prom-bundle";
 import helmet from "helmet";
 import { matchPath } from "react-router";
 import serialize from "serialize-javascript";
-import { Manifest, ManifestChunk, ViteDevServer } from "vite";
+import { Manifest, ViteDevServer } from "vite";
 import { getCookie } from "@ndla/util";
 import api from "./api";
 import contentSecurityPolicy from "./contentSecurityPolicy";
@@ -24,7 +24,6 @@ import { privateRoutes, routes } from "../routes";
 import { INTERNAL_SERVER_ERROR } from "../statusCodes";
 import { isAccessTokenValid } from "../util/authHelpers";
 import handleError, { ensureError } from "../util/handleError";
-import { getRouteChunks } from "./getManifestChunks";
 import { activeRequestsMiddleware } from "./middleware/activeRequestsMiddleware";
 import { healthRouter } from "./routes/healthRouter";
 import loggerContextMiddleware, { getLoggerContextStore } from "./middleware/loggerContextMiddleware";
@@ -94,7 +93,7 @@ if (isProduction) {
   manifest = (await import(`../../build/public/.vite/manifest.json`)).default;
 }
 
-const renderRoute = async (req: Request, res: Response, renderer: string, chunks: ManifestChunk[]) => {
+const renderRoute = async (req: Request, res: Response, renderer: string, manifest: Manifest) => {
   const ctx = getLoggerContextStore();
   if (!ctx) {
     throw new Error("Logger context is not available");
@@ -114,7 +113,7 @@ const renderRoute = async (req: Request, res: Response, renderer: string, chunks
     render = (await import(`../../build/server/server.render.js`)).default;
   }
 
-  const response = await render(req, res, renderer, chunks, ctx);
+  const response = await render(req, res, renderer, manifest, ctx);
   if ("location" in response) {
     return {
       status: response.status,
@@ -150,13 +149,10 @@ const handleRequest = async (req: Request, res: Response, next: NextFunction, ro
   }
 };
 
-const defaultRoute = async (req: Request, res: Response) =>
-  renderRoute(req, res, "default", getRouteChunks(manifest, "default"));
-const ltiRoute = async (req: Request, res: Response) => renderRoute(req, res, "lti", getRouteChunks(manifest, "lti"));
-const iframeEmbedRoute = async (req: Request, res: Response) =>
-  renderRoute(req, res, "iframeEmbed", getRouteChunks(manifest, "iframeEmbed"));
-const iframeArticleRoute = async (req: Request, res: Response) =>
-  renderRoute(req, res, "iframeArticle", getRouteChunks(manifest, "iframeArticle"));
+const defaultRoute = async (req: Request, res: Response) => renderRoute(req, res, "default", manifest);
+const ltiRoute = async (req: Request, res: Response) => renderRoute(req, res, "lti", manifest);
+const iframeEmbedRoute = async (req: Request, res: Response) => renderRoute(req, res, "iframeEmbed", manifest);
+const iframeArticleRoute = async (req: Request, res: Response) => renderRoute(req, res, "iframeArticle", manifest);
 
 app.get(["/embed-iframe/:embedType/:embedId", "/embed-iframe/:lang/:embedType/:embedId"], async (req, res, next) => {
   handleRequest(req, res, next, iframeEmbedRoute);
@@ -209,8 +205,7 @@ app.get(["/", "/*splat"], (req, res, next) => {
   return handleRequest(req, res, next, defaultRoute);
 });
 
-const errorRoute = async (req: Request, res: Response) =>
-  renderRoute(req, res, "error", getRouteChunks(manifest, "error"));
+const errorRoute = async (req: Request, res: Response) => renderRoute(req, res, "error", manifest);
 
 const getStatusCodeToReturn = (err?: Error): number => {
   if (err && "status" in err && typeof err.status === "number") {

--- a/src/server/serverHelpers.ts
+++ b/src/server/serverHelpers.ts
@@ -9,7 +9,7 @@
 import { Request, Response } from "express";
 import { OK, MOVED_PERMANENTLY, TEMPORARY_REDIRECT, GONE } from "../statusCodes";
 import { LocaleType } from "../interfaces";
-import { ManifestChunk } from "vite";
+import { Manifest } from "vite";
 import { NDLAError } from "../util/error/NDLAError";
 import handleError from "../util/handleError";
 import { LoggerContext } from "../util/logger/loggerContext";
@@ -30,13 +30,13 @@ export interface RenderDataReturn {
 
 export type RenderReturn = RenderLocationReturn | RenderDataReturn;
 
-export type RenderFunc = (req: Request, chunks?: ManifestChunk[]) => Promise<RenderReturn>;
+export type RenderFunc = (req: Request, manifest: Manifest) => Promise<RenderReturn>;
 
 export type RootRenderFunc = (
   req: Request,
   res: Response,
   renderer: string,
-  chunks: ManifestChunk[],
+  manifest: Manifest,
   ctx: LoggerContext,
 ) => Promise<RenderReturn>;
 


### PR DESCRIPTION
Atter en måte å gjøre første sidelasting raskere. Med vårt gamle oppsett hentet vi alt av JS som krevdes for å rendre entrypointet vårt (client.tsx). Dette gikk helt fint før vi begynte med lazy-loading. Konsekvensen av å lazy-loade er at vi endte opp med et slags fossefall, der vi først importerer en lazy-route. Når den er hentet fra server må vi også hente alle js-avhengighetene den definerer. Dette slår alt sammen, slik at vi henter all js vi trenger på siden med en gang.