### PR TITLE
chore: lazy-load resource images

### DIFF
--- a/src/containers/Resources/ResourceItem.tsx
+++ b/src/containers/Resources/ResourceItem.tsx
@@ -203,6 +203,7 @@ export const ResourceItem = ({
         <StyledListItemImage
           src={article?.metaImage?.url ?? learningpath?.coverphoto?.url}
           alt=""
+          loading="lazy"
           sizes={`(min-width: ${breakpoints.desktop}) 150px, (max-width: ${breakpoints.tablet} ) 100px, 150px`}
           fallbackElement={<ContentTypeFallbackIcon contentType={contentType} />}
         />


### PR DESCRIPTION
Lazy-loader bildene i ressurs-listen. Ressurs-listen vises kun på klient uansett, så vi kan spare noen kb på å ikke alltid hente de ut.