### PR TITLE
perf: apply constant folding for client and prod flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@vitejs/plugin-react": "^5.1.0",
     "babel-plugin-graphql-tag": "^3.3.0",
     "concurrently": "^9.2.1",
-    "esbuild": "^0.25.11",
+    "esbuild": "^0.27.0",
     "eslint": "^9.38.0",
     "eslint-config-ndla": "^6.0.10-alpha.0",
     "jsdom": "^27.0.1",

--- a/scripts/build-server.mjs
+++ b/scripts/build-server.mjs
@@ -22,6 +22,8 @@ await esbuild.build({
   // Vite automatically handles SSR env variables, covering most of our application.
   // However, we also need to define it here to cover the small portion of our backend that runs outside of Vite.
   define: {
+    "config.isClient": "false",
+    "config.isProduction": "true",
     "import.meta.env.SSR": "true",
   },
   // Mixing ESM and CJS is still a struggle. This is a workaround for now.

--- a/scripts/build-server.mjs
+++ b/scripts/build-server.mjs
@@ -22,8 +22,8 @@ await esbuild.build({
   // Vite automatically handles SSR env variables, covering most of our application.
   // However, we also need to define it here to cover the small portion of our backend that runs outside of Vite.
   define: {
-    "config.isClient": "false",
-    "config.isProduction": "true",
+    __IS_CLIENT__: "false",
+    __IS_PRODUCTION__: "true",
     "import.meta.env.SSR": "true",
   },
   // Mixing ESM and CJS is still a struggle. This is a workaround for now.

--- a/src/Document.tsx
+++ b/src/Document.tsx
@@ -7,6 +7,7 @@
  */
 
 import { ReactNode } from "react";
+import { IS_CLIENT, IS_PRODUCTION } from "./buildConfig";
 import { Scripts } from "./components/Scripts/Scripts";
 import config from "./config";
 import { RouteChunkInfo } from "./server/serverHelpers";
@@ -67,7 +68,7 @@ export const Document = ({ language, hash, children, chunkInfo }: Props) => {
 `,
           }}
         ></script>
-        {!config.isProduction && (
+        {!IS_PRODUCTION && (
           <>
             <script
               dangerouslySetInnerHTML={{
@@ -88,7 +89,7 @@ export const Document = ({ language, hash, children, chunkInfo }: Props) => {
           // We're hydrating the entire document. Our config differentiates between server and client, so it's necessary to suppress any hydration warnings here. TODO: Find a better workaround for this
           suppressHydrationWarning
           dangerouslySetInnerHTML={{
-            __html: config.isClient ? "" : `window.DATA = "$WINDOW_DATA"`,
+            __html: IS_CLIENT ? "" : `window.DATA = "$WINDOW_DATA"`,
           }}
         ></script>
         <Scripts />

--- a/src/Document.tsx
+++ b/src/Document.tsx
@@ -67,7 +67,7 @@ export const Document = ({ language, hash, children, chunkInfo }: Props) => {
 `,
           }}
         ></script>
-        {config.runtimeType === "development" && (
+        {!config.isProduction && (
           <>
             <script
               dangerouslySetInnerHTML={{

--- a/src/RouteErrorElement.tsx
+++ b/src/RouteErrorElement.tsx
@@ -8,7 +8,7 @@
 
 import { ReactNode } from "react";
 import { useRouteError } from "react-router";
-import config from "./config";
+import { IS_PRODUCTION } from "./buildConfig";
 import { ErrorPage } from "./containers/ErrorPage/ErrorPage";
 import { handleError } from "./util/handleError";
 
@@ -18,7 +18,7 @@ interface Props {
 
 export const ErrorElement = ({ children }: Props) => {
   const error = useRouteError();
-  if (config.isProduction) {
+  if (IS_PRODUCTION) {
     handleError(error as Error);
   }
   return children ?? <ErrorPage />;

--- a/src/RouteErrorElement.tsx
+++ b/src/RouteErrorElement.tsx
@@ -18,7 +18,7 @@ interface Props {
 
 export const ErrorElement = ({ children }: Props) => {
   const error = useRouteError();
-  if (config.runtimeType === "production") {
+  if (config.isProduction) {
     handleError(error as Error);
   }
   return children ?? <ErrorPage />;

--- a/src/buildConfig.ts
+++ b/src/buildConfig.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2025-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+declare const __IS_CLIENT__: boolean | undefined;
+declare const __IS_PRODUCTION__: boolean | undefined;
+declare const __IS_TEST__: boolean | undefined;
+
+function detectIsClient(): boolean {
+  return typeof window !== "undefined";
+}
+
+function detectIsProduction(): boolean {
+  return typeof process !== "undefined" ? process.env.NODE_ENV === "production" : false;
+}
+
+// These are the exported constants
+export const IS_CLIENT: boolean = typeof __IS_CLIENT__ !== "undefined" ? __IS_CLIENT__ : detectIsClient();
+
+export const IS_PRODUCTION: boolean =
+  typeof __IS_PRODUCTION__ !== "undefined" ? __IS_PRODUCTION__ : detectIsProduction();
+
+export const IS_TEST: boolean = typeof __IS_TEST__ !== "undefined" ? __IS_TEST__ : false;

--- a/src/config.ts
+++ b/src/config.ts
@@ -108,6 +108,7 @@ export type ConfigType = {
   isVercel: boolean;
   monsidoToken: string;
   runtimeType: RuntimeType;
+  isProduction: boolean;
   isClient: boolean;
   sentrydsn: string;
   formbricksId: string;
@@ -142,6 +143,7 @@ const getServerSideConfig = (): ConfigType => {
     isVercel: getEnvironmentVariable("IS_VERCEL", false),
     monsidoToken: getEnvironmentVariable("MONSIDO_TOKEN", ""),
     runtimeType: getEnvironmentVariable("NODE_ENV", "development") as RuntimeType,
+    isProduction: getEnvironmentVariable("NODE_ENV", "development") === "production",
     isClient: false,
     sentrydsn: getEnvironmentVariable(
       "SENTRY_DSN",

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,7 @@
  *
  */
 
-type RuntimeType = "test" | "development" | "production";
+import { IS_CLIENT, IS_TEST } from "./buildConfig";
 
 export function getEnvironmentVariable(key: string, fallback: string): string;
 export function getEnvironmentVariable(key: string, fallback: boolean): boolean;
@@ -107,9 +107,6 @@ export type ConfigType = {
   matomoTagmanagerId: string;
   isVercel: boolean;
   monsidoToken: string;
-  runtimeType: RuntimeType;
-  isProduction: boolean;
-  isClient: boolean;
   sentrydsn: string;
   formbricksId: string;
   arenaDomain: string;
@@ -142,9 +139,6 @@ const getServerSideConfig = (): ConfigType => {
     matomoTagmanagerId: getEnvironmentVariable("MATOMO_TAGMANAGER_ID", ""),
     isVercel: getEnvironmentVariable("IS_VERCEL", false),
     monsidoToken: getEnvironmentVariable("MONSIDO_TOKEN", ""),
-    runtimeType: getEnvironmentVariable("NODE_ENV", "development") as RuntimeType,
-    isProduction: getEnvironmentVariable("NODE_ENV", "development") === "production",
-    isClient: false,
     sentrydsn: getEnvironmentVariable(
       "SENTRY_DSN",
       "https://0058e1cbf3df96a365c7afefee29b665@o4508018773524480.ingest.de.sentry.io/4508018776735824",
@@ -158,12 +152,5 @@ const getServerSideConfig = (): ConfigType => {
   };
 };
 
-export function getUniversalConfig() {
-  if (typeof window === "undefined" || process.env.NODE_ENV === "test") {
-    return getServerSideConfig();
-  }
-
-  return window.DATA.config;
-}
-
-export default getUniversalConfig();
+export const config = !IS_CLIENT || IS_TEST ? getServerSideConfig() : window.DATA.config;
+export default config;

--- a/src/containers/ErrorPage/__tests__/ErrorPage-test.tsx
+++ b/src/containers/ErrorPage/__tests__/ErrorPage-test.tsx
@@ -16,7 +16,6 @@ vi.mock("../../../config.ts", () => {
   return {
     default: {
       zendeskWidgetKey: "123",
-      runtimeType: "test",
     },
   };
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,6 +30,7 @@ import { privateRoutes, routes } from "./routes";
 import { isAccessTokenValid } from "./util/authHelpers";
 import { handleError, ensureError } from "./util/handleError";
 import { NOT_FOUND_PAGE_PATH } from "./constants";
+import { IS_PRODUCTION } from "./buildConfig";
 
 const base = "/";
 
@@ -41,7 +42,7 @@ app.disable("x-powered-by");
 app.enable("trust proxy");
 
 let vite: ViteDevServer | undefined;
-if (!config.isProduction) {
+if (!IS_PRODUCTION) {
   const { createServer } = await import("vite");
   vite = await createServer({
     server: { middlewareMode: true },
@@ -91,7 +92,7 @@ app.use(healthRouter);
 
 let manifest: Manifest = {};
 
-if (config.isProduction) {
+if (IS_PRODUCTION) {
   manifest = (await import(`../build/public/.vite/manifest.json`)).default;
 }
 
@@ -101,7 +102,7 @@ const renderRoute = async (req: Request, res: Response, renderer: string, chunkI
     throw new Error("Logger context is not available");
   }
   let render: RootRenderFunc;
-  if (!config.isProduction) {
+  if (!IS_PRODUCTION) {
     try {
       render = (await vite!.ssrLoadModule(`./src/server/server.render.ts`)).default;
     } catch (e) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,7 +32,6 @@ import { handleError, ensureError } from "./util/handleError";
 import { NOT_FOUND_PAGE_PATH } from "./constants";
 
 const base = "/";
-const isProduction = config.runtimeType === "production";
 
 global.fetch = fetch;
 const app = express();
@@ -42,7 +41,7 @@ app.disable("x-powered-by");
 app.enable("trust proxy");
 
 let vite: ViteDevServer | undefined;
-if (!isProduction) {
+if (!config.isProduction) {
   const { createServer } = await import("vite");
   vite = await createServer({
     server: { middlewareMode: true },
@@ -92,7 +91,7 @@ app.use(healthRouter);
 
 let manifest: Manifest = {};
 
-if (isProduction) {
+if (config.isProduction) {
   manifest = (await import(`../build/public/.vite/manifest.json`)).default;
 }
 
@@ -102,7 +101,7 @@ const renderRoute = async (req: Request, res: Response, renderer: string, chunkI
     throw new Error("Logger context is not available");
   }
   let render: RootRenderFunc;
-  if (!isProduction) {
+  if (!config.isProduction) {
     try {
       render = (await vite!.ssrLoadModule(`./src/server/server.render.ts`)).default;
     } catch (e) {

--- a/src/server/contentSecurityPolicy.ts
+++ b/src/server/contentSecurityPolicy.ts
@@ -33,7 +33,7 @@ const connectSrc = (() => {
     "https://*.sentry.io",
     "https://app.formbricks.com",
   ];
-  if (config.runtimeType === "development") {
+  if (!config.isProduction) {
     return [
       ...defaultConnectSrc,
       "https://devtools.apollodata.com/graphql",
@@ -114,7 +114,7 @@ const scriptSrc = (() => {
     "https://js.sentry-cdn.com",
     "https://app.formbricks.com",
   ];
-  if (config.runtimeType === "development") {
+  if (!config.isProduction) {
     return [
       ...defaultScriptSrc,
       "http://localhost:3001",
@@ -211,7 +211,7 @@ const frameSrc = (() => {
     "www.norskpetroleum.no",
     "pub.dialogapi.no",
   ];
-  if (config.runtimeType === "development") {
+  if (!config.isProduction) {
     return [
       ...defaultFrameSrc,
       "http://localhost:3001",
@@ -233,7 +233,7 @@ const fontSrc = (() => {
     "cdn.jsdelivr.net",
     "*.fontshare.com",
   ];
-  if (config.runtimeType === "development") {
+  if (!config.isProduction) {
     return defaultFontSrc.concat("http://localhost:3001");
   }
   return defaultFontSrc;
@@ -243,7 +243,7 @@ export const contentSecurityPolicy = {
   directives: {
     baseUri: ["'self'", "https://tall.ndla.no"],
     defaultSrc: ["'self'", "blob:"],
-    upgradeInsecureRequests: config.runtimeType === "development" || config.ndlaEnvironment === "local" ? null : [],
+    upgradeInsecureRequests: !config.isProduction || config.ndlaEnvironment === "local" ? null : [],
     scriptSrc,
     frameSrc,
     workerSrc: ["'self'", "blob:"],

--- a/src/server/contentSecurityPolicy.ts
+++ b/src/server/contentSecurityPolicy.ts
@@ -10,6 +10,7 @@ import { IncomingMessage } from "http";
 import { matchPath } from "react-router";
 import config from "../config";
 import { embedRoutes } from "../routes";
+import { IS_PRODUCTION } from "../buildConfig";
 
 const connectSrc = (() => {
   const defaultConnectSrc = [
@@ -33,7 +34,7 @@ const connectSrc = (() => {
     "https://*.sentry.io",
     "https://app.formbricks.com",
   ];
-  if (!config.isProduction) {
+  if (!IS_PRODUCTION) {
     return [
       ...defaultConnectSrc,
       "https://devtools.apollodata.com/graphql",
@@ -114,7 +115,7 @@ const scriptSrc = (() => {
     "https://js.sentry-cdn.com",
     "https://app.formbricks.com",
   ];
-  if (!config.isProduction) {
+  if (!IS_PRODUCTION) {
     return [
       ...defaultScriptSrc,
       "http://localhost:3001",
@@ -211,7 +212,7 @@ const frameSrc = (() => {
     "www.norskpetroleum.no",
     "pub.dialogapi.no",
   ];
-  if (!config.isProduction) {
+  if (!IS_PRODUCTION) {
     return [
       ...defaultFrameSrc,
       "http://localhost:3001",
@@ -233,7 +234,7 @@ const fontSrc = (() => {
     "cdn.jsdelivr.net",
     "*.fontshare.com",
   ];
-  if (!config.isProduction) {
+  if (!IS_PRODUCTION) {
     return defaultFontSrc.concat("http://localhost:3001");
   }
   return defaultFontSrc;
@@ -243,7 +244,7 @@ export const contentSecurityPolicy = {
   directives: {
     baseUri: ["'self'", "https://tall.ndla.no"],
     defaultSrc: ["'self'", "blob:"],
-    upgradeInsecureRequests: !config.isProduction || config.ndlaEnvironment === "local" ? null : [],
+    upgradeInsecureRequests: !IS_PRODUCTION || config.ndlaEnvironment === "local" ? null : [],
     scriptSrc,
     frameSrc,
     workerSrc: ["'self'", "blob:"],

--- a/src/server/getManifestChunks.tsx
+++ b/src/server/getManifestChunks.tsx
@@ -9,7 +9,7 @@
 import type { Manifest, ManifestChunk } from "vite";
 import { entryPoints, EntryPointType } from "../entrypoints";
 import { RouteChunkInfo } from "./serverHelpers";
-import config from "../config";
+import { IS_PRODUCTION } from "../buildConfig";
 
 function getImportedChunks(manifest: Manifest, name: string): ManifestChunk[] {
   const seen = new Set<string>();
@@ -34,7 +34,7 @@ function getImportedChunks(manifest: Manifest, name: string): ManifestChunk[] {
 }
 
 export const getRouteChunkInfo = (manifest: Manifest, entryPoint: EntryPointType): RouteChunkInfo => {
-  if (!config.isProduction) {
+  if (!IS_PRODUCTION) {
     return { entryPoint: entryPoints[entryPoint] };
   }
   const mainEntry = manifest[entryPoints[entryPoint]];

--- a/src/server/getManifestChunks.tsx
+++ b/src/server/getManifestChunks.tsx
@@ -34,7 +34,7 @@ function getImportedChunks(manifest: Manifest, name: string): ManifestChunk[] {
 }
 
 export const getRouteChunkInfo = (manifest: Manifest, entryPoint: EntryPointType): RouteChunkInfo => {
-  if (config.runtimeType === "development") {
+  if (!config.isProduction) {
     return { entryPoint: entryPoints[entryPoint] };
   }
   const mainEntry = manifest[entryPoints[entryPoint]];

--- a/src/server/routes/__tests__/forwardingRoute-test.ts
+++ b/src/server/routes/__tests__/forwardingRoute-test.ts
@@ -15,7 +15,6 @@ vi.mock("../../../config", () => {
     default: {
       isNdlaProdEnvironment: true,
       getEnvironmentVariable: () => {},
-      runtimeType: "test",
     },
   };
 });

--- a/src/util/apiHelpers.ts
+++ b/src/util/apiHelpers.ts
@@ -32,8 +32,9 @@ import { StatusError } from "./error/StatusError";
 import { handleError } from "./handleError";
 import config from "../config";
 import { NOT_FOUND } from "../statusCodes";
+import { IS_CLIENT, IS_TEST } from "../buildConfig";
 
-const apiBaseUrl = config.runtimeType === "test" ? "http://ndla-api" : config.ndlaApiUrl;
+const apiBaseUrl = IS_TEST ? "http://ndla-api" : config.ndlaApiUrl;
 const uri = config.localGraphQLApi ? "http://localhost:4000/graphql-api/graphql" : `${apiBaseUrl}/graphql-api/graphql`;
 
 export function apiResourceUrl(path: string) {
@@ -123,7 +124,7 @@ const typePolicies: TypePolicies = {
 
 function getCache() {
   const cache: InMemoryCache = new InMemoryCache({ possibleTypes, typePolicies });
-  if (config.isClient) {
+  if (IS_CLIENT) {
     cache.restore(window.DATA.apolloState);
   }
 
@@ -136,7 +137,7 @@ export const createApolloClient = (language = "nb", versionHash?: any) => {
   return new ApolloClient({
     link: createApolloLinks(language, versionHash),
     cache,
-    ssrMode: !config.isClient,
+    ssrMode: typeof window !== "undefined",
     defaultOptions: {
       watchQuery: {
         errorPolicy: "all",
@@ -152,7 +153,7 @@ export const createApolloClient = (language = "nb", versionHash?: any) => {
 };
 
 export const createApolloLinks = (lang: string, versionHash?: any) => {
-  const cookieString = config.isClient ? document.cookie : "";
+  const cookieString = IS_CLIENT ? document.cookie : "";
   const feideCookie = getFeideCookie(cookieString);
   const accessTokenValid = isAccessTokenValid(feideCookie);
   const accessToken = feideCookie?.access_token;

--- a/src/util/getArticleScripts.ts
+++ b/src/util/getArticleScripts.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import config from "../config";
+import { IS_CLIENT } from "../buildConfig";
 import { GQLArticleRequiredLibrary, GQLTransformedArticleContent } from "../graphqlTypes";
 
 export interface Scripts {
@@ -28,7 +28,7 @@ export function getArticleScripts(article: BaseArticle, locale = "nb") {
       src: lib.url,
       type: lib.mediaType,
     })) || [];
-  if (article && article.transformedContent?.content.indexOf("<math") > -1 && config.isClient) {
+  if (article && article.transformedContent?.content.indexOf("<math") > -1 && IS_CLIENT) {
     if (!window.MathJax) {
       window.MathJax = {
         loader: { load: ["[mml]/mml3"] },

--- a/src/util/handleError.ts
+++ b/src/util/handleError.ts
@@ -204,7 +204,7 @@ export const ensureError = (unknownError: ErrorLike | unknown): ErrorLike => {
 };
 
 export const handleError = async (error: ErrorLike, extraContext: Record<string, unknown> = {}) => {
-  if (config.runtimeType === "production" && config.isClient) {
+  if (config.isProduction && config.isClient) {
     const ctx = await getLoggerContext();
     sendToSentry(error, ctx, extraContext);
   } else if (!config.isClient) {

--- a/src/util/handleError.ts
+++ b/src/util/handleError.ts
@@ -9,7 +9,6 @@
 import { NDLAError } from "./error/NDLAError";
 import { StatusError } from "./error/StatusError";
 import { log } from "./logger/logger";
-import config from "../config";
 import { unreachable } from "./guards";
 import { LogLevel } from "../interfaces";
 import { LoggerContext } from "./logger/loggerContext";
@@ -18,6 +17,7 @@ import { CombinedGraphQLErrors, ErrorLike } from "@apollo/client";
 import { GONE, NOT_FOUND } from "../statusCodes";
 import { GraphQLFormattedError } from "graphql";
 import { captureException, setContext } from "@sentry/react";
+import { IS_CLIENT, IS_PRODUCTION } from "../buildConfig";
 
 type UnknownError = {
   status?: number;
@@ -204,10 +204,10 @@ export const ensureError = (unknownError: ErrorLike | unknown): ErrorLike => {
 };
 
 export const handleError = async (error: ErrorLike, extraContext: Record<string, unknown> = {}) => {
-  if (config.isProduction && config.isClient) {
+  if (IS_PRODUCTION && IS_CLIENT) {
     const ctx = await getLoggerContext();
     sendToSentry(error, ctx, extraContext);
-  } else if (!config.isClient) {
+  } else if (!IS_CLIENT) {
     await logServerError(error, extraContext);
   } else {
     console.error(error); // eslint-disable-line no-console

--- a/src/util/logger/getLoggerContext.ts
+++ b/src/util/logger/getLoggerContext.ts
@@ -6,22 +6,24 @@
  *
  */
 
-import config from "../../config";
+// import { IS_CLIENT, IS_TEST } from "../../buildConfig";
 import { LoggerContext } from "./loggerContext";
 
 export const getLoggerContext = async (): Promise<LoggerContext | undefined> => {
-  if ((typeof __IS_SSR_BUILD__ === "undefined" || __IS_SSR_BUILD__) && !config.isClient) {
-    const { getLoggerContextStore } = await import("../../server/middleware/loggerContextMiddleware");
-    return getLoggerContextStore();
-  }
-
-  if (config.isClient) {
-    return {
-      requestPath: `${window.location.pathname}${window.location.search}`,
-      correlationID: undefined,
-    };
-  }
-
-  if (config.runtimeType === "test") return undefined;
-  throw new Error("LoggerContext is not available in this environment");
+  return undefined;
+  // if (!IS_CLIENT) {
+  //   const { getLoggerContextStore } = await import(
+  //     /* @vite-ignore */ "../../server/middleware/loggerContextMiddleware"
+  //   );
+  //   return getLoggerContextStore();
+  // }
+  // if (IS_CLIENT) {
+  //   return {
+  //     requestPath: `${window.location.pathname}${window.location.search}`,
+  //     correlationID: undefined,
+  //   };
+  // }
+  //
+  // if (IS_TEST) return undefined;
+  // throw new Error("LoggerContext is not available in this environment");
 };

--- a/src/util/logger/logger.ts
+++ b/src/util/logger/logger.ts
@@ -7,16 +7,16 @@
  */
 
 import type { Logger } from "winston";
-import config from "../../config";
 import { LogLevel } from "../../interfaces";
 import { getLoggerContext } from "./getLoggerContext";
 import { getErrorLog } from "../handleError";
 import { LoggerContext } from "./loggerContext";
+import { IS_CLIENT } from "../../buildConfig";
 
 let winstonLogger: Logger | undefined;
 
 // NOTE: The winston setup does not run in a browser, so lets not import it there.
-if ((typeof __IS_SSR_BUILD__ === "undefined" || __IS_SSR_BUILD__) && !config.isClient) {
+if (!IS_CLIENT) {
   import("./winston").then((w) => {
     winstonLogger = w.winstonLogger;
   });
@@ -90,7 +90,7 @@ class NDLALogger {
   private async log(level: LogLevel, message: Loggable, ...meta: Loggable[]): Promise<void> {
     const ctx = await getLoggerContext();
     const msg = await this.getMessage(message, meta, ctx);
-    if (!config.isClient && winstonLogger) {
+    if (!IS_CLIENT && winstonLogger) {
       winstonLogger[level](msg);
     } else {
       // eslint-disable-next-line no-console

--- a/src/util/logger/winston.ts
+++ b/src/util/logger/winston.ts
@@ -10,7 +10,7 @@ import "source-map-support/register";
 import pc from "picocolors";
 import type { Formatter } from "picocolors/types";
 import winston from "winston";
-import config from "../../config";
+import { IS_PRODUCTION } from "../../buildConfig";
 
 const logLevelColors: Record<string, Formatter> = {
   error: pc.red,
@@ -26,7 +26,7 @@ const indentString = (str: string): string => {
 };
 
 const getFormat = () => {
-  if (config.isProduction) {
+  if (IS_PRODUCTION) {
     return winston.format.combine(
       winston.format.timestamp(),
       winston.format.errors({ stack: true }),

--- a/src/util/logger/winston.ts
+++ b/src/util/logger/winston.ts
@@ -26,7 +26,7 @@ const indentString = (str: string): string => {
 };
 
 const getFormat = () => {
-  if (config.runtimeType === "production") {
+  if (config.isProduction) {
     return winston.format.combine(
       winston.format.timestamp(),
       winston.format.errors({ stack: true }),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -70,6 +70,7 @@ export default defineConfig(({ isSsrBuild, mode }) => {
     },
     define: {
       "globalThis.__DEV__": JSON.stringify(false),
+      "config.isClient": JSON.stringify(!isSsrBuild),
       ...(isDevelopment ? {} : { __IS_SSR_BUILD__: JSON.stringify(isSsrBuild) }),
     },
   };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,7 @@ import react from "@vitejs/plugin-react";
 export default defineConfig(({ isSsrBuild, mode }) => {
   const componentVersion = process.env.COMPONENT_VERSION ?? "SNAPSHOT";
   const isDevelopment = mode === "development";
+  const isTest = mode === "test";
   return {
     test: {
       include: ["src/**/__tests__/*-test.(js|jsx|ts|tsx)"],
@@ -51,6 +52,7 @@ export default defineConfig(({ isSsrBuild, mode }) => {
       target: "es2020",
       assetsDir: "static",
       outDir: "build/public",
+      // minify: false,
       cssCodeSplit: false,
       manifest: true,
       sourcemap: true,
@@ -70,7 +72,9 @@ export default defineConfig(({ isSsrBuild, mode }) => {
     },
     define: {
       "globalThis.__DEV__": JSON.stringify(false),
-      "config.isClient": JSON.stringify(!isSsrBuild),
+      __IS_CLIENT__: !isSsrBuild,
+      __IS_PRODUCTION__: !isDevelopment,
+      __IS_TEST__: JSON.stringify(isTest),
       ...(isDevelopment ? {} : { __IS_SSR_BUILD__: JSON.stringify(isSsrBuild) }),
     },
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1503,9 +1503,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/aix-ppc64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/aix-ppc64@npm:0.27.0"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-arm64@npm:0.25.11":
   version: 0.25.11
   resolution: "@esbuild/android-arm64@npm:0.25.11"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/android-arm64@npm:0.27.0"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -1517,9 +1531,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/android-arm@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/android-arm@npm:0.27.0"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-x64@npm:0.25.11":
   version: 0.25.11
   resolution: "@esbuild/android-x64@npm:0.25.11"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/android-x64@npm:0.27.0"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
@@ -1531,9 +1559,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/darwin-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/darwin-arm64@npm:0.27.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/darwin-x64@npm:0.25.11":
   version: 0.25.11
   resolution: "@esbuild/darwin-x64@npm:0.25.11"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/darwin-x64@npm:0.27.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -1545,9 +1587,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/freebsd-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/freebsd-arm64@npm:0.27.0"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/freebsd-x64@npm:0.25.11":
   version: 0.25.11
   resolution: "@esbuild/freebsd-x64@npm:0.25.11"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/freebsd-x64@npm:0.27.0"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -1559,9 +1615,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-arm64@npm:0.27.0"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-arm@npm:0.25.11":
   version: 0.25.11
   resolution: "@esbuild/linux-arm@npm:0.25.11"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-arm@npm:0.27.0"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -1573,9 +1643,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-ia32@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-ia32@npm:0.27.0"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-loong64@npm:0.25.11":
   version: 0.25.11
   resolution: "@esbuild/linux-loong64@npm:0.25.11"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-loong64@npm:0.27.0"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
@@ -1587,9 +1671,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-mips64el@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-mips64el@npm:0.27.0"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-ppc64@npm:0.25.11":
   version: 0.25.11
   resolution: "@esbuild/linux-ppc64@npm:0.25.11"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-ppc64@npm:0.27.0"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
@@ -1601,9 +1699,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-riscv64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-riscv64@npm:0.27.0"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-s390x@npm:0.25.11":
   version: 0.25.11
   resolution: "@esbuild/linux-s390x@npm:0.25.11"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-s390x@npm:0.27.0"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
@@ -1615,9 +1727,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-x64@npm:0.27.0"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/netbsd-arm64@npm:0.25.11":
   version: 0.25.11
   resolution: "@esbuild/netbsd-arm64@npm:0.25.11"
+  conditions: os=netbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/netbsd-arm64@npm:0.27.0"
   conditions: os=netbsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -1629,9 +1755,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/netbsd-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/netbsd-x64@npm:0.27.0"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/openbsd-arm64@npm:0.25.11":
   version: 0.25.11
   resolution: "@esbuild/openbsd-arm64@npm:0.25.11"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/openbsd-arm64@npm:0.27.0"
   conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -1643,9 +1783,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/openbsd-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/openbsd-x64@npm:0.27.0"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/openharmony-arm64@npm:0.25.11":
   version: 0.25.11
   resolution: "@esbuild/openharmony-arm64@npm:0.25.11"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openharmony-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/openharmony-arm64@npm:0.27.0"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
@@ -1657,9 +1811,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/sunos-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/sunos-x64@npm:0.27.0"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-arm64@npm:0.25.11":
   version: 0.25.11
   resolution: "@esbuild/win32-arm64@npm:0.25.11"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/win32-arm64@npm:0.27.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -1671,9 +1839,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/win32-ia32@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/win32-ia32@npm:0.27.0"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-x64@npm:0.25.11":
   version: 0.25.11
   resolution: "@esbuild/win32-x64@npm:0.25.11"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/win32-x64@npm:0.27.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -7080,7 +7262,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.25.0, esbuild@npm:^0.25.1, esbuild@npm:^0.25.11, esbuild@npm:~0.25.0":
+"esbuild@npm:^0.25.0, esbuild@npm:^0.25.1, esbuild@npm:~0.25.0":
   version: 0.25.11
   resolution: "esbuild@npm:0.25.11"
   dependencies:
@@ -7166,6 +7348,95 @@ __metadata:
   bin:
     esbuild: bin/esbuild
   checksum: 10c0/7f819b16a9f502091ddc6e1855291eaa5ede32c2b792cd8a8a60cc24faee469e3c7b607e2f22ea8684eb7c7bc377b2509e9f1cd50f10b3bf5042d1e9e4234be3
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:^0.27.0":
+  version: 0.27.0
+  resolution: "esbuild@npm:0.27.0"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.27.0"
+    "@esbuild/android-arm": "npm:0.27.0"
+    "@esbuild/android-arm64": "npm:0.27.0"
+    "@esbuild/android-x64": "npm:0.27.0"
+    "@esbuild/darwin-arm64": "npm:0.27.0"
+    "@esbuild/darwin-x64": "npm:0.27.0"
+    "@esbuild/freebsd-arm64": "npm:0.27.0"
+    "@esbuild/freebsd-x64": "npm:0.27.0"
+    "@esbuild/linux-arm": "npm:0.27.0"
+    "@esbuild/linux-arm64": "npm:0.27.0"
+    "@esbuild/linux-ia32": "npm:0.27.0"
+    "@esbuild/linux-loong64": "npm:0.27.0"
+    "@esbuild/linux-mips64el": "npm:0.27.0"
+    "@esbuild/linux-ppc64": "npm:0.27.0"
+    "@esbuild/linux-riscv64": "npm:0.27.0"
+    "@esbuild/linux-s390x": "npm:0.27.0"
+    "@esbuild/linux-x64": "npm:0.27.0"
+    "@esbuild/netbsd-arm64": "npm:0.27.0"
+    "@esbuild/netbsd-x64": "npm:0.27.0"
+    "@esbuild/openbsd-arm64": "npm:0.27.0"
+    "@esbuild/openbsd-x64": "npm:0.27.0"
+    "@esbuild/openharmony-arm64": "npm:0.27.0"
+    "@esbuild/sunos-x64": "npm:0.27.0"
+    "@esbuild/win32-arm64": "npm:0.27.0"
+    "@esbuild/win32-ia32": "npm:0.27.0"
+    "@esbuild/win32-x64": "npm:0.27.0"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-arm64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/openharmony-arm64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 10c0/a3a1deec285337b7dfe25cbb9aa8765d27a0192b610a8477a39bf5bd907a6bdb75e98898b61fb4337114cfadb13163bd95977db14e241373115f548e235b40a2
   languageName: node
   linkType: hard
 
@@ -10024,7 +10295,7 @@ __metadata:
     babel-plugin-graphql-tag: "npm:^3.3.0"
     concurrently: "npm:^9.2.1"
     cross-env: "npm:^10.1.0"
-    esbuild: "npm:^0.25.11"
+    esbuild: "npm:^0.27.0"
     eslint: "npm:^9.38.0"
     eslint-config-ndla: "npm:^6.0.10-alpha.0"
     express: "npm:5.0.0"


### PR DESCRIPTION
Erstatter `isClient` og `isProduction` med `true` eller `false` ved bygging. Dette funker ved at vite rett og slett gjør en string-replacement av `config.isClient` og `config.isProduction`. Er det tryggere å kalle flaggene `IS_CLIENT` og `IS_PRODUCTION` for å redusere sjansen for konflikter?