### PR TITLE
fix: no type errors when linking locally

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "strictBindCallApply": true,
     "strictPropertyInitialization": true,
     "noImplicitThis": true,
+    "preserveSymlinks": true,
     "alwaysStrict": true,
 
     "noUnusedLocals": true,


### PR DESCRIPTION
Kan testes ved å linke inn frontend-packages. Skal være null typefeil