### PR TITLE
refactor: reduce duplicate code when tracking a page view

### DIFF
--- a/src/components/DefaultErrorMessage.tsx
+++ b/src/components/DefaultErrorMessage.tsx
@@ -15,10 +15,10 @@ import {
   ErrorMessageActions,
 } from "@ndla/primitives";
 import { SafeLink } from "@ndla/safelink";
-import { HelmetWithTracker } from "@ndla/tracker";
 import { Status } from "../components/Status";
 import { SKIP_TO_CONTENT_ID } from "../constants";
 import { PageContainer } from "./Layout/PageContainer";
+import { PageTitle } from "./PageTitle";
 
 interface MessageRootProps {
   applySkipToContentId?: boolean;
@@ -50,7 +50,7 @@ export const DefaultErrorMessagePage = () => {
   return (
     <PageContainer asChild consumeCss>
       <main>
-        <HelmetWithTracker title={t("htmlTitles.errorPage")} />
+        <PageTitle title={t("htmlTitles.errorPage")} />
         <DefaultErrorMessage applySkipToContentId={true} />
       </main>
     </PageContainer>

--- a/src/components/PageTitle.tsx
+++ b/src/components/PageTitle.tsx
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2025-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { useContext, useEffect, useRef } from "react";
+import { useHref, useLocation } from "react-router";
+import { AuthContext } from "./AuthenticationContext";
+import { log } from "../util/logger/logger";
+import { getAllDimensions } from "../util/trackingUtil";
+
+interface Props {
+  title: string;
+}
+
+/**
+ * A component for setting the page title and tracking a page view event.
+ * @param title - The title of the page. Will update the document title tag and dispatch a page view event. The component expects this title to be stable for the lifetime of the page, meaning it should not change unless the page location changes.
+ */
+export const PageTitle = ({ title }: Props) => {
+  const { user, authContextLoaded } = useContext(AuthContext);
+  const hasTracked = useRef(false);
+
+  const location = useLocation();
+  const href = useHref(location);
+
+  useEffect(() => {
+    hasTracked.current = false;
+  }, [href]);
+
+  useEffect(() => {
+    if (!authContextLoaded) return;
+    if (hasTracked.current) {
+      log.info("PageTitle: Page view already tracked, skipping duplicate tracking. This should not happen");
+      return;
+    }
+    // for debugging purposes
+    // log.info(`PageTitle: Tracking page view with title: ${title}`);
+    const dimensions = getAllDimensions({ user });
+    window._mtm?.push({
+      page_title: title,
+      event: "Pageview",
+      ...dimensions,
+    });
+    hasTracked.current = true;
+  }, [authContextLoaded, title, user]);
+
+  return <title>{title}</title>;
+};

--- a/src/containers/AboutPageV2/AboutPageLeaf.tsx
+++ b/src/containers/AboutPageV2/AboutPageLeaf.tsx
@@ -7,12 +7,11 @@
  */
 
 import { TFunction } from "i18next";
-import { useContext, useEffect, useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { gql } from "@apollo/client";
 import { AccordionRoot, Heading, Hero, HeroBackground, HeroContent, PageContent, Text } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
-import { useTracker } from "@ndla/tracker";
 import {
   ArticleContent,
   ArticleFooter,
@@ -22,9 +21,9 @@ import {
   ArticleBylineAccordionItem,
   licenseAttributes,
 } from "@ndla/ui";
-import { AuthContext } from "../../components/AuthenticationContext";
 import { LdJson } from "../../components/LdJson";
 import { LicenseBox } from "../../components/license/LicenseBox";
+import { PageTitle } from "../../components/PageTitle";
 import { SocialMediaMetadata } from "../../components/SocialMediaMetadata";
 import config from "../../config";
 import { SKIP_TO_CONTENT_ID, ABOUT_PATH } from "../../constants";
@@ -32,7 +31,6 @@ import { GQLAboutPageLeaf_ArticleFragment } from "../../graphqlTypes";
 import { Breadcrumb } from "../../interfaces";
 import { getArticleScripts } from "../../util/getArticleScripts";
 import { structuredArticleDataFragment } from "../../util/getStructuredDataFromArticle";
-import { getAllDimensions } from "../../util/trackingUtil";
 import { transformArticle } from "../../util/transformArticle";
 
 interface Props {
@@ -63,17 +61,8 @@ const StyledArticleContent = styled(ArticleContent, {
 const getDocumentTitle = (t: TFunction, title: string) => t("htmlTitles.aboutPage", { name: title });
 
 export const AboutPageLeaf = ({ article: _article, crumbs }: Props) => {
-  const { user, authContextLoaded } = useContext(AuthContext);
   const { t, i18n } = useTranslation();
-  const { trackPageView } = useTracker();
   const oembedUrl = `${config.ndlaFrontendDomain}/oembed?url=${config.ndlaFrontendDomain}/article/${_article.id}`;
-
-  useEffect(() => {
-    if (_article && authContextLoaded) {
-      const dimensions = getAllDimensions({ user });
-      trackPageView({ dimensions, title: getDocumentTitle(t, _article.title) });
-    }
-  }, [_article, authContextLoaded, t, trackPageView, user]);
 
   const [article, scripts] = useMemo(() => {
     const transformedArticle = transformArticle(_article, i18n.language, {
@@ -107,7 +96,7 @@ export const AboutPageLeaf = ({ article: _article, crumbs }: Props) => {
 
   return (
     <main>
-      <title>{`${getDocumentTitle(t, article.title)}`}</title>
+      <PageTitle title={getDocumentTitle(t, article.title)} />
       <meta name="pageid" content={`${article.id}`} />
       {scripts?.map((script) => (
         <script key={script.src} src={script.src} type={script.type} async={script.async} defer={script.defer} />

--- a/src/containers/AboutPageV2/AboutPageNode.tsx
+++ b/src/containers/AboutPageV2/AboutPageNode.tsx
@@ -8,7 +8,7 @@
 
 import parse from "html-react-parser";
 import { TFunction } from "i18next";
-import { useContext, useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { gql } from "@apollo/client";
 import {
@@ -24,7 +24,6 @@ import {
 import { SafeLink } from "@ndla/safelink";
 import { styled } from "@ndla/styled-system/jsx";
 import { linkOverlay } from "@ndla/styled-system/patterns";
-import { useTracker } from "@ndla/tracker";
 import {
   ArticleBylineAccordionItem,
   ArticleContent,
@@ -32,9 +31,9 @@ import {
   HomeBreadcrumb,
   licenseAttributes,
 } from "@ndla/ui";
-import { AuthContext } from "../../components/AuthenticationContext";
 import { LdJson } from "../../components/LdJson";
 import { LicenseBox } from "../../components/license/LicenseBox";
+import { PageTitle } from "../../components/PageTitle";
 import { SocialMediaMetadata } from "../../components/SocialMediaMetadata";
 import { TransportationPageHeader } from "../../components/TransportationPage/TransportationPageHeader";
 import { TransportationPageNodeListGrid } from "../../components/TransportationPage/TransportationPageNodeListGrid";
@@ -46,7 +45,6 @@ import { Breadcrumb } from "../../interfaces";
 import { toAbout } from "../../routeHelpers";
 import { getArticleScripts } from "../../util/getArticleScripts";
 import { structuredArticleDataFragment } from "../../util/getStructuredDataFromArticle";
-import { getAllDimensions } from "../../util/trackingUtil";
 import { transformArticle } from "../../util/transformArticle";
 
 const StyledPageContent = styled(PageContent, {
@@ -121,16 +119,7 @@ const getDocumentTitle = (t: TFunction, title: string) => t("htmlTitles.aboutPag
 
 export const AboutPageNode = ({ article, menuItems, crumbs }: Props) => {
   const { t, i18n } = useTranslation();
-  const { user, authContextLoaded } = useContext(AuthContext);
-  const { trackPageView } = useTracker();
   const oembedUrl = `${config.ndlaFrontendDomain}/oembed?url=${config.ndlaFrontendDomain}/article/${article.id}`;
-
-  useEffect(() => {
-    if (article && authContextLoaded) {
-      const dimensions = getAllDimensions({ user });
-      trackPageView({ dimensions, title: getDocumentTitle(t, article.title) });
-    }
-  }, [article, authContextLoaded, t, trackPageView, user]);
 
   const [transformedArticle, scripts] = useMemo(() => {
     const transformedArticle = transformArticle(article, i18n.language, {
@@ -150,7 +139,7 @@ export const AboutPageNode = ({ article, menuItems, crumbs }: Props) => {
 
   return (
     <main>
-      <title>{`${getDocumentTitle(t, article.title)}`}</title>
+      <PageTitle title={getDocumentTitle(t, article.title)} />
       <meta name="pageid" content={`${article.id}`} />
       {scripts?.map((script) => (
         <script key={script.src} src={script.src} type={script.type} async={script.async} defer={script.defer} />

--- a/src/containers/AccessDeniedPage/AccessDeniedPage.tsx
+++ b/src/containers/AccessDeniedPage/AccessDeniedPage.tsx
@@ -20,9 +20,9 @@ import {
 
 import { SafeLink, SafeLinkButton } from "@ndla/safelink";
 import { styled } from "@ndla/styled-system/jsx";
-import { HelmetWithTracker } from "@ndla/tracker";
 import { AuthContext } from "../../components/AuthenticationContext";
 import { PageContainer } from "../../components/Layout/PageContainer";
+import { PageTitle } from "../../components/PageTitle";
 import { Status } from "../../components/Status";
 import { SKIP_TO_CONTENT_ID } from "../../constants";
 import { toHref } from "../../util/urlHelper";
@@ -60,7 +60,7 @@ export const AccessDenied = ({ applySkipToContentId }: AccessDeniedProps) => {
   return (
     <Status code={statusCode}>
       <ErrorMessageRoot>
-        <HelmetWithTracker title={t("htmlTitles.accessDenied")} />
+        <PageTitle title={t("htmlTitles.accessDenied")} />
         <StyledPresentationLine />
         <ErrorMessageContent>
           <ErrorMessageDescription id={applySkipToContentId ? SKIP_TO_CONTENT_ID : undefined}>

--- a/src/containers/AllSubjectsPage/AllSubjectsPage.tsx
+++ b/src/containers/AllSubjectsPage/AllSubjectsPage.tsx
@@ -13,7 +13,6 @@ import { gql } from "@apollo/client";
 import { useQuery } from "@apollo/client/react";
 import { Heading } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
-import { HelmetWithTracker } from "@ndla/tracker";
 import { subjectCategories } from "@ndla/ui";
 import { groupBy, sortBy } from "@ndla/util";
 import { FavoriteSubjects } from "./FavoriteSubjects";
@@ -24,6 +23,7 @@ import { AuthContext } from "../../components/AuthenticationContext";
 import { ContentPlaceholder } from "../../components/ContentPlaceholder";
 import { DefaultErrorMessagePage } from "../../components/DefaultErrorMessage";
 import { PageContainer } from "../../components/Layout/PageContainer";
+import { PageTitle } from "../../components/PageTitle";
 import { TabFilter } from "../../components/TabFilter";
 import { SKIP_TO_CONTENT_ID } from "../../constants";
 import { GQLAllSubjectsQuery, GQLAllSubjectsQueryVariables } from "../../graphqlTypes";
@@ -141,7 +141,7 @@ export const AllSubjectsPage = () => {
   return (
     <StyledPageContainer asChild consumeCss>
       <main>
-        <HelmetWithTracker title={t("htmlTitles.subjectsPage")} />
+        <PageTitle title={t("htmlTitles.subjectsPage")} />
         <HeadingWrapper>
           <Heading textStyle="heading.medium" id={SKIP_TO_CONTENT_ID}>
             {t("subjectsPage.allSubjects")}

--- a/src/containers/CollectionPage/CollectionPage.tsx
+++ b/src/containers/CollectionPage/CollectionPage.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import { useContext, useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router";
 import { gql } from "@apollo/client";
@@ -14,19 +14,17 @@ import { useQuery } from "@apollo/client/react";
 import { ErrorWarningLine } from "@ndla/icons";
 import { Heading, Image, MessageBox } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
-import { useTracker } from "@ndla/tracker";
 import { subjectTypes } from "@ndla/ui";
 import { groupBy } from "@ndla/util";
-import { AuthContext } from "../../components/AuthenticationContext";
 import { DefaultErrorMessagePage } from "../../components/DefaultErrorMessage";
 import { PageContainer } from "../../components/Layout/PageContainer";
 import { NavigationBox } from "../../components/NavigationBox";
 import { PageSpinner } from "../../components/PageSpinner";
+import { PageTitle } from "../../components/PageTitle";
 import { SocialMediaMetadata } from "../../components/SocialMediaMetadata";
 import { COLLECTION_LANGUAGES, SKIP_TO_CONTENT_ID } from "../../constants";
 import { GQLCollectionPageQuery, GQLCollectionPageQueryVariables } from "../../graphqlTypes";
 import { htmlTitle } from "../../util/titleHelper";
-import { getAllDimensions } from "../../util/trackingUtil";
 import { NotFoundPage } from "../NotFoundPage/NotFoundPage";
 
 // TODO: We might want to reconsider this at some point. For now it'll do.
@@ -88,9 +86,7 @@ interface CollectionpageContentProps {
 }
 
 const CollectionPageContent = ({ collectionLanguage, subjects }: CollectionpageContentProps) => {
-  const { user, authContextLoaded } = useContext(AuthContext);
   const { t } = useTranslation();
-  const { trackPageView } = useTracker();
 
   const metaTitle = useMemo(
     () => t("collectionPage.title", { language: t(`languages.${collectionLanguage}`).toLowerCase() }),
@@ -114,19 +110,10 @@ const CollectionPageContent = ({ collectionLanguage, subjects }: CollectionpageC
     return Object.entries(groupBy(transformedSubjects, (d) => d.metadata.customFields.subjectType));
   }, [subjects]);
 
-  useEffect(() => {
-    if (!authContextLoaded) return;
-    const dimensions = getAllDimensions({ user });
-    trackPageView({
-      dimensions,
-      title: pageTitle,
-    });
-  }, [authContextLoaded, pageTitle, trackPageView, user]);
-
   return (
     <StyledPageContainer padding="large" asChild consumeCss>
       <main>
-        <title>{pageTitle}</title>
+        <PageTitle title={pageTitle} />
         <SocialMediaMetadata title={metaTitle} imageUrl={IMAGE_URL} />
         <div>
           {/* TODO: Use semantic tokens */}

--- a/src/containers/ErrorPage/ErrorPage.tsx
+++ b/src/containers/ErrorPage/ErrorPage.tsx
@@ -12,6 +12,7 @@ import { SafeLink } from "@ndla/safelink";
 import { styled } from "@ndla/styled-system/jsx";
 import { DefaultErrorMessage } from "../../components/DefaultErrorMessage";
 import { PageLayout } from "../../components/Layout/PageContainer";
+import { PageTitle } from "../../components/PageTitle";
 import { Status } from "../../components/Status";
 import { INTERNAL_SERVER_ERROR } from "../../statusCodes";
 import { MastheadContainer } from "../Masthead/Masthead";
@@ -27,7 +28,7 @@ export const ErrorPage = () => {
   const { t } = useTranslation();
   return (
     <Status code={INTERNAL_SERVER_ERROR}>
-      <title>{t("htmlTitles.errorPage")}</title>
+      <PageTitle title={t("htmlTitles.errorPage")} />
       <meta name="description" content={t("meta.description")} />
       <MastheadContainer>
         <SafeLink to="/" aria-label="NDLA" title="NDLA">

--- a/src/containers/ErrorPage/ForbiddenPage.tsx
+++ b/src/containers/ErrorPage/ForbiddenPage.tsx
@@ -18,8 +18,8 @@ import {
   ErrorMessageTitle,
 } from "@ndla/primitives";
 import { SafeLink } from "@ndla/safelink";
-import { HelmetWithTracker } from "@ndla/tracker";
 import { PageContainer } from "../../components/Layout/PageContainer";
+import { PageTitle } from "../../components/PageTitle";
 import { Status } from "../../components/Status";
 import { SKIP_TO_CONTENT_ID } from "../../constants";
 
@@ -36,7 +36,7 @@ export const Forbidden = ({ applySkipToContentId, navigationLink }: Props) => {
   return (
     <Status code={403}>
       <ErrorMessageRoot>
-        <HelmetWithTracker title={t("htmlTitles.forbidden")} />
+        <PageTitle title={t("htmlTitles.forbidden")} />
         <img src={"/static/not-exist.gif"} alt={t("errorMessage.title")} />
         <ErrorMessageContent>
           <ErrorMessageTitle id={applySkipToContentId ? SKIP_TO_CONTENT_ID : undefined}>

--- a/src/containers/FilmFrontpage/FilmFrontpage.tsx
+++ b/src/containers/FilmFrontpage/FilmFrontpage.tsx
@@ -29,6 +29,7 @@ import { MovieResourceType, movieResourceTypes } from "./resourceTypes";
 import { Article } from "../../components/Article/Article";
 import { PageContainer } from "../../components/Layout/PageContainer";
 import { NavigationBox } from "../../components/NavigationBox";
+import { PageTitle } from "../../components/PageTitle";
 import { SocialMediaMetadata } from "../../components/SocialMediaMetadata";
 import { FILM_ID, SKIP_TO_CONTENT_ID } from "../../constants";
 import { GQLFilmFrontPageQuery } from "../../graphqlTypes";
@@ -65,7 +66,7 @@ const StyledRadioGroupRoot = styled(RadioGroupRoot, {
   },
 });
 
-const getDocumentTitle = (t: TFunction, node: GQLFilmFrontPageQuery["node"]) =>
+const getDocumentTitle = (t: TFunction, node: NonNullable<GQLFilmFrontPageQuery["node"]>) =>
   htmlTitle(node?.name, [t("htmlTitles.titleTemplate")]);
 
 const fromNdla = {
@@ -111,7 +112,7 @@ export const FilmFrontpage = () => {
 
   return (
     <>
-      <title>{getDocumentTitle(t, node)}</title>
+      {!!node && <PageTitle title={getDocumentTitle(t, node)} />}
       <SocialMediaMetadata type="website" title={node?.name ?? ""} description={about?.description} />
       <StyledPageContainer asChild consumeCss>
         <main>

--- a/src/containers/LearningpathPage/LearningpathPage.tsx
+++ b/src/containers/LearningpathPage/LearningpathPage.tsx
@@ -7,14 +7,13 @@
  */
 
 import { TFunction } from "i18next";
-import { useContext, useEffect } from "react";
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { gql } from "@apollo/client";
-import { useTracker } from "@ndla/tracker";
-import { AuthContext } from "../../components/AuthenticationContext";
 import { DefaultErrorMessagePage } from "../../components/DefaultErrorMessage";
 import { PageLayout } from "../../components/Layout/PageContainer";
 import { Learningpath } from "../../components/Learningpath/Learningpath";
+import { PageTitle } from "../../components/PageTitle";
 import { SocialMediaMetadata } from "../../components/SocialMediaMetadata";
 import {
   GQLLearningpath,
@@ -24,19 +23,15 @@ import {
 } from "../../graphqlTypes";
 import { toBreadcrumbItems } from "../../routeHelpers";
 import { htmlTitle } from "../../util/titleHelper";
-import { getAllDimensions } from "../../util/trackingUtil";
 
 interface Props {
-  loading: boolean;
   node: GQLLearningpathPage_NodeFragment | undefined;
   skipToContentId: string;
   stepId?: string;
 }
 
-export const LearningpathPage = ({ node, skipToContentId, stepId, loading }: Props) => {
-  const { user, authContextLoaded } = useContext(AuthContext);
+export const LearningpathPage = ({ node, skipToContentId, stepId }: Props) => {
   const { t } = useTranslation();
-  const { trackPageView } = useTracker();
   useEffect(() => {
     if (window.MathJax && typeof window.MathJax.typesetPromise === "function") {
       try {
@@ -46,12 +41,6 @@ export const LearningpathPage = ({ node, skipToContentId, stepId, loading }: Pro
       }
     }
   });
-
-  useEffect(() => {
-    if (loading || !node || !authContextLoaded) return;
-    const dimensions = getAllDimensions({ user });
-    trackPageView({ dimensions, title: getDocumentTitle(t, node, stepId) });
-  }, [authContextLoaded, node, loading, stepId, t, trackPageView, user]);
 
   if (!node || !node.learningpath || !node?.learningpath?.learningsteps?.length) {
     return <DefaultErrorMessagePage />;
@@ -70,7 +59,7 @@ export const LearningpathPage = ({ node, skipToContentId, stepId, loading }: Pro
 
   return (
     <>
-      <title>{`${getDocumentTitle(t, node, stepId)}`}</title>
+      <PageTitle title={getDocumentTitle(t, node, stepId)} />
       {!node.context?.isActive && <meta name="robots" content="noindex, nofollow" />}
       <SocialMediaMetadata
         title={getTitle(root, learningpath, learningpathStep)}
@@ -102,8 +91,8 @@ const getTitle = (
   return htmlTitle(learningpath?.title, [learningpathStep?.title, root?.name]);
 };
 
-const getDocumentTitle = (t: TFunction, node: GQLLearningpathPage_NodeFragment, stepId?: string) => {
-  const subject = node?.context?.parents?.[0];
+const getDocumentTitle = (t: TFunction, node: NonNullable<GQLLearningpathPage_NodeFragment>, stepId?: string) => {
+  const subject = node.context?.parents?.[0];
   const learningpath = node?.learningpath;
   const maybeStepId = parseInt(stepId ?? "");
   const step = learningpath?.learningsteps.find((step) => step.id === maybeStepId);

--- a/src/containers/MovedResourcePage/MovedResourcePage.tsx
+++ b/src/containers/MovedResourcePage/MovedResourcePage.tsx
@@ -14,11 +14,11 @@ import { Badge, CardContent, CardHeading, CardImage, CardRoot, Heading, Text } f
 import { SafeLink } from "@ndla/safelink";
 import { styled } from "@ndla/styled-system/jsx";
 import { linkOverlay } from "@ndla/styled-system/patterns";
-import { HelmetWithTracker } from "@ndla/tracker";
 import { BadgesContainer } from "@ndla/ui";
 import { DefaultErrorMessagePage } from "../../components/DefaultErrorMessage";
 import { PageContainer } from "../../components/Layout/PageContainer";
 import { NavigationBox } from "../../components/NavigationBox";
+import { PageTitle } from "../../components/PageTitle";
 import { SKIP_TO_CONTENT_ID } from "../../constants";
 import { GQLMovedResourcePage_NodeFragment, GQLMovedResourceQuery } from "../../graphqlTypes";
 import { contentTypeMapping } from "../../util/getContentType";
@@ -93,9 +93,8 @@ export const MovedResourcePage = ({ resource }: Props) => {
 
   return (
     <PageContainer>
-      <HelmetWithTracker title={t("htmlTitles.movedResourcePage")}>
-        <meta name="robots" content="noindex" />
-      </HelmetWithTracker>
+      <PageTitle title={t("htmlTitles.movedResourcePage")} />
+      <meta name="robots" content="noindex" />
       <StyledMain>
         <StyledHeading id={SKIP_TO_CONTENT_ID} textStyle="heading.large">
           {resourceId ? t("movedResourcePage.title") : t("searchPage.searchResultListMessages.noResultHeading")}

--- a/src/containers/MyNdla/FavoriteSubjects/FavoriteSubjectsPage.tsx
+++ b/src/containers/MyNdla/FavoriteSubjects/FavoriteSubjectsPage.tsx
@@ -6,17 +6,16 @@
  *
  */
 
-import { useEffect, useContext } from "react";
+import { useContext } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
 import { ArrowRightLine } from "@ndla/icons";
 import { Skeleton } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
-import { HelmetWithTracker, useTracker } from "@ndla/tracker";
 import { AuthContext } from "../../../components/AuthenticationContext";
 import { MyNdlaTitle } from "../../../components/MyNdla/MyNdlaTitle";
+import { PageTitle } from "../../../components/PageTitle";
 import { useFavouriteSubjects } from "../../../mutations/folder/folderQueries";
-import { getAllDimensions } from "../../../util/trackingUtil";
 import { GridList } from "../../AllSubjectsPage/SubjectCategory";
 import { SubjectLink } from "../../AllSubjectsPage/SubjectLink";
 import { PrivateRoute } from "../../PrivateRoute/PrivateRoute";
@@ -54,20 +53,11 @@ export const Component = () => {
 
 export const FavoriteSubjectsPage = () => {
   const { t } = useTranslation();
-  const { user, authContextLoaded } = useContext(AuthContext);
+  const { user } = useContext(AuthContext);
   const favouriteSubjectsQuery = useFavouriteSubjects(user?.favoriteSubjects.toReversed() ?? [], {
     skip: !user?.favoriteSubjects.length,
   });
-  const { trackPageView } = useTracker();
   const navigate = useNavigate();
-
-  useEffect(() => {
-    if (!authContextLoaded) return;
-    trackPageView({
-      title: t("myNdla.favoriteSubjects.title"),
-      dimensions: getAllDimensions({ user }),
-    });
-  }, [authContextLoaded, t, trackPageView, user]);
 
   const menuItems: MenuItemProps[] = [
     {
@@ -82,7 +72,7 @@ export const FavoriteSubjectsPage = () => {
 
   return (
     <StyledMyNdlaPageWrapper menuItems={menuItems}>
-      <HelmetWithTracker title={t("myNdla.favoriteSubjects.title")} />
+      <PageTitle title={t("myNdla.favoriteSubjects.title")} />
       <MyNdlaTitle title={t("myNdla.favoriteSubjects.title")} />
       {favouriteSubjectsQuery.loading ? (
         <LoadingGrid>

--- a/src/containers/MyNdla/Folders/FoldersPage.tsx
+++ b/src/containers/MyNdla/Folders/FoldersPage.tsx
@@ -13,17 +13,16 @@ import { useQuery } from "@apollo/client/react";
 import { Heading } from "@ndla/primitives";
 import { SafeLinkButton } from "@ndla/safelink";
 import { styled } from "@ndla/styled-system/jsx";
-import { HelmetWithTracker, useTracker } from "@ndla/tracker";
 import { useFolderActions } from "./components/FolderActionHooks";
 import { FolderList } from "./components/FolderList";
 import { ResourceList } from "./components/ResourceList";
 import { AuthContext } from "../../../components/AuthenticationContext";
 import { FoldersPageTitle } from "../../../components/MyNdla/FoldersPageTitle";
+import { PageTitle } from "../../../components/PageTitle";
 import { GQLFolder, GQLFoldersPageQuery } from "../../../graphqlTypes";
 import { foldersPageQuery, useFolder } from "../../../mutations/folder/folderQueries";
 import { routes } from "../../../routeHelpers";
 import { getAllTags } from "../../../util/folderHelpers";
-import { getAllDimensions } from "../../../util/trackingUtil";
 import { PrivateRoute } from "../../PrivateRoute/PrivateRoute";
 import { MyNdlaPageWrapper } from "../components/MyNdlaPageWrapper";
 
@@ -81,8 +80,7 @@ export const Component = () => {
 export const FoldersPage = () => {
   const { t } = useTranslation();
   const { folderId } = useParams();
-  const { user, authContextLoaded, examLock } = useContext(AuthContext);
-  const { trackPageView } = useTracker();
+  const { examLock } = useContext(AuthContext);
   const { data, loading } = useQuery<GQLFoldersPageQuery>(foldersPageQuery);
   const selectedFolder = useFolder(folderId);
 
@@ -125,11 +123,6 @@ export const FoldersPage = () => {
   );
 
   useEffect(() => {
-    if (!authContextLoaded) return;
-    trackPageView({ title, dimensions: getAllDimensions({ user }) });
-  }, [authContextLoaded, title, trackPageView, user]);
-
-  useEffect(() => {
     const folderIds = folders.map((f) => f.id).sort();
     const prevFolderIds = previousFolders.map((f) => f.id).sort();
     const isEqual = folderIds.length === prevFolderIds.length && folderIds.every((v, i) => v === prevFolderIds[i]);
@@ -152,7 +145,7 @@ export const FoldersPage = () => {
 
   return (
     <StyledMyNdlaPageWrapper menuItems={menuItems} showButtons={!examLock || !!selectedFolder}>
-      <HelmetWithTracker title={title} />
+      <PageTitle title={title} />
       <FoldersPageTitle key={selectedFolder?.id} loading={loading} selectedFolder={selectedFolder} />
       {!!selectedFolder && (
         <p>

--- a/src/containers/MyNdla/Folders/FoldersTagPage.tsx
+++ b/src/containers/MyNdla/Folders/FoldersTagPage.tsx
@@ -11,7 +11,6 @@ import { useTranslation } from "react-i18next";
 import { useParams, useNavigate } from "react-router";
 import { FolderLine, LinkMedium } from "@ndla/icons";
 import { styled } from "@ndla/styled-system/jsx";
-import { HelmetWithTracker, useTracker } from "@ndla/tracker";
 import { keyBy, usePrevious } from "@ndla/util";
 import { AuthContext } from "../../../components/AuthenticationContext";
 import { AddResourceToFolderModalContent } from "../../../components/MyNdla/AddResourceToFolderModal";
@@ -20,13 +19,13 @@ import { ListResource } from "../../../components/MyNdla/ListResource";
 import { MyNdlaBreadcrumb } from "../../../components/MyNdla/MyNdlaBreadcrumb";
 import { MyNdlaTitle, TitleWrapper } from "../../../components/MyNdla/MyNdlaTitle";
 import { PageSpinner } from "../../../components/PageSpinner";
+import { PageTitle } from "../../../components/PageTitle";
 import { useToast } from "../../../components/ToastContext";
 import config from "../../../config";
 import { GQLFolderResource } from "../../../graphqlTypes";
 import { useFolders, useFolderResourceMetaSearch } from "../../../mutations/folder/folderQueries";
 import { routes } from "../../../routeHelpers";
 import { getAllTags, getResourcesForTag } from "../../../util/folderHelpers";
-import { getAllDimensions } from "../../../util/trackingUtil";
 import { NotFoundPage } from "../../NotFoundPage/NotFoundPage";
 import { PrivateRoute } from "../../PrivateRoute/PrivateRoute";
 import { MyNdlaPageWrapper } from "../components/MyNdlaPageWrapper";
@@ -43,8 +42,6 @@ export const Component = () => {
 };
 
 export const FoldersTagsPage = () => {
-  const { user, authContextLoaded } = useContext(AuthContext);
-  const { trackPageView } = useTracker();
   const { folders, loading } = useFolders();
   const { tag } = useParams();
   const { t } = useTranslation();
@@ -53,11 +50,6 @@ export const FoldersTagsPage = () => {
   const resources = useMemo(() => (tag ? getResourcesForTag(folders, tag) : []), [tag, folders]);
   const previousResources = usePrevious(resources);
   const navigate = useNavigate();
-
-  useEffect(() => {
-    if (!authContextLoaded) return;
-    trackPageView({ title: title, dimensions: getAllDimensions({ user }) });
-  }, [authContextLoaded, title, trackPageView, user]);
 
   useEffect(() => {
     if (tag && !!previousResources?.length && resources.length === 0) {
@@ -75,7 +67,7 @@ export const FoldersTagsPage = () => {
 
   return (
     <StyledMyNdlaPageWrapper>
-      <HelmetWithTracker title={title} />
+      <PageTitle title={title} />
       <TitleWrapper>
         <MyNdlaBreadcrumb page="folders" breadcrumbs={tag ? [{ name: tag, id: tag }] : []} />
         <MyNdlaTitle title={`#${tag}`} />

--- a/src/containers/MyNdla/Learningpath/EditLearningpathStepsPage.tsx
+++ b/src/containers/MyNdla/Learningpath/EditLearningpathStepsPage.tsx
@@ -6,19 +6,16 @@
  *
  */
 
-import { useContext, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { Navigate, useParams } from "react-router";
 import { Heading, Spinner } from "@ndla/primitives";
-import { HelmetWithTracker, useTracker } from "@ndla/tracker";
 import { LearningpathStepper } from "./components/LearningpathStepper";
 import { EditLearningpathStepsPageContent } from "./EditLearningpathStepsPageContent";
 import { useFetchLearningpath } from "./learningpathQueries";
-import { AuthContext } from "../../../components/AuthenticationContext";
 import { MyNdlaBreadcrumb } from "../../../components/MyNdla/MyNdlaBreadcrumb";
+import { PageTitle } from "../../../components/PageTitle";
 import { SKIP_TO_CONTENT_ID } from "../../../constants";
 import { routes } from "../../../routeHelpers";
-import { getAllDimensions } from "../../../util/trackingUtil";
 import { NotFoundPage } from "../../NotFoundPage/NotFoundPage";
 import { PrivateRoute } from "../../PrivateRoute/PrivateRoute";
 import { MyNdlaPageWrapper } from "../components/MyNdlaPageWrapper";
@@ -29,21 +26,12 @@ export const Component = () => {
 
 export const EditLearningpathStepsPage = () => {
   const { t } = useTranslation();
-  const { trackPageView } = useTracker();
   const { learningpathId } = useParams();
-  const { user } = useContext(AuthContext);
 
   const { data, loading } = useFetchLearningpath({
     variables: { pathId: learningpathId ?? "-1" },
     skip: !learningpathId,
   });
-
-  useEffect(() => {
-    trackPageView({
-      title: t("htmlTitles.learningpathEditStepsPage", { name: data?.myNdlaLearningpath?.title }),
-      dimensions: getAllDimensions({ user }),
-    });
-  }, [data?.myNdlaLearningpath?.title, t, trackPageView, user]);
 
   if (loading) {
     return <Spinner aria-label={t("loading")} />;
@@ -59,7 +47,7 @@ export const EditLearningpathStepsPage = () => {
 
   return (
     <MyNdlaPageWrapper type="learningpath">
-      <HelmetWithTracker title={t("htmlTitles.learningpathEditStepsPage", { name: data?.myNdlaLearningpath?.title })} />
+      <PageTitle title={t("htmlTitles.learningpathEditStepsPage", { name: data.myNdlaLearningpath.title })} />
       <MyNdlaBreadcrumb
         breadcrumbs={[{ id: "0", name: `${t("myNdla.learningpath.editLearningpath")}` }]}
         page="learningpath"

--- a/src/containers/MyNdla/Learningpath/EditLearningpathTitlePage.tsx
+++ b/src/containers/MyNdla/Learningpath/EditLearningpathTitlePage.tsx
@@ -6,23 +6,20 @@
  *
  */
 
-import { useContext, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { Navigate, useNavigate, useParams } from "react-router";
 import { Spinner, Heading, Button } from "@ndla/primitives";
 import { Stack } from "@ndla/styled-system/jsx";
-import { useTracker, HelmetWithTracker } from "@ndla/tracker";
 import { LearningpathStepper } from "./components/LearningpathStepper";
 import { TitleFormValues, TitleForm } from "./components/TitleForm";
 import { useFetchLearningpath } from "./learningpathQueries";
-import { AuthContext } from "../../../components/AuthenticationContext";
 import { MyNdlaBreadcrumb } from "../../../components/MyNdla/MyNdlaBreadcrumb";
+import { PageTitle } from "../../../components/PageTitle";
 import { deserializeToRichText, serializeFromRichText } from "../../../components/RichTextEditor/richTextSerialization";
 import config from "../../../config";
 import { SKIP_TO_CONTENT_ID } from "../../../constants";
 import { useUpdateLearningpath } from "../../../mutations/learningpathMutations";
 import { routes } from "../../../routeHelpers";
-import { getAllDimensions } from "../../../util/trackingUtil";
 import { NotFoundPage } from "../../NotFoundPage/NotFoundPage";
 import { PrivateRoute } from "../../PrivateRoute/PrivateRoute";
 import { MyNdlaPageWrapper } from "../components/MyNdlaPageWrapper";
@@ -35,22 +32,13 @@ export const EditLearningpathTitlePage = () => {
   const [updatePath] = useUpdateLearningpath();
 
   const { t } = useTranslation();
-  const { trackPageView } = useTracker();
   const { learningpathId } = useParams();
-  const { user } = useContext(AuthContext);
 
   const navigate = useNavigate();
   const { data, loading } = useFetchLearningpath({
     variables: { pathId: learningpathId ?? "-1" },
     skip: !learningpathId,
   });
-
-  useEffect(() => {
-    trackPageView({
-      title: t("htmlTitles.learningpathEditTitlePage", { name: data?.myNdlaLearningpath?.title }),
-      dimensions: getAllDimensions({ user }),
-    });
-  }, [data?.myNdlaLearningpath?.title, t, trackPageView, user]);
 
   const onSaveTitle = async ({ title, imageUrl, introduction: formIntroduction }: TitleFormValues) => {
     const learningpath = data?.myNdlaLearningpath;
@@ -93,7 +81,7 @@ export const EditLearningpathTitlePage = () => {
 
   return (
     <MyNdlaPageWrapper type="learningpath">
-      <HelmetWithTracker title={t("htmlTitles.learningpathEditTitlePage", { name: data?.myNdlaLearningpath?.title })} />
+      <PageTitle title={t("htmlTitles.learningpathEditTitlePage", { name: data.myNdlaLearningpath.title })} />
       <MyNdlaBreadcrumb
         breadcrumbs={[{ id: "0", name: `${t("myNdla.learningpath.editLearningpathTitle")}` }]}
         page="learningpath"

--- a/src/containers/MyNdla/Learningpath/LearningpathPage.tsx
+++ b/src/containers/MyNdla/Learningpath/LearningpathPage.tsx
@@ -6,15 +6,12 @@
  *
  */
 
-import { useContext, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { Heading, Text } from "@ndla/primitives";
-import { HelmetWithTracker, useTracker } from "@ndla/tracker";
 import { useLearningpathActionHooks } from "./components/LearningpathActionHooks";
 import { LearningpathList } from "./components/LearningpathList";
-import { AuthContext } from "../../../components/AuthenticationContext";
+import { PageTitle } from "../../../components/PageTitle";
 import { SKIP_TO_CONTENT_ID } from "../../../constants";
-import { getAllDimensions } from "../../../util/trackingUtil";
 import { PrivateRoute } from "../../PrivateRoute/PrivateRoute";
 import { MyNdlaPageWrapper } from "../components/MyNdlaPageWrapper";
 
@@ -24,17 +21,11 @@ export const Component = () => {
 
 export const LearningpathPage = () => {
   const { t } = useTranslation();
-  const { trackPageView } = useTracker();
-  const { user } = useContext(AuthContext);
   const menuItems = useLearningpathActionHooks();
-
-  useEffect(() => {
-    trackPageView({ title: t("htmlTitles.learningpathsPage"), dimensions: getAllDimensions({ user }) });
-  }, [t, trackPageView, user]);
 
   return (
     <MyNdlaPageWrapper menuItems={menuItems} type="learningpath">
-      <HelmetWithTracker title={t("htmlTitles.learningpathsPage")} />
+      <PageTitle title={t("htmlTitles.learningpathsPage")} />
       <Heading id={SKIP_TO_CONTENT_ID} textStyle="heading.medium">
         {t("myNdla.learningpath.title")}
       </Heading>

--- a/src/containers/MyNdla/Learningpath/NewLearningpathPage.tsx
+++ b/src/containers/MyNdla/Learningpath/NewLearningpathPage.tsx
@@ -6,22 +6,21 @@
  *
  */
 
-import { useContext, useEffect } from "react";
+import { useContext } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
 import { licenses } from "@ndla/licenses";
 import { Heading } from "@ndla/primitives";
-import { HelmetWithTracker, useTracker } from "@ndla/tracker";
 import { LearningpathStepper } from "./components/LearningpathStepper";
 import { TitleForm, TitleFormValues } from "./components/TitleForm";
 import { AuthContext } from "../../../components/AuthenticationContext";
 import { MyNdlaBreadcrumb } from "../../../components/MyNdla/MyNdlaBreadcrumb";
+import { PageTitle } from "../../../components/PageTitle";
 import { serializeFromRichText } from "../../../components/RichTextEditor/richTextSerialization";
 import { useToast } from "../../../components/ToastContext";
 import { SKIP_TO_CONTENT_ID } from "../../../constants";
 import { useCreateLearningpath } from "../../../mutations/learningpathMutations";
 import { routes } from "../../../routeHelpers";
-import { getAllDimensions } from "../../../util/trackingUtil";
 import { PrivateRoute } from "../../PrivateRoute/PrivateRoute";
 import { MyNdlaPageWrapper } from "../components/MyNdlaPageWrapper";
 
@@ -31,16 +30,11 @@ export const Component = () => {
 
 export const NewLearningpathPage = () => {
   const { t, i18n } = useTranslation();
-  const { trackPageView } = useTracker();
   const { user } = useContext(AuthContext);
 
   const toast = useToast();
   const { createLearningpath } = useCreateLearningpath();
   const navigate = useNavigate();
-
-  useEffect(() => {
-    trackPageView({ title: t("htmlTitles.learningpathNewPage"), dimensions: getAllDimensions({ user }) });
-  }, [t, trackPageView, user]);
 
   const onSave = async ({ title, imageUrl, introduction }: TitleFormValues) => {
     if (!user) {
@@ -72,7 +66,7 @@ export const NewLearningpathPage = () => {
 
   return (
     <MyNdlaPageWrapper type="learningpath">
-      <HelmetWithTracker title={t("htmlTitles.learningpathNewPage")} />
+      <PageTitle title={t("htmlTitles.learningpathNewPage")} />
       <MyNdlaBreadcrumb
         breadcrumbs={[{ id: "newLearningpath", name: t("myNdla.learningpath.newLearningpath") }]}
         page="learningpath"

--- a/src/containers/MyNdla/Learningpath/PreviewLearningpathPage.tsx
+++ b/src/containers/MyNdla/Learningpath/PreviewLearningpathPage.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import { useContext, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router";
 import { gql } from "@apollo/client";
@@ -14,20 +13,18 @@ import { useQuery } from "@apollo/client/react";
 import { Heading, Text } from "@ndla/primitives";
 import { SafeLinkButton } from "@ndla/safelink";
 import { styled } from "@ndla/styled-system/jsx";
-import { useTracker } from "@ndla/tracker";
 import { LearningpathFormButtonContainer } from "./LearningpathFormButtonContainer";
-import { AuthContext } from "../../../components/AuthenticationContext";
 import { DefaultErrorMessagePage } from "../../../components/DefaultErrorMessage";
 import { Learningpath } from "../../../components/Learningpath/Learningpath";
 import { MyNdlaBreadcrumb } from "../../../components/MyNdla/MyNdlaBreadcrumb";
 import { PageSpinner } from "../../../components/PageSpinner";
+import { PageTitle } from "../../../components/PageTitle";
 import { SKIP_TO_CONTENT_ID } from "../../../constants";
 import { routes } from "../../../routeHelpers";
 import { NotFoundPage } from "../../NotFoundPage/NotFoundPage";
 import { MyNdlaPageWrapper } from "../components/MyNdlaPageWrapper";
 import { LearningpathStepper } from "./components/LearningpathStepper";
 import { GQLPreviewLearningpathQuery, GQLPreviewLearningpathQueryVariables } from "../../../graphqlTypes";
-import { getAllDimensions } from "../../../util/trackingUtil";
 import { PrivateRoute } from "../../PrivateRoute/PrivateRoute";
 
 const TextWrapper = styled("div", {
@@ -60,8 +57,6 @@ export const Component = () => {
 export const PreviewLearningpathPage = () => {
   const { t } = useTranslation();
   const { learningpathId, stepId } = useParams();
-  const { user } = useContext(AuthContext);
-  const { trackPageView } = useTracker();
 
   const learningpathQuery = useQuery<GQLPreviewLearningpathQuery, GQLPreviewLearningpathQueryVariables>(
     previewLearningpathQuery,
@@ -71,14 +66,6 @@ export const PreviewLearningpathPage = () => {
       fetchPolicy: "network-only",
     },
   );
-
-  useEffect(() => {
-    if (!learningpathQuery.data?.learningpath?.title) return;
-    trackPageView({
-      title: t("htmlTitles.learningpathSavePage", { name: learningpathQuery.data.learningpath.title }),
-      dimensions: getAllDimensions({ user }),
-    });
-  }, [learningpathQuery.data?.learningpath?.title, t, trackPageView, user]);
 
   if (learningpathQuery.loading) {
     return <PageSpinner />;
@@ -107,7 +94,7 @@ export const PreviewLearningpathPage = () => {
 
   return (
     <MyNdlaPageWrapper>
-      <title>{t("htmlTitles.learningpathPreviewPage", { name: learningpath.title })}</title>
+      <PageTitle title={t("htmlTitles.learningpathPreviewPage", { name: learningpath.title })} />
       <MyNdlaBreadcrumb
         breadcrumbs={[
           { id: `preview-${learningpath.id}`, name: t("myNdla.learningpath.previewLearningpath.pageHeading") },

--- a/src/containers/MyNdla/Learningpath/SaveLearningpathPage.tsx
+++ b/src/containers/MyNdla/Learningpath/SaveLearningpathPage.tsx
@@ -6,29 +6,27 @@
  *
  */
 
-import { MouseEvent, useContext, useEffect, useRef, useState } from "react";
+import { MouseEvent, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router";
 import { Button, DialogRoot, Heading, Text } from "@ndla/primitives";
 import { SafeLinkButton } from "@ndla/safelink";
 import { styled } from "@ndla/styled-system/jsx";
-import { useTracker } from "@ndla/tracker";
 import { LearningpathItem } from "./components/LearningpathItem";
 import { LearningpathShareDialogContent } from "./components/LearningpathShareDialogContent";
 import { LearningpathStepper } from "./components/LearningpathStepper";
 import { LearningpathFormButtonContainer } from "./LearningpathFormButtonContainer";
 import { useFetchLearningpath } from "./learningpathQueries";
 import { LEARNINGPATH_READY_FOR_SHARING, LEARNINGPATH_SHARED } from "./utils";
-import { AuthContext } from "../../../components/AuthenticationContext";
 import { DefaultErrorMessagePage } from "../../../components/DefaultErrorMessage";
 import { MyNdlaBreadcrumb } from "../../../components/MyNdla/MyNdlaBreadcrumb";
 import { PageSpinner } from "../../../components/PageSpinner";
 import { useToast } from "../../../components/ToastContext";
 import { SKIP_TO_CONTENT_ID } from "../../../constants";
 import { routes } from "../../../routeHelpers";
-import { getAllDimensions } from "../../../util/trackingUtil";
 import { MyNdlaPageWrapper } from "../components/MyNdlaPageWrapper";
 import { LearningpathShareLink } from "./components/LearningpathShareLink";
+import { PageTitle } from "../../../components/PageTitle";
 import { useUpdateLearningpathStatus } from "../../../mutations/learningpathMutations";
 import { NotFoundPage } from "../../NotFoundPage/NotFoundPage";
 import { PrivateRoute } from "../../PrivateRoute/PrivateRoute";
@@ -56,22 +54,13 @@ export const SaveLearningpathPage = () => {
   const [open, setOpen] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const { t } = useTranslation();
-  const { trackPageView } = useTracker();
   const { learningpathId } = useParams();
-  const { user } = useContext(AuthContext);
   const toast = useToast();
   const learningpathQuery = useFetchLearningpath({
     variables: { pathId: learningpathId ?? "" },
     skip: !learningpathId,
   });
   const [updateLearningpathStatus] = useUpdateLearningpathStatus();
-
-  useEffect(() => {
-    trackPageView({
-      title: t("htmlTitles.learningpathSavePage", { name: learningpathQuery.data?.myNdlaLearningpath?.title }),
-      dimensions: getAllDimensions({ user }),
-    });
-  }, [learningpathQuery.data?.myNdlaLearningpath?.title, t, trackPageView, user]);
 
   const onUnshare = async (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
@@ -127,7 +116,7 @@ export const SaveLearningpathPage = () => {
 
   return (
     <MyNdlaPageWrapper type="learningpath">
-      <title>{t("htmlTitles.learningpathSavePage", { name: learningpath?.title })}</title>
+      <PageTitle title={t("htmlTitles.learningpathSavePage", { name: learningpath.title })} />
       <MyNdlaBreadcrumb
         breadcrumbs={[{ id: `save-${learningpath.id}`, name: t("myNdla.learningpath.form.steps.save") }]}
         page="learningpath"

--- a/src/containers/MyNdla/MyNdlaPage.tsx
+++ b/src/containers/MyNdla/MyNdlaPage.tsx
@@ -6,19 +6,19 @@
  *
  */
 
-import { useContext, useEffect } from "react";
+import { useContext } from "react";
 import { useTranslation } from "react-i18next";
 import { Feide, ArrowRightLine } from "@ndla/icons";
 import { Button, DialogRoot, DialogTrigger, Heading, Text } from "@ndla/primitives";
 import { SafeLink } from "@ndla/safelink";
 import { styled } from "@ndla/styled-system/jsx";
-import { HelmetWithTracker, useTracker } from "@ndla/tracker";
 import { keyBy } from "@ndla/util";
 import { MyNdlaPageWrapper } from "./components/MyNdlaPageWrapper";
 import { AuthContext } from "../../components/AuthenticationContext";
 import { ListResource } from "../../components/MyNdla/ListResource";
 import { LoginModalContent } from "../../components/MyNdla/LoginModalContent";
 import { MyNdlaTitle, TitleWrapper } from "../../components/MyNdla/MyNdlaTitle";
+import { PageTitle } from "../../components/PageTitle";
 import { SocialMediaMetadata } from "../../components/SocialMediaMetadata";
 import config from "../../config";
 import { myndlaLanguages } from "../../i18n";
@@ -28,7 +28,6 @@ import {
   useRecentlyUsedResources,
 } from "../../mutations/folder/folderQueries";
 import { routes } from "../../routeHelpers";
-import { getAllDimensions } from "../../util/trackingUtil";
 import { GridList } from "../AllSubjectsPage/SubjectCategory";
 import { SubjectLink } from "../AllSubjectsPage/SubjectLink";
 
@@ -68,9 +67,8 @@ const StyledArrowRightLine = styled(ArrowRightLine, {
 });
 
 export const MyNdlaPage = () => {
-  const { user, authContextLoaded, authenticated } = useContext(AuthContext);
+  const { user, authenticated } = useContext(AuthContext);
   const { t } = useTranslation();
-  const { trackPageView } = useTracker();
   const recentFavouriteSubjectsQuery = useFavouriteSubjects(user?.favoriteSubjects?.toReversed().slice(0, 4) ?? [], {
     skip: !user?.favoriteSubjects.length,
   });
@@ -86,21 +84,13 @@ export const MyNdlaPage = () => {
     },
   );
 
-  useEffect(() => {
-    if (!authContextLoaded) return;
-    trackPageView({
-      title: t("htmlTitles.myNdlaPage"),
-      dimensions: getAllDimensions({ user }),
-    });
-  }, [authContextLoaded, t, trackPageView, user]);
-
   const keyedData = keyBy(metaData ?? [], (r) => `${r.type}${r.id}`);
 
   // const aiLang = i18n.language === "nn" ? "" : ""; // TODO: Readd nn when Jan says so
 
   return (
     <StyledMyNdlaPageWrapper>
-      <HelmetWithTracker title={t("htmlTitles.myNdlaPage")} />
+      <PageTitle title={t("htmlTitles.myNdlaPage")} />
       <SocialMediaMetadata
         title={t("myNdla.myNDLA")}
         description={t("myNdla.description")}

--- a/src/containers/MyNdla/MyProfile/MyProfilePage.tsx
+++ b/src/containers/MyNdla/MyProfile/MyProfilePage.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import { useContext, useEffect } from "react";
+import { useContext } from "react";
 import { useTranslation } from "react-i18next";
 import { useHref } from "react-router";
 import { DeleteBinLine } from "@ndla/icons";
@@ -25,12 +25,11 @@ import {
 } from "@ndla/primitives";
 import { SafeLink } from "@ndla/safelink";
 import { Stack, styled } from "@ndla/styled-system/jsx";
-import { HelmetWithTracker, useTracker } from "@ndla/tracker";
 import { AuthContext } from "../../../components/AuthenticationContext";
 import { DialogCloseButton } from "../../../components/DialogCloseButton";
 import { MyNdlaTitle } from "../../../components/MyNdla/MyNdlaTitle";
+import { PageTitle } from "../../../components/PageTitle";
 import { useDeletePersonalData } from "../../../mutations/userMutations";
-import { getAllDimensions } from "../../../util/trackingUtil";
 import { PrivateRoute } from "../../PrivateRoute/PrivateRoute";
 import { MyContactArea } from "../components/MyContactArea";
 import { MyNdlaPageWrapper } from "../components/MyNdlaPageWrapper";
@@ -76,16 +75,8 @@ export const Component = () => {
 export const MyProfilePage = () => {
   const { user } = useContext(AuthContext);
   const { t } = useTranslation();
-  const { trackPageView } = useTracker();
   const { deletePersonalData } = useDeletePersonalData();
   const logoutPath = useHref("/logout?state=/");
-
-  useEffect(() => {
-    trackPageView({
-      title: t("htmlTitles.myProfile"),
-      dimensions: getAllDimensions({ user }),
-    });
-  }, [t, trackPageView, user]);
 
   const onDeleteAccount = async () => {
     await deletePersonalData();
@@ -94,7 +85,7 @@ export const MyProfilePage = () => {
 
   return (
     <StyledMyNdlaPageWrapper>
-      <HelmetWithTracker title={t("myNdla.myProfile.title")} />
+      <PageTitle title={t("myNdla.myProfile.title")} />
       <MyNdlaTitle title={t("myNdla.myProfile.title")} />
       <MyContactArea
         user={{

--- a/src/containers/NotFoundPage/NotFoundPage.tsx
+++ b/src/containers/NotFoundPage/NotFoundPage.tsx
@@ -15,8 +15,8 @@ import {
   ErrorMessageActions,
 } from "@ndla/primitives";
 import { SafeLink } from "@ndla/safelink";
-import { HelmetWithTracker } from "@ndla/tracker";
 import { PageContainer } from "../../components/Layout/PageContainer";
+import { PageTitle } from "../../components/PageTitle";
 import { Status } from "../../components/Status";
 import { SKIP_TO_CONTENT_ID } from "../../constants";
 
@@ -29,7 +29,7 @@ const NotFound = ({ applySkipToContentId }: NotFoundProps) => {
   return (
     <Status code={404}>
       <ErrorMessageRoot>
-        <HelmetWithTracker title={t("htmlTitles.notFound")} />
+        <PageTitle title={t("htmlTitles.notFound")} />
         <img src={"/static/not-exist.gif"} alt={t("errorMessage.title")} />
         <ErrorMessageContent>
           <ErrorMessageTitle id={applySkipToContentId ? SKIP_TO_CONTENT_ID : undefined}>

--- a/src/containers/PlainArticlePage/PlainArticleContainer.tsx
+++ b/src/containers/PlainArticlePage/PlainArticleContainer.tsx
@@ -7,21 +7,19 @@
  */
 
 import { TFunction } from "i18next";
-import { useContext, useEffect, useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { gql } from "@apollo/client";
 import { PageContent } from "@ndla/primitives";
-import { useTracker } from "@ndla/tracker";
 import { Article } from "../../components/Article/Article";
-import { AuthContext } from "../../components/AuthenticationContext";
 import { LdJson } from "../../components/LdJson";
+import { PageTitle } from "../../components/PageTitle";
 import { SocialMediaMetadata } from "../../components/SocialMediaMetadata";
 import config from "../../config";
 import { GQLPlainArticleContainer_ArticleFragment } from "../../graphqlTypes";
 import { getArticleScripts } from "../../util/getArticleScripts";
 import { structuredArticleDataFragment } from "../../util/getStructuredDataFromArticle";
 import { htmlTitle } from "../../util/titleHelper";
-import { getAllDimensions } from "../../util/trackingUtil";
 import { transformArticle } from "../../util/transformArticle";
 import { NotFoundPage } from "../NotFoundPage/NotFoundPage";
 
@@ -33,9 +31,7 @@ interface Props {
 const getDocumentTitle = (t: TFunction, title: string) => htmlTitle(title, [t("htmlTitles.titleTemplate")]);
 
 export const PlainArticleContainer = ({ article: propArticle, skipToContentId }: Props) => {
-  const { user, authContextLoaded } = useContext(AuthContext);
   const { t, i18n } = useTranslation();
-  const { trackPageView } = useTracker();
   useEffect(() => {
     if (window.MathJax && typeof window.MathJax.typesetPromise === "function") {
       try {
@@ -45,15 +41,6 @@ export const PlainArticleContainer = ({ article: propArticle, skipToContentId }:
       }
     }
   });
-
-  useEffect(() => {
-    if (!propArticle || !authContextLoaded) return;
-    const dimensions = getAllDimensions({ user });
-    trackPageView({
-      dimensions,
-      title: getDocumentTitle(t, propArticle.title),
-    });
-  }, [authContextLoaded, propArticle, t, trackPageView, user]);
 
   const [article, scripts] = useMemo(() => {
     return [
@@ -70,7 +57,7 @@ export const PlainArticleContainer = ({ article: propArticle, skipToContentId }:
 
   return (
     <div>
-      <title>{`${getDocumentTitle(t, article.title)}`}</title>
+      <PageTitle title={getDocumentTitle(t, article.title)} />
       <meta name="robots" content="noindex, nofollow" />
       {scripts.map((script) => (
         <script key={script.src} src={script.src} type={script.type} async={script.async} defer={script.defer} />

--- a/src/containers/PlainLearningpathPage/PlainLearningpathContainer.tsx
+++ b/src/containers/PlainLearningpathPage/PlainLearningpathContainer.tsx
@@ -7,17 +7,15 @@
  */
 
 import { TFunction } from "i18next";
-import { useContext, useEffect } from "react";
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { gql } from "@apollo/client";
-import { useTracker } from "@ndla/tracker";
-import { AuthContext } from "../../components/AuthenticationContext";
 import { PageLayout } from "../../components/Layout/PageContainer";
 import { Learningpath } from "../../components/Learningpath/Learningpath";
+import { PageTitle } from "../../components/PageTitle";
 import { SocialMediaMetadata } from "../../components/SocialMediaMetadata";
 import { GQLPlainLearningpathContainer_LearningpathFragment } from "../../graphqlTypes";
 import { htmlTitle } from "../../util/titleHelper";
-import { getAllDimensions } from "../../util/trackingUtil";
 
 const getDocumentTitle = (learningpath: Props["learningpath"], t: TFunction) =>
   htmlTitle(learningpath.title, [t("htmlTitles.titleTemplate")]);
@@ -28,9 +26,7 @@ interface Props {
   skipToContentId?: string;
 }
 export const PlainLearningpathContainer = ({ learningpath, skipToContentId, stepId }: Props) => {
-  const { user, authContextLoaded } = useContext(AuthContext);
   const { t } = useTranslation();
-  const { trackPageView } = useTracker();
   const steps = learningpath.learningsteps;
 
   useEffect(() => {
@@ -43,13 +39,6 @@ export const PlainLearningpathContainer = ({ learningpath, skipToContentId, step
     }
   });
 
-  useEffect(() => {
-    if (learningpath && authContextLoaded) {
-      const dimensions = getAllDimensions({ user });
-      trackPageView({ dimensions, title: getDocumentTitle(learningpath, t) });
-    }
-  }, [authContextLoaded, learningpath, stepId, t, trackPageView, user]);
-
   const currentStep = stepId
     ? steps.find((step) => step.id.toString() === stepId)
     : learningpath.introduction?.length
@@ -58,7 +47,7 @@ export const PlainLearningpathContainer = ({ learningpath, skipToContentId, step
 
   return (
     <>
-      <title>{`${getDocumentTitle(learningpath, t)}`}</title>
+      <PageTitle title={getDocumentTitle(learningpath, t)} />
       <meta name="robots" content="noindex, nofollow" />
       <SocialMediaMetadata
         title={learningpath.title}

--- a/src/containers/PodcastPage/PodcastSeriesListPage.tsx
+++ b/src/containers/PodcastPage/PodcastSeriesListPage.tsx
@@ -24,11 +24,11 @@ import {
   Spinner,
 } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
-import { HelmetWithTracker } from "@ndla/tracker";
 import { HomeBreadcrumb, usePaginationTranslations } from "@ndla/ui";
 import { PodcastSeries } from "./PodcastSeries";
 import { DefaultErrorMessagePage } from "../../components/DefaultErrorMessage";
 import { PageContainer } from "../../components/Layout/PageContainer";
+import { PageTitle } from "../../components/PageTitle";
 import { SocialMediaMetadata } from "../../components/SocialMediaMetadata";
 import { SKIP_TO_CONTENT_ID } from "../../constants";
 import { GQLPodcastSeriesListPageQuery } from "../../graphqlTypes";
@@ -116,7 +116,7 @@ export const PodcastSeriesListPage = () => {
   return (
     <StyledPageContainer asChild consumeCss>
       <main>
-        <HelmetWithTracker title={t("htmlTitles.podcast", { page: page })} />
+        <PageTitle title={t("htmlTitles.podcast", { page })} />
         <SocialMediaMetadata type="website" title={t("podcastPage.podcasts")} description={t("podcastPage.meta")} />
         <HomeBreadcrumb
           items={[

--- a/src/containers/PodcastPage/PodcastSeriesPage.tsx
+++ b/src/containers/PodcastPage/PodcastSeriesPage.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+import { TFunction } from "i18next";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Navigate, useParams } from "react-router";
@@ -27,10 +28,10 @@ import {
   PageContent,
   Text,
 } from "@ndla/primitives";
-import { HelmetWithTracker } from "@ndla/tracker";
 import { ArticleContent, ArticleFooter, ArticleHeader, ArticleHGroup, ArticleWrapper, HomeBreadcrumb } from "@ndla/ui";
 import { ContentPlaceholder } from "../../components/ContentPlaceholder";
 import { DefaultErrorMessagePage } from "../../components/DefaultErrorMessage";
+import { PageTitle } from "../../components/PageTitle";
 import { SocialMediaMetadata } from "../../components/SocialMediaMetadata";
 import config from "../../config";
 import { AcquireLicensePage, PODCAST_SERIES_LIST_PAGE_PATH, SKIP_TO_CONTENT_ID } from "../../constants";
@@ -38,6 +39,10 @@ import { GQLPodcastSeriesPageQuery } from "../../graphqlTypes";
 import { publisher } from "../../util/getStructuredDataFromArticle";
 import { hasLicensedContent } from "../ResourceEmbed/components/ResourceEmbed";
 import { ResourceEmbedLicenseContent } from "../ResourceEmbed/components/ResourceEmbedLicenseContent";
+
+const getDocumentTitle = (podcast: NonNullable<GQLPodcastSeriesPageQuery["podcastSeries"]>, t: TFunction) => {
+  return `${podcast?.title?.title || t("podcastPage.podcast")} - ${t("htmlTitles.titleTemplate")}`;
+};
 
 export const PodcastSeriesPage = () => {
   const { id } = useParams();
@@ -56,10 +61,6 @@ export const PodcastSeriesPage = () => {
   }, [podcastSeries?.content?.content]);
 
   const { t } = useTranslation();
-
-  const getDocumentTitle = (podcast: GQLPodcastSeriesPageQuery["podcastSeries"]) => {
-    return `${podcast?.title?.title || t("podcastPage.podcast")} - ${t("htmlTitles.titleTemplate")}`;
-  };
 
   if (loading) {
     return <ContentPlaceholder variant="article" />;
@@ -121,12 +122,11 @@ export const PodcastSeriesPage = () => {
 
   return (
     <>
-      <HelmetWithTracker title={`${getDocumentTitle(podcastSeries)}`}>
-        {!!podcastSeries.hasRSS && (
-          <link type="application/rss+xml" rel="alternate" title={podcastSeries.title.title} href={rssUrl} />
-        )}
-        <script type="application/ld+json">{podcastSeriesJSONLd()}</script>
-      </HelmetWithTracker>
+      <PageTitle title={getDocumentTitle(podcastSeries, t)} />
+      {!!podcastSeries.hasRSS && (
+        <link type="application/rss+xml" rel="alternate" title={podcastSeries.title.title} href={rssUrl} />
+      )}
+      <script type="application/ld+json">{podcastSeriesJSONLd()}</script>
       <SocialMediaMetadata
         type="website"
         title={podcastSeries.title.title ?? ""}

--- a/src/containers/ProgrammePage/ProgrammeContainer.tsx
+++ b/src/containers/ProgrammePage/ProgrammeContainer.tsx
@@ -7,24 +7,22 @@
  */
 
 import { TFunction } from "i18next";
-import { useContext, useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { gql } from "@apollo/client";
 import { InformationLine } from "@ndla/icons";
 import { Heading, Image, MessageBox, Text } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
-import { useTracker } from "@ndla/tracker";
-import { AuthContext } from "../../components/AuthenticationContext";
 import { PageContainer } from "../../components/Layout/PageContainer";
 import { NavigationBox } from "../../components/NavigationBox";
 import { NavigationSafeLinkButton } from "../../components/NavigationSafeLinkButton";
+import { PageTitle } from "../../components/PageTitle";
 import { SocialMediaMetadata } from "../../components/SocialMediaMetadata";
 import { SKIP_TO_CONTENT_ID } from "../../constants";
 import { GQLProgrammeContainer_ProgrammeFragment } from "../../graphqlTypes";
 import { LocaleType } from "../../interfaces";
 import { toProgramme } from "../../routeHelpers";
 import { htmlTitle } from "../../util/titleHelper";
-import { getAllDimensions } from "../../util/trackingUtil";
 
 const getDocumentTitle = (title: string, grade: string, t: TFunction) => {
   return htmlTitle(`${title} - ${grade}`, [t("htmlTitles.titleTemplate")]);
@@ -136,7 +134,6 @@ const StyledImage = styled(Image, {
 });
 
 export const ProgrammeContainer = ({ programme, grade: gradeProp }: Props) => {
-  const { user, authContextLoaded } = useContext(AuthContext);
   const { t } = useTranslation();
   const heading = programme.title.title;
   const grades = mapGradesData(programme.grades || []);
@@ -144,16 +141,6 @@ export const ProgrammeContainer = ({ programme, grade: gradeProp }: Props) => {
   const metaDescription = programme.metaDescription;
   const image = programme.desktopImage?.url || "";
   const pageTitle = getDocumentTitle(programme.title.title, gradeProp, t);
-  const { trackPageView } = useTracker();
-
-  useEffect(() => {
-    if (!authContextLoaded) return;
-    const dimensions = getAllDimensions({ user });
-    trackPageView({
-      dimensions,
-      title: getDocumentTitle(programme.title.title, gradeProp, t),
-    });
-  }, [authContextLoaded, gradeProp, programme.title.title, t, trackPageView, user]);
 
   const selectedGrade = gradeProp.toLowerCase();
 
@@ -165,7 +152,7 @@ export const ProgrammeContainer = ({ programme, grade: gradeProp }: Props) => {
   return (
     <StyledPageContainer padding="large" asChild consumeCss>
       <main>
-        <title>{pageTitle}</title>
+        <PageTitle title={pageTitle} />
         <SocialMediaMetadata title={socialMediaTitle} description={metaDescription} imageUrl={image} />
         <div>
           {/* TODO: Use semantic tokens */}

--- a/src/containers/ResourceEmbed/components/ResourceEmbed.tsx
+++ b/src/containers/ResourceEmbed/components/ResourceEmbed.tsx
@@ -7,19 +7,18 @@
  */
 
 import { TFunction } from "i18next";
-import { useContext, useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation } from "react-router";
 import { gql } from "@apollo/client";
 import { useQuery } from "@apollo/client/react";
 import { transform } from "@ndla/article-converter";
 import { Badge, Hero, HeroBackground, HeroContent, PageContent, Spinner } from "@ndla/primitives";
-import { HelmetWithTracker, useTracker } from "@ndla/tracker";
 import { ArticleFooter, ArticleWrapper, HomeBreadcrumb, ArticleContent, ArticleTitle } from "@ndla/ui";
 import { ResourceEmbedLicenseContent } from "./ResourceEmbedLicenseContent";
 import { CreatedBy } from "../../../components/Article/CreatedBy";
-import { AuthContext } from "../../../components/AuthenticationContext";
 import { DefaultErrorMessagePage } from "../../../components/DefaultErrorMessage";
+import { PageTitle } from "../../../components/PageTitle";
 import { SocialMediaMetadata } from "../../../components/SocialMediaMetadata";
 import config from "../../../config";
 import { SKIP_TO_CONTENT_ID } from "../../../constants";
@@ -30,7 +29,6 @@ import {
 } from "../../../graphqlTypes";
 import { isNotFoundError } from "../../../util/handleError";
 import { useListItemTraits } from "../../../util/listItemTraits";
-import { getAllDimensions } from "../../../util/trackingUtil";
 import { NotFoundPage } from "../../NotFoundPage/NotFoundPage";
 
 export type StandaloneEmbed = "image" | "audio" | "video" | "h5p" | "concept";
@@ -123,8 +121,6 @@ export const hasLicensedContent = (meta: GQLResourceEmbedLicenseContent_MetaFrag
 };
 
 export const ResourceEmbed = ({ id, type, isOembed }: Props) => {
-  const { user, authContextLoaded } = useContext(AuthContext);
-  const { trackPageView } = useTracker();
   const { t } = useTranslation();
   const { pathname } = useLocation();
 
@@ -147,13 +143,6 @@ export const ResourceEmbed = ({ id, type, isOembed }: Props) => {
     });
   }, [data?.resourceEmbed.content, pathname]);
 
-  useEffect(() => {
-    if (!authContextLoaded || !properties) return;
-    const dimensions = getAllDimensions({ user });
-    const title = getDocumentTitle(properties.title, properties.type, t);
-    trackPageView({ dimensions, title });
-  }, [authContextLoaded, properties, t, trackPageView, user]);
-
   if (loading) {
     return <Spinner />;
   }
@@ -170,7 +159,7 @@ export const ResourceEmbed = ({ id, type, isOembed }: Props) => {
 
   return (
     <>
-      <HelmetWithTracker title={getDocumentTitle(properties.title, properties.type, t)} />
+      <PageTitle title={getDocumentTitle(properties.title, properties.type, t)} />
       <SocialMediaMetadata
         type="website"
         audioUrl={properties?.audioUrl}

--- a/src/containers/ResourcePage/ResourcePage.tsx
+++ b/src/containers/ResourcePage/ResourcePage.tsx
@@ -138,18 +138,10 @@ export const ResourcePage = () => {
 
   if (isLearningPathResource(data.node.contentUri)) {
     return (
-      <LearningpathPage
-        key={data.node.url}
-        skipToContentId={SKIP_TO_CONTENT_ID}
-        stepId={stepId}
-        node={data.node}
-        loading={loading}
-      />
+      <LearningpathPage key={data.node.url} skipToContentId={SKIP_TO_CONTENT_ID} stepId={stepId} node={data.node} />
     );
   }
-  return (
-    <ArticlePage key={data.node.url} skipToContentId={SKIP_TO_CONTENT_ID} resource={data.node} loading={loading} />
-  );
+  return <ArticlePage key={data.node.url} skipToContentId={SKIP_TO_CONTENT_ID} resource={data.node} />;
 };
 
 export const Component = ResourcePage;

--- a/src/containers/SearchPage/SearchPage.tsx
+++ b/src/containers/SearchPage/SearchPage.tsx
@@ -6,16 +6,13 @@
  *
  */
 
-import { useContext, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { gql } from "@apollo/client";
 import { useQuery } from "@apollo/client/react";
-import { useTracker } from "@ndla/tracker";
 import { SearchContainer } from "./SearchContainer";
-import { AuthContext } from "../../components/AuthenticationContext";
 import { PageContainer } from "../../components/Layout/PageContainer";
+import { PageTitle } from "../../components/PageTitle";
 import { GQLSearchResourceTypesQuery } from "../../graphqlTypes";
-import { getAllDimensions } from "../../util/trackingUtil";
 
 const searchResourceTypesQuery = gql`
   query searchResourceTypes {
@@ -31,21 +28,9 @@ export const SearchPage = () => {
 
   const resourceTypesQuery = useQuery<GQLSearchResourceTypesQuery>(searchResourceTypesQuery);
 
-  const { trackPageView } = useTracker();
-  const { user, authContextLoaded } = useContext(AuthContext);
-
-  useEffect(() => {
-    if (authContextLoaded) {
-      trackPageView({
-        title: t("htmlTitles.searchPage"),
-        dimensions: getAllDimensions({ user }),
-      });
-    }
-  }, [authContextLoaded, t, trackPageView, user]);
-
   return (
     <PageContainer>
-      <title>{t("htmlTitles.searchPage")}</title>
+      <PageTitle title={t("htmlTitles.searchPage")} />
       <SearchContainer
         resourceTypes={resourceTypesQuery.data?.resourceTypes ?? []}
         resourceTypesLoading={resourceTypesQuery.loading}

--- a/src/containers/SharedFolderPage/SharedFolderPage.tsx
+++ b/src/containers/SharedFolderPage/SharedFolderPage.tsx
@@ -24,6 +24,7 @@ import { Folder } from "../../components/MyNdla/Folder";
 import { FoldersPageTitle } from "../../components/MyNdla/FoldersPageTitle";
 import { ListResource } from "../../components/MyNdla/ListResource";
 import { PageSpinner } from "../../components/PageSpinner";
+import { PageTitle } from "../../components/PageTitle";
 import { SocialMediaMetadata } from "../../components/SocialMediaMetadata";
 import { GQLFolder, GQLFolderResource, GQLFoldersPageQuery } from "../../graphqlTypes";
 import {
@@ -142,7 +143,7 @@ export const SharedFolderPage = () => {
   return (
     <StyledPageContainer asChild consumeCss>
       <main>
-        <title>{folder.name}</title>
+        <PageTitle title={folder.name} />
         <SocialMediaMetadata
           type="website"
           title={folder.name}

--- a/src/containers/SubjectPage/SubjectContainer.tsx
+++ b/src/containers/SubjectPage/SubjectContainer.tsx
@@ -7,13 +7,12 @@
  */
 
 import { TFunction } from "i18next";
-import { useEffect, useContext, useId } from "react";
+import { useContext, useId } from "react";
 import { useTranslation } from "react-i18next";
 import { gql } from "@apollo/client";
 import { InformationLine } from "@ndla/icons";
 import { Heading, MessageBox, PageContent, Text } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
-import { useTracker } from "@ndla/tracker";
 import { SimpleBreadcrumbItem, HomeBreadcrumb, subjectCategories, subjectTypes } from "@ndla/ui";
 import { AuthContext } from "../../components/AuthenticationContext";
 import { CompetenceGoals } from "../../components/CompetenceGoals";
@@ -21,6 +20,7 @@ import { FavoriteSubject } from "../../components/FavoriteSubject";
 import { PageContainer } from "../../components/Layout/PageContainer";
 import { ImageLicenseAccordion } from "../../components/license/ImageLicenseAccordion";
 import { ImageLicenseList } from "../../components/license/ImageLicenseList";
+import { PageTitle } from "../../components/PageTitle";
 import { SocialMediaMetadata } from "../../components/SocialMediaMetadata";
 import { SubjectLinks } from "../../components/Subject/SubjectLinks";
 import { TransportationPageHeader } from "../../components/TransportationPage/TransportationPageHeader";
@@ -35,12 +35,10 @@ import {
 } from "../../constants";
 import { GQLSubjectContainer_NodeFragment } from "../../graphqlTypes";
 import { htmlTitle } from "../../util/titleHelper";
-import { getAllDimensions } from "../../util/trackingUtil";
 
 type Props = {
   node: GQLSubjectContainer_NodeFragment;
   subjectType?: string;
-  loading?: boolean;
 };
 
 const HeadingWrapper = styled("div", {
@@ -115,22 +113,12 @@ const getSubjectTypeMessage = (subjectType: string | undefined, t: TFunction): s
   }
 };
 
-export const SubjectContainer = ({ node, subjectType, loading }: Props) => {
-  const { user, authContextLoaded } = useContext(AuthContext);
+export const SubjectContainer = ({ node, subjectType }: Props) => {
+  const { user } = useContext(AuthContext);
   const { t } = useTranslation();
-  const { trackPageView } = useTracker();
   const about = node.subjectpage?.about;
   const headingId = useId();
   const linksHeadingId = useId();
-
-  useEffect(() => {
-    if (!authContextLoaded || loading) return;
-    const dimensions = getAllDimensions({ user });
-    trackPageView({
-      dimensions,
-      title: htmlTitle(node.name, [t("htmlTitles.titleTemplate")]),
-    });
-  }, [authContextLoaded, loading, node, t, trackPageView, user]);
 
   const breadCrumbs: SimpleBreadcrumbItem[] = [
     {
@@ -153,7 +141,7 @@ export const SubjectContainer = ({ node, subjectType, loading }: Props) => {
 
   return (
     <main>
-      <title>{pageTitle}</title>
+      <PageTitle title={pageTitle} />
       {(!node.context?.isActive || customFields?.[TAXONOMY_CUSTOM_FIELD_SUBJECT_FOR_CONCEPT] === "true") && (
         <meta name="robots" content="noindex, nofollow" />
       )}

--- a/src/containers/SubjectPage/SubjectPage.tsx
+++ b/src/containers/SubjectPage/SubjectPage.tsx
@@ -83,7 +83,7 @@ export const SubjectPage = () => {
     return <FilmFrontpage />;
   }
 
-  return <SubjectContainer node={data.node} subjectType={subjectType} loading={loading} />;
+  return <SubjectContainer node={data.node} subjectType={subjectType} />;
 };
 
 export const Component = SubjectPage;

--- a/src/containers/TopicPage/MultidisciplinarySubjectArticle.tsx
+++ b/src/containers/TopicPage/MultidisciplinarySubjectArticle.tsx
@@ -6,12 +6,11 @@
  *
  */
 
-import { useMemo, useEffect, useContext } from "react";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { gql } from "@apollo/client";
 import { Badge, PageContent } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
-import { useTracker } from "@ndla/tracker";
 import {
   ArticleByline,
   ArticleContent,
@@ -25,10 +24,10 @@ import { NoSSR } from "@ndla/util";
 import { Article } from "../../components/Article/Article";
 import { useArticleCopyText, useNavigateToHash } from "../../components/Article/articleHelpers";
 import { FavoriteButton } from "../../components/Article/FavoritesButton";
-import { AuthContext } from "../../components/AuthenticationContext";
 import { CompetenceGoals } from "../../components/CompetenceGoals";
 import { LicenseBox } from "../../components/license/LicenseBox";
 import { AddResourceToFolderModal } from "../../components/MyNdla/AddResourceToFolderModal";
+import { PageTitle } from "../../components/PageTitle";
 import { SocialMediaMetadata } from "../../components/SocialMediaMetadata";
 import { SubjectLinkSet } from "../../components/Subject/SubjectLinks";
 import config from "../../config";
@@ -38,7 +37,6 @@ import { toBreadcrumbItems } from "../../routeHelpers";
 import { getArticleScripts } from "../../util/getArticleScripts";
 import { useListItemTraits } from "../../util/listItemTraits";
 import { htmlTitle } from "../../util/titleHelper";
-import { getAllDimensions } from "../../util/trackingUtil";
 import { transformArticle } from "../../util/transformArticle";
 import { Resources } from "../Resources/Resources";
 
@@ -89,9 +87,7 @@ interface Props {
 }
 
 export const MultidisciplinarySubjectArticle = ({ node }: Props) => {
-  const { user, authContextLoaded } = useContext(AuthContext);
   const { t, i18n } = useTranslation();
-  const { trackPageView } = useTracker();
   const crumbs = useMemo(() => node.context?.parents ?? [], [node]);
   const root = crumbs[0];
 
@@ -100,15 +96,6 @@ export const MultidisciplinarySubjectArticle = ({ node }: Props) => {
     [node.article?.title, node.name, root?.name],
   );
   const pageTitle = useMemo(() => htmlTitle(metaTitle, [t("htmlTitles.titleTemplate")]), [metaTitle, t]);
-
-  useEffect(() => {
-    if (!node?.article || !authContextLoaded) return;
-    const dimensions = getAllDimensions({ user });
-    trackPageView({
-      dimensions,
-      title: pageTitle,
-    });
-  }, [authContextLoaded, node.article, trackPageView, user, pageTitle]);
 
   const breadCrumbs = useMemo(() => {
     return toBreadcrumbItems(t("breadcrumb.toFrontpage"), [...crumbs, node]);
@@ -166,7 +153,7 @@ export const MultidisciplinarySubjectArticle = ({ node }: Props) => {
           <script key={script.src} src={script.src} type={script.type} async={script.async} defer={script.defer} />
         ))}
         {!node.context?.isActive && <meta name="robots" content="noindex" />}
-        <title>{pageTitle}</title>
+        <PageTitle title={pageTitle} />
         <SocialMediaMetadata
           title={socialMediaMetaData.title}
           description={socialMediaMetaData.description}

--- a/src/containers/TopicPage/TopicContainer.tsx
+++ b/src/containers/TopicPage/TopicContainer.tsx
@@ -7,21 +7,20 @@
  */
 
 import parse from "html-react-parser";
-import { useContext, useEffect, useId, useMemo } from "react";
+import { useId, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { gql } from "@apollo/client";
 import { extractEmbedMeta } from "@ndla/article-converter";
 import { Badge, Heading, PageContent, Text } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
-import { useTracker } from "@ndla/tracker";
 import { HomeBreadcrumb } from "@ndla/ui";
 import { NoSSR } from "@ndla/util";
 import { FavoriteButton } from "../../components/Article/FavoritesButton";
-import { AuthContext } from "../../components/AuthenticationContext";
 import { CompetenceGoals } from "../../components/CompetenceGoals";
 import { PageContainer } from "../../components/Layout/PageContainer";
 import { ImageLicenseAccordion } from "../../components/license/ImageLicenseAccordion";
 import { AddResourceToFolderModal } from "../../components/MyNdla/AddResourceToFolderModal";
+import { PageTitle } from "../../components/PageTitle";
 import { SocialMediaMetadata } from "../../components/SocialMediaMetadata";
 import { TransportationPageHeader } from "../../components/TransportationPage/TransportationPageHeader";
 import { TransportationNode } from "../../components/TransportationPage/TransportationPageNode";
@@ -31,7 +30,6 @@ import { RELEVANCE_SUPPLEMENTARY, SKIP_TO_CONTENT_ID } from "../../constants";
 import { GQLTopicPageQuery } from "../../graphqlTypes";
 import { SubjectType } from "../../routeHelpers";
 import { htmlTitle } from "../../util/titleHelper";
-import { getAllDimensions } from "../../util/trackingUtil";
 import { getArticleIdFromResource } from "../Resources/resourceHelpers";
 import { Resources } from "../Resources/Resources";
 
@@ -87,21 +85,12 @@ interface TopicContainerProps {
 
 export const TopicContainer = ({ node, subjectType }: TopicContainerProps) => {
   const { t } = useTranslation();
-  const { user, authContextLoaded } = useContext(AuthContext);
-  const { trackPageView } = useTracker();
   const headingId = useId();
   const linksHeadingId = useId();
   const articleId = getArticleIdFromResource(node.contentUri);
 
   const metaTitle = useMemo(() => htmlTitle(node.name, [node.breadcrumbs[0]]), [node.breadcrumbs, node.name]);
   const pageTitle = useMemo(() => htmlTitle(metaTitle, [t("htmlTitles.titleTemplate")]), [metaTitle, t]);
-
-  useEffect(() => {
-    if (authContextLoaded && node.article) {
-      const dimensions = getAllDimensions({ user });
-      trackPageView({ dimensions, title: pageTitle });
-    }
-  }, [authContextLoaded, node.article, pageTitle, trackPageView, user]);
 
   const breadcrumbs = useMemo(() => {
     if (!node.context) return [];
@@ -131,7 +120,7 @@ export const TopicContainer = ({ node, subjectType }: TopicContainerProps) => {
 
   return (
     <main>
-      <title>{pageTitle}</title>
+      <PageTitle title={pageTitle} />
       {!node.context?.isActive && <meta name="robots" content="noindex" />}
       <SocialMediaMetadata
         title={metaTitle}

--- a/src/containers/UnpublishedResourcePage/UnpublishedResourcePage.tsx
+++ b/src/containers/UnpublishedResourcePage/UnpublishedResourcePage.tsx
@@ -15,8 +15,8 @@ import {
   ErrorMessageActions,
 } from "@ndla/primitives";
 import { SafeLink } from "@ndla/safelink";
-import { HelmetWithTracker } from "@ndla/tracker";
 import { PageContainer } from "../../components/Layout/PageContainer";
+import { PageTitle } from "../../components/PageTitle";
 import { Status } from "../../components/Status";
 import { SKIP_TO_CONTENT_ID } from "../../constants";
 
@@ -26,7 +26,7 @@ export const UnpublishedResourcePage = () => {
     <Status code={410}>
       <PageContainer asChild consumeCss>
         <main>
-          <HelmetWithTracker title={t("htmlTitles.unpublished")} />
+          <PageTitle title={t("htmlTitles.unpublished")} />
           <ErrorMessageRoot>
             <img src={"/static/not-exist.gif"} alt={t("errorMessage.title")} />
             <ErrorMessageContent>

--- a/src/containers/WelcomePage/WelcomePage.tsx
+++ b/src/containers/WelcomePage/WelcomePage.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import { useContext, useEffect, useMemo } from "react";
+import { useContext, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { gql } from "@apollo/client";
 import { useQuery } from "@apollo/client/react";
@@ -15,10 +15,10 @@ import { CardContent, CardHeading, CardRoot, Heading, Hero, HeroBackground, Text
 import { SafeLink, SafeLinkButton } from "@ndla/safelink";
 import { styled } from "@ndla/styled-system/jsx";
 import { linkOverlay } from "@ndla/styled-system/patterns";
-import { HelmetWithTracker, useTracker } from "@ndla/tracker";
 import { ArticleWrapper, ArticleContent } from "@ndla/ui";
 import { AuthContext } from "../../components/AuthenticationContext";
 import { PageContainer } from "../../components/Layout/PageContainer";
+import { PageTitle } from "../../components/PageTitle";
 import { useSiteTheme } from "../../components/SiteThemeContext";
 import { SocialMediaMetadata } from "../../components/SocialMediaMetadata";
 import config from "../../config";
@@ -29,7 +29,6 @@ import { getChatRobotUrl } from "../../util/chatRobotHelpers";
 import { getArticleScripts } from "../../util/getArticleScripts";
 import { structuredArticleDataFragment } from "../../util/getStructuredDataFromArticle";
 import { siteThemeToHeroVariant } from "../../util/siteTheme";
-import { getAllDimensions } from "../../util/trackingUtil";
 import { transformArticle } from "../../util/transformArticle";
 
 const HeadingWrapper = styled("div", {
@@ -210,8 +209,7 @@ const frontpageQuery = gql`
 
 export const WelcomePage = () => {
   const { t, i18n } = useTranslation();
-  const { trackPageView } = useTracker();
-  const { user, authContextLoaded } = useContext(AuthContext);
+  const { user } = useContext(AuthContext);
   const siteTheme = useSiteTheme();
 
   const quickLinks = useMemo(() => {
@@ -222,15 +220,6 @@ export const WelcomePage = () => {
       { type: "film", icon: MovieLine, url: FILM_PAGE_URL, external: false },
     ] as const;
   }, [user]);
-
-  useEffect(() => {
-    if (authContextLoaded) {
-      trackPageView({
-        title: t("htmlTitles.welcomePage"),
-        dimensions: getAllDimensions({ user }),
-      });
-    }
-  }, [authContextLoaded, t, trackPageView, user]);
 
   const fpQuery = useQuery<GQLFrontpageDataQuery>(frontpageQuery);
 
@@ -271,9 +260,8 @@ export const WelcomePage = () => {
   return (
     <>
       <Heading srOnly>{t("welcomePage.heading.heading")}</Heading>
-      <HelmetWithTracker title={t("htmlTitles.welcomePage")}>
-        <script type="application/ld+json">{googleSearchJSONLd()}</script>
-      </HelmetWithTracker>
+      <PageTitle title={t("htmlTitles.welcomePage")} />
+      <script type="application/ld+json">{googleSearchJSONLd()}</script>
       <SocialMediaMetadata
         type="website"
         title={t("welcomePage.heading.heading")}

--- a/src/iframe/IframeArticlePage.tsx
+++ b/src/iframe/IframeArticlePage.tsx
@@ -6,13 +6,12 @@
  *
  */
 
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
 import { gql } from "@apollo/client";
 import { ArrowLeftLine } from "@ndla/icons";
 import { BleedPageContent, Button, PageContent } from "@ndla/primitives";
-import { useTracker } from "@ndla/tracker";
 import { contentTypes } from "@ndla/ui";
 import { PostResizeMessage } from "./PostResizeMessage";
 import { Article } from "../components/Article/Article";
@@ -20,6 +19,7 @@ import { CreatedBy } from "../components/Article/CreatedBy";
 import { BannerAlerts } from "../components/BannerAlerts";
 import { LdJson } from "../components/LdJson";
 import { useLtiData } from "../components/LtiContext";
+import { PageTitle } from "../components/PageTitle";
 import { SocialMediaMetadata } from "../components/SocialMediaMetadata";
 import config from "../config";
 import { GQLIframeArticlePage_ArticleFragment, GQLIframeArticlePage_NodeFragment } from "../graphqlTypes";
@@ -43,7 +43,6 @@ const getDocumentTitle = ({ article }: Pick<Props, "article">) => {
 };
 
 export const IframeArticlePage = ({ node, article: propArticle, locale: localeProp }: Props) => {
-  const { trackPageView } = useTracker();
   const navigate = useNavigate();
   const ltiData = useLtiData();
   const { t, i18n } = useTranslation();
@@ -59,13 +58,6 @@ export const IframeArticlePage = ({ node, article: propArticle, locale: localePr
       getArticleScripts(propArticle, locale),
     ];
   }, [propArticle, locale]);
-
-  useEffect(() => {
-    if (propArticle?.id) return;
-    trackPageView({
-      title: getDocumentTitle({ article: propArticle }),
-    });
-  }, [propArticle, node, trackPageView]);
 
   const url = node?.url;
   const contentUrl = url ? `${config.ndlaFrontendDomain}${url}` : undefined;
@@ -83,7 +75,7 @@ export const IframeArticlePage = ({ node, article: propArticle, locale: localePr
           <BannerAlerts />
         </BleedPageContent>
       }
-      <title>{getDocumentTitle({ article: propArticle })}</title>
+      <PageTitle title={getDocumentTitle({ article: propArticle })} />
       <meta name="robots" content="noindex, nofollow" />
       {scripts.map((script) => (
         <script key={script.src} src={script.src} type={script.type} async={script.async} defer={script.defer} />

--- a/src/iframe/IframePage.tsx
+++ b/src/iframe/IframePage.tsx
@@ -18,8 +18,8 @@ import {
   ErrorMessageTitle,
   PageContainer,
 } from "@ndla/primitives";
-import { HelmetWithTracker } from "@ndla/tracker";
 import { IframeArticlePage, iframeArticlePageFragments } from "./IframeArticlePage";
+import { PageTitle } from "../components/PageTitle";
 import { RedirectContext } from "../components/RedirectContext";
 import { Status } from "../components/Status";
 import { SKIP_TO_CONTENT_ID } from "../constants";
@@ -31,10 +31,11 @@ import { isGoneError } from "../util/handleError";
 
 const Error = () => {
   const { t } = useTranslation();
+
   return (
     <PageContainer asChild consumeCss>
       <main>
-        <HelmetWithTracker title={t("htmlTitles.errorPage")} />
+        <PageTitle title={t("htmlTitles.errorPage")} />
         <Status code={INTERNAL_SERVER_ERROR}>
           <ErrorMessageRoot>
             <img src="/static/oops.gif" alt={t("errorMessage.title")} />


### PR DESCRIPTION
Synes det er veldig mye boilerplate for å tracke en page-view, så ville gjerne forenkle prosessen litt. Hovedproblemet med trackingen vår er at vi setter sidetittel asynkront. Det er ingen generell måte man kan finne ut av om sidetittel er klar på. Man kan dog forenkle det drastisk dersom man baserer seg på at man aldri vil sette sidetittel mer enn én gang per side. Denne løsningen bygger på den antakelsen. 

Så lenge tittelen som sendes inn til `PageTitle` er stabil vil den fungere perfekt, og det er ikke altfor vanskelig å garantere. Har lagt inn et debug-statement i komponenten som logges dersom `title`-propen endrer seg inn i komponenten. Flørtet også litt med tanken om å komme med en advarsel når href endret seg uten at tittelen endret seg, men det virket ikke generisk nok til å få plass til i komponenten.

Kjør debatt!