### PR TITLE
chore: update tsconfig to support typescript go

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,16 +24,11 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
-
     "moduleResolution": "Bundler",
-    "baseUrl": "src",
-    "paths": {
-      "*": ["node_modules/*", "src/types/*"]
-    },
     "types": ["vitest/globals", "node"],
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src/**/*"]
+  "include": ["./src/**/*"]
 }


### PR DESCRIPTION
Den nye typescript-versjonen i Go begynner egentlig å funke ganske fint, gitt at vi bruker ting den støtter. Fjerner og oppdaterer litt så vi aligner med TypeScript 6 når det kommer ut.
