### PR TITLE
fix: display node content type if no resource types

### DIFF
--- a/src/containers/Masthead/MastheadSearch.tsx
+++ b/src/containers/Masthead/MastheadSearch.tsx
@@ -341,7 +341,7 @@ export const MastheadSearch = () => {
         const nodeType =
           result.__typename === "NodeSearchResult" ? "subject" : result.url.startsWith("/e/") ? "topic" : undefined;
         let contentType: string | undefined = nodeType;
-        if (context?.resourceTypes) {
+        if (context?.resourceTypes?.length) {
           contentType = contentTypeMapping[context?.resourceTypes?.[0]?.id ?? "default"];
         }
 

--- a/src/containers/SearchPage/SearchResult.tsx
+++ b/src/containers/SearchPage/SearchResult.tsx
@@ -89,7 +89,9 @@ export const SearchResult = ({ searchResult }: Props) => {
 
   const listItemTraits = useListItemTraits({
     relevanceId: context?.relevanceId,
-    contentType: context?.resourceTypes ? contentTypeMapping?.[context.resourceTypes[0]?.id ?? "default"] : nodeType,
+    contentType: context?.resourceTypes?.length
+      ? contentTypeMapping?.[context.resourceTypes[0]?.id ?? "default"]
+      : nodeType,
     resourceType: nodeType,
     resourceTypes: context?.resourceTypes,
     traits:


### PR DESCRIPTION
Kan se forskjellen ved å søke på "Utforskeren" i masthead f.eks