### PR TITLE
fix: cache bust translation files

### DIFF
--- a/src/Document.tsx
+++ b/src/Document.tsx
@@ -13,6 +13,7 @@ import config from "./config";
 
 interface Props {
   language: string;
+  hash: string;
   children?: ReactNode;
   chunks?: ManifestChunk[];
   devEntrypoint: string;
@@ -26,7 +27,7 @@ const getUniqueCss = (chunks: ManifestChunk[]) => {
   return Array.from(uniq);
 };
 
-export const Document = ({ language, children, chunks = [], devEntrypoint }: Props) => {
+export const Document = ({ language, hash, children, chunks = [], devEntrypoint }: Props) => {
   const faviconEnvironment = config.ndlaEnvironment === "dev" ? "test" : config.ndlaEnvironment;
   const locale = language === "nb" || language === "nn" ? "no" : language;
 
@@ -40,7 +41,7 @@ export const Document = ({ language, children, chunks = [], devEntrypoint }: Pro
         <link rel="icon" type="image/png" sizes="16x16" href={`/static/favicon-${faviconEnvironment}-16x16.png`} />
         <link
           rel="preload"
-          href={`/locales/${language}/translation.json`}
+          href={`/locales/${language}/translation-${hash}.json`}
           as="fetch"
           type="application/json"
           crossOrigin="anonymous"

--- a/src/client.tsx
+++ b/src/client.tsx
@@ -41,7 +41,7 @@ declare global {
 }
 
 const {
-  DATA: { config, serverPath, serverResponse, chunks },
+  DATA: { config, serverPath, serverResponse, chunks, hash },
 } = window;
 
 initSentry(config);
@@ -58,7 +58,7 @@ const client = createApolloClient(abbreviation, versionHash);
 
 const router = createBrowserRouter(routes, { basename: basename ? `/${basename}` : undefined });
 
-const i18nInstance = initializeI18n(abbreviation);
+const i18nInstance = initializeI18n(abbreviation, hash);
 
 renderOrHydrate(
   document,
@@ -66,6 +66,7 @@ renderOrHydrate(
     chunks={chunks}
     language={isValidLocale(abbreviation) ? abbreviation : config.defaultLocale}
     devEntrypoint={entryPoints.default}
+    hash={hash}
   >
     <I18nextProvider i18n={i18nInstance}>
       <ApolloProvider client={client}>

--- a/src/containers/ErrorPage/ErrorEntry.tsx
+++ b/src/containers/ErrorPage/ErrorEntry.tsx
@@ -18,18 +18,18 @@ import { getLocaleInfoFromPath, initializeI18n } from "../../i18n";
 import { renderOrHydrate } from "../../util/renderOrHydrate";
 import { initSentry } from "../../util/sentry";
 
-const { config, serverPath, chunks } = window.DATA;
+const { config, serverPath, chunks, hash } = window.DATA;
 
 initSentry(config);
 
 const { abbreviation } = getLocaleInfoFromPath(serverPath ?? "");
-const i18n = initializeI18n(abbreviation);
+const i18n = initializeI18n(abbreviation, hash);
 
 const router = createBrowserRouter(errorRoutes);
 
 renderOrHydrate(
   document,
-  <Document language={abbreviation} chunks={chunks} devEntrypoint={entryPoints.error}>
+  <Document language={abbreviation} chunks={chunks} devEntrypoint={entryPoints.error} hash={hash}>
     <I18nextProvider i18n={i18n}>
       <MissingRouterContext value={true}>
         <SiteThemeProvider value={window.DATA.siteTheme}>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -38,11 +38,12 @@ export const getLocaleInfoFromPath = (path: string) => {
   } as const;
 };
 
-export const initializeI18n = (locale: string): i18n => {
+export const initializeI18n = (locale: string, hash: string): i18n => {
   const i18nInstance = createInstance({
     lng: locale,
     supportedLngs: supportedLanguages,
     backend: {
+      hash,
       loadPath: "/locales/{{lng}}/{{ns}}.json",
     },
   })
@@ -62,11 +63,16 @@ class I18nBackend {
     this.services = services;
     this.options = options;
     this.allOptions = allOptions;
+    this.init(services, options, allOptions);
   }
-  init() {}
+  init(services: Services, backendOptions = {}, allOptions: InitOptions = {}) {
+    this.services = services;
+    this.options = backendOptions;
+    this.allOptions = allOptions;
+  }
 
   read(language: string, namespace: string, callback: ReadCallback) {
-    return fetch(`/locales/${language}/${namespace}.json`)
+    return fetch(`/locales/${language}/${namespace}-${this.options.hash}.json`)
       .then((res) => res.json())
       .then((data) => callback(null, data))
       .catch((err) => callback(err, false));

--- a/src/iframe/embedIframeIndex.tsx
+++ b/src/iframe/embedIframeIndex.tsx
@@ -31,20 +31,20 @@ import { createApolloClient } from "../util/apiHelpers";
 import { renderOrHydrate } from "../util/renderOrHydrate";
 import { initSentry } from "../util/sentry";
 
-const { config, initialProps, chunks } = window.DATA;
+const { config, initialProps, chunks, hash } = window.DATA;
 
 initSentry(config);
 
 const language = initialProps.locale ?? config.defaultLocale;
 
 const client = createApolloClient(language, undefined);
-const i18n = initializeI18n(language);
+const i18n = initializeI18n(language, hash);
 
 const router = createBrowserRouter(iframeEmbedRoutes);
 
 renderOrHydrate(
   document,
-  <Document language={language} chunks={chunks} devEntrypoint={entryPoints.iframeEmbed}>
+  <Document language={language} chunks={chunks} devEntrypoint={entryPoints.iframeEmbed} hash={hash}>
     <I18nextProvider i18n={i18n}>
       <ApolloProvider client={client}>
         <MissingRouterContext value={true}>

--- a/src/iframe/index.tsx
+++ b/src/iframe/index.tsx
@@ -32,20 +32,20 @@ import { createApolloClient } from "../util/apiHelpers";
 import { renderOrHydrate } from "../util/renderOrHydrate";
 import { initSentry } from "../util/sentry";
 
-const { config, initialProps, chunks } = window.DATA;
+const { config, initialProps, chunks, hash } = window.DATA;
 
 initSentry(config);
 
 const language = initialProps.locale ?? config.defaultLocale;
 
 const client = createApolloClient(language);
-const i18n = initializeI18n(language);
+const i18n = initializeI18n(language, hash);
 
 const router = createBrowserRouter(iframeArticleRoutes);
 
 renderOrHydrate(
   document,
-  <Document language={language} chunks={chunks} devEntrypoint={entryPoints.iframeArticle}>
+  <Document language={language} chunks={chunks} devEntrypoint={entryPoints.iframeArticle} hash={hash}>
     <I18nextProvider i18n={i18n}>
       <ApolloProvider client={client}>
         <AlertsProvider>

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -25,6 +25,7 @@ export interface WindowData {
   initialProps: InitialProps;
   ltiData?: LtiData;
   serverPath?: string;
+  hash: string;
   chunks?: ManifestChunk[];
   siteTheme?: SiteTheme;
   serverQuery?: {

--- a/src/lti/index.tsx
+++ b/src/lti/index.tsx
@@ -32,20 +32,20 @@ import { createApolloClient } from "../util/apiHelpers";
 import { initSentry } from "../util/sentry";
 
 const {
-  DATA: { initialProps, config, chunks },
+  DATA: { initialProps, config, chunks, hash },
 } = window;
 
 initSentry(config);
 
 const language = config.defaultLocale;
 const client = createApolloClient(language);
-const i18n = initializeI18n(language);
+const i18n = initializeI18n(language, hash);
 
 const router = createMemoryRouter(routes);
 
 const root = createRoot(document);
 root.render(
-  <Document language={language} devEntrypoint={entryPoints.lti} chunks={chunks}>
+  <Document language={language} devEntrypoint={entryPoints.lti} chunks={chunks} hash={hash}>
     <LtiContextProvider ltiData={initialProps.ltiData}>
       <I18nextProvider i18n={i18n}>
         <ApolloProvider client={client}>

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -203,13 +203,14 @@ router.post("/lti/oauth", async (req, res) => {
   res.send(JSON.stringify(generateOauthData(query.url, body)));
 });
 
-router.get("/locales/:lang/:ns.json", (req, res) => {
+router.get("/locales/:lang/:ns-:hash.json", (req, res) => {
   if (!isValidLocale(req.params.lang) || req.params.ns !== "translation") {
     res.sendStatus(BAD_REQUEST);
     return;
   }
   res.setHeader("Cache-Control", "public, max-age=3600");
-  res.json(stringifiedLanguages[req.params.lang]);
+  res.setHeader("Content-Type", "application/json");
+  res.send(stringifiedLanguages[req.params.lang].translations);
 });
 
 /** Handle different paths to a node in old ndla. */

--- a/src/server/locales/locales.ts
+++ b/src/server/locales/locales.ts
@@ -13,8 +13,8 @@ import nn from "../../messages/messagesNN";
 import se from "../../messages/messagesSE";
 import { preferredLanguages } from "../../i18n";
 import config from "../../config";
-import { LocaleType } from "../../interfaces";
 import { i18nInstanceWithTranslations } from "../../i18nInstanceWithTranslations";
+import { createHash } from "crypto";
 
 export const initializeI18n = (language: string): i18n => {
   const i18nInstance = i18nInstanceWithTranslations.cloneInstance({
@@ -31,9 +31,17 @@ export const initializeI18n = (language: string): i18n => {
 
 const backendI18nInstance = initializeI18n(config.defaultLocale);
 
-export const stringifiedLanguages: Record<LocaleType, any> = {
-  en: backendI18nInstance.getResourceBundle("en", "translation"),
-  nn: backendI18nInstance.getResourceBundle("nn", "translation"),
-  nb: backendI18nInstance.getResourceBundle("nb", "translation"),
-  se: backendI18nInstance.getResourceBundle("se", "translation"),
+const stringifyLanguage = (language: object) => {
+  const stringified = JSON.stringify(language);
+  return {
+    translations: stringified,
+    hash: createHash("md5").update(stringified).digest("hex"),
+  };
 };
+
+export const stringifiedLanguages = {
+  en: stringifyLanguage(backendI18nInstance.getResourceBundle("en", "translation")),
+  nn: stringifyLanguage(backendI18nInstance.getResourceBundle("nn", "translation")),
+  nb: stringifyLanguage(backendI18nInstance.getResourceBundle("nb", "translation")),
+  se: stringifyLanguage(backendI18nInstance.getResourceBundle("se", "translation")),
+} as const;

--- a/src/server/render/errorRender.tsx
+++ b/src/server/render/errorRender.tsx
@@ -19,7 +19,7 @@ import { entryPoints } from "../../entrypoints";
 import { getHtmlLang, getLocaleInfoFromPath } from "../../i18n";
 import { MOVED_PERMANENTLY, OK } from "../../statusCodes";
 import { getSiteTheme } from "../../util/siteTheme";
-import { initializeI18n } from "../locales/locales";
+import { initializeI18n, stringifiedLanguages } from "../locales/locales";
 import { createFetchRequest } from "../request";
 import { RenderFunc } from "../serverHelpers";
 
@@ -32,6 +32,7 @@ export const errorRender: RenderFunc = async (req, chunks) => {
   const siteTheme = getSiteTheme();
   const { abbreviation } = getLocaleInfoFromPath(req.path ?? "");
   const i18n = initializeI18n(abbreviation);
+  const hash = stringifiedLanguages[lang].hash;
 
   const fetchRequest = createFetchRequest(req);
   const routerContext = await query(fetchRequest);
@@ -43,7 +44,7 @@ export const errorRender: RenderFunc = async (req, chunks) => {
   const router = createStaticRouter(dataRoutes, routerContext);
 
   const Page = (
-    <Document language={lang} chunks={chunks} devEntrypoint={entryPoints.error}>
+    <Document language={lang} chunks={chunks} devEntrypoint={entryPoints.error} hash={hash}>
       <I18nextProvider i18n={i18n}>
         <MissingRouterContext value={true}>
           <SiteThemeProvider value={siteTheme}>
@@ -76,6 +77,7 @@ export const errorRender: RenderFunc = async (req, chunks) => {
         config: {
           ...config,
         },
+        hash,
       },
     },
   };

--- a/src/server/render/iframeArticleRender.tsx
+++ b/src/server/render/iframeArticleRender.tsx
@@ -23,7 +23,7 @@ import { iframeArticleRoutes } from "../../iframe/iframeArticleRoutes";
 import { LocaleType } from "../../interfaces";
 import { MOVED_PERMANENTLY, OK } from "../../statusCodes";
 import { createApolloClient } from "../../util/apiHelpers";
-import { initializeI18n } from "../locales/locales";
+import { initializeI18n, stringifiedLanguages } from "../locales/locales";
 import { createFetchRequest } from "../request";
 import { RenderFunc } from "../serverHelpers";
 
@@ -34,6 +34,7 @@ export const iframeArticleRender: RenderFunc = async (req, chunks) => {
   const htmlLang = getHtmlLang(lang);
   const locale = isValidLocale(htmlLang) ? htmlLang : undefined;
   const { articleId, taxonomyId } = req.params;
+  const hash = stringifiedLanguages[locale ?? (config.defaultLocale as LocaleType)].hash;
 
   const noSSR = disableSSR(req);
 
@@ -54,12 +55,14 @@ export const iframeArticleRender: RenderFunc = async (req, chunks) => {
             language={locale ?? config.defaultLocale}
             chunks={chunks}
             devEntrypoint={entryPoints.iframeArticle}
+            hash={hash}
           />,
         ),
         data: {
           chunks,
           config: { ...config, disableSSR: true },
           initialProps,
+          hash,
         },
       },
     };
@@ -79,7 +82,12 @@ export const iframeArticleRender: RenderFunc = async (req, chunks) => {
   const router = createStaticRouter(dataRoutes, routerContext);
 
   const Page = (
-    <Document language={locale ?? config.defaultLocale} chunks={chunks} devEntrypoint={entryPoints.iframeArticle}>
+    <Document
+      language={locale ?? config.defaultLocale}
+      chunks={chunks}
+      devEntrypoint={entryPoints.iframeArticle}
+      hash={hash}
+    >
       <RedirectContext value={context}>
         <I18nextProvider i18n={i18n}>
           <ApolloProvider client={client}>
@@ -118,6 +126,7 @@ export const iframeArticleRender: RenderFunc = async (req, chunks) => {
           disableSSR: noSSR,
         },
         initialProps,
+        hash,
       },
     },
   };

--- a/src/server/render/iframeEmbedRender.tsx
+++ b/src/server/render/iframeEmbedRender.tsx
@@ -22,7 +22,7 @@ import { iframeEmbedRoutes } from "../../iframe/embedIframeRoutes";
 import { LocaleType } from "../../interfaces";
 import { MOVED_PERMANENTLY, OK } from "../../statusCodes";
 import { createApolloClient } from "../../util/apiHelpers";
-import { initializeI18n } from "../locales/locales";
+import { initializeI18n, stringifiedLanguages } from "../locales/locales";
 import { createFetchRequest } from "../request";
 import { RenderFunc } from "../serverHelpers";
 
@@ -37,6 +37,7 @@ export const iframeEmbedRender: RenderFunc = async (req, chunks) => {
   const noSSR = disableSSR(req);
 
   const initialProps = { basename: lang, embedType, embedId, locale };
+  const hash = stringifiedLanguages[locale ?? (config.defaultLocale as LocaleType)].hash;
 
   if (noSSR) {
     return {
@@ -48,11 +49,13 @@ export const iframeEmbedRender: RenderFunc = async (req, chunks) => {
             language={locale ?? (config.defaultLocale as LocaleType)}
             chunks={chunks}
             devEntrypoint={entryPoints.iframeEmbed}
+            hash={hash}
           />,
         ),
         data: {
           config: { ...config, disableSSR: true },
           initialProps,
+          hash,
         },
       },
     };
@@ -72,7 +75,12 @@ export const iframeEmbedRender: RenderFunc = async (req, chunks) => {
   const router = createStaticRouter(dataRoutes, routerContext);
 
   const Page = (
-    <Document language={locale ?? config.defaultLocale} chunks={chunks} devEntrypoint={entryPoints.iframeEmbed}>
+    <Document
+      language={locale ?? config.defaultLocale}
+      chunks={chunks}
+      devEntrypoint={entryPoints.iframeEmbed}
+      hash={hash}
+    >
       <RedirectContext value={context}>
         <I18nextProvider i18n={i18n}>
           <ApolloProvider client={client}>
@@ -109,6 +117,7 @@ export const iframeEmbedRender: RenderFunc = async (req, chunks) => {
           disableSSR: noSSR,
         },
         initialProps,
+        hash,
       },
     },
   };

--- a/src/server/render/ltiRender.tsx
+++ b/src/server/render/ltiRender.tsx
@@ -12,6 +12,7 @@ import { Document } from "../../Document";
 import { entryPoints } from "../../entrypoints";
 import { getHtmlLang } from "../../i18n";
 import { BAD_REQUEST, OK } from "../../statusCodes";
+import { stringifiedLanguages } from "../locales/locales";
 import { RenderFunc } from "../serverHelpers";
 
 const bodyFields: Record<string, { required: boolean; value?: any }> = {
@@ -58,6 +59,7 @@ export const ltiRender: RenderFunc = async (req, chunks) => {
   const isPostRequest = req.method === "POST";
   const validParameters = isPostRequest ? parseAndValidateParameters(req.body) : undefined;
   const lang = getHtmlLang(req.params.lang ?? "");
+  const hash = stringifiedLanguages[lang].hash;
   if (isPostRequest) {
     if (!validParameters?.valid) {
       const messages = validParameters?.messages
@@ -72,7 +74,7 @@ export const ltiRender: RenderFunc = async (req, chunks) => {
   }
 
   const htmlContent = renderToString(
-    <Document language={lang} chunks={chunks} devEntrypoint={entryPoints.lti}>
+    <Document language={lang} chunks={chunks} devEntrypoint={entryPoints.lti} hash={hash}>
       {null}
     </Document>,
   );
@@ -89,6 +91,7 @@ export const ltiRender: RenderFunc = async (req, chunks) => {
         },
         chunks,
         config: config,
+        hash,
       },
     },
   };


### PR DESCRIPTION
Oversettelsene våre ble tidligere lagt inn i en chunk, som automatisk håndterte cache-busting for oss når chunken endret seg. Det er ikke tilfellet lenger. Hasher innholdet i oversettelses-filene, slik at vi automatisk invaliderer de i cachen når de endrer seg.