### PR TITLE
fix: properly hydrate when basename is set

### DIFF
--- a/src/client.tsx
+++ b/src/client.tsx
@@ -32,7 +32,7 @@ const {
 
 initSentry(config);
 
-const { abbreviation } = getLocaleInfoFromPath(serverPath ?? "");
+const { abbreviation, basepath } = getLocaleInfoFromPath(serverPath ?? "");
 
 const paths = window.location.pathname.split("/");
 const basename = isValidLocale(paths[1] ?? "") ? `${paths[1]}` : undefined;
@@ -68,4 +68,5 @@ renderOrHydrate(
     </I18nextProvider>
   </Document>,
   routes,
+  basepath,
 );

--- a/src/containers/ErrorPage/ErrorEntry.tsx
+++ b/src/containers/ErrorPage/ErrorEntry.tsx
@@ -21,7 +21,7 @@ const { config, serverPath, chunkInfo, hash } = window.DATA;
 
 initSentry(config);
 
-const { abbreviation } = getLocaleInfoFromPath(serverPath ?? "");
+const { abbreviation, basepath } = getLocaleInfoFromPath(serverPath ?? "");
 const i18n = initializeI18n(abbreviation, hash);
 
 const router = createBrowserRouter(errorRoutes);
@@ -38,4 +38,5 @@ renderOrHydrate(
     </I18nextProvider>
   </Document>,
   errorRoutes,
+  basepath,
 );

--- a/src/iframe/embedIframeIndex.tsx
+++ b/src/iframe/embedIframeIndex.tsx
@@ -41,4 +41,5 @@ renderOrHydrate(
     </I18nextProvider>
   </Document>,
   iframeEmbedRoutes,
+  window.location.pathname,
 );

--- a/src/iframe/index.tsx
+++ b/src/iframe/index.tsx
@@ -41,4 +41,5 @@ renderOrHydrate(
     </I18nextProvider>
   </Document>,
   iframeArticleRoutes,
+  window.location.pathname,
 );

--- a/src/util/renderOrHydrate.ts
+++ b/src/util/renderOrHydrate.ts
@@ -11,8 +11,13 @@ import { matchRoutes, RouteObject } from "react-router";
 import config from "../config";
 import { createRoot, hydrateRoot } from "react-dom/client";
 
-export const renderOrHydrate = async (container: Element | Document, children: ReactNode, routes: RouteObject[]) => {
-  const lazyMatches = matchRoutes(routes, window.location)?.filter((m) => m.route.lazy);
+export const renderOrHydrate = async (
+  container: Element | Document,
+  children: ReactNode,
+  routes: RouteObject[],
+  path: string,
+) => {
+  const lazyMatches = matchRoutes(routes, path)?.filter((m) => m.route.lazy);
 
   // Load the lazy matches and update the routes before creating your router
   // so we can hydrate the SSR-rendered content synchronously


### PR DESCRIPTION
Denne har irritert meg lenge. Vi får en hydreringsfeil når vi laster inn en side med basename satt. Dette er fordi pathname inkluderer basename når man bruker `window.location`. 