### PR TITLE
fix: do not lazy load content within SettingsMenu

### DIFF
--- a/src/components/MyNdla/AddResourceToFolderModal.tsx
+++ b/src/components/MyNdla/AddResourceToFolderModal.tsx
@@ -76,24 +76,3 @@ export const AddResourceToFolderModal = ({ resource, children, defaultOpenFolder
     </DialogRoot>
   );
 };
-
-interface ContentProps {
-  close: VoidFunction;
-  defaultOpenFolder?: GQLFolder;
-  resource: ResourceAttributes;
-}
-
-export const AddResourceToFolderModalContent = ({ resource, defaultOpenFolder, close }: ContentProps) => {
-  const { t } = useTranslation();
-  return (
-    <DialogContent>
-      <DialogHeader>
-        <DialogTitle>{t("myNdla.resource.addToMyNdla")}</DialogTitle>
-        <DialogCloseButton />
-      </DialogHeader>
-      <DialogBody>
-        <AddResourceToFolder onClose={close} resource={resource} defaultOpenFolder={defaultOpenFolder} />
-      </DialogBody>
-    </DialogContent>
-  );
-};

--- a/src/components/MyNdla/AddResourceToFolderModalContent.tsx
+++ b/src/components/MyNdla/AddResourceToFolderModalContent.tsx
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2025-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { useTranslation } from "react-i18next";
+import { DialogBody, DialogContent, DialogHeader, DialogTitle } from "@ndla/primitives";
+import AddResourceToFolder, { ResourceAttributes } from "./AddResourceToFolder";
+import { GQLFolder } from "../../graphqlTypes";
+import { DialogCloseButton } from "../DialogCloseButton";
+
+interface Props {
+  close: VoidFunction;
+  defaultOpenFolder?: GQLFolder;
+  resource: ResourceAttributes;
+}
+
+export const AddResourceToFolderModalContent = ({ resource, defaultOpenFolder, close }: Props) => {
+  const { t } = useTranslation();
+  return (
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>{t("myNdla.resource.addToMyNdla")}</DialogTitle>
+        <DialogCloseButton />
+      </DialogHeader>
+      <DialogBody>
+        <AddResourceToFolder onClose={close} resource={resource} defaultOpenFolder={defaultOpenFolder} />
+      </DialogBody>
+    </DialogContent>
+  );
+};

--- a/src/containers/MyNdla/Folders/FoldersTagPage.tsx
+++ b/src/containers/MyNdla/Folders/FoldersTagPage.tsx
@@ -13,7 +13,7 @@ import { FolderLine, LinkMedium } from "@ndla/icons";
 import { styled } from "@ndla/styled-system/jsx";
 import { keyBy, usePrevious } from "@ndla/util";
 import { AuthContext } from "../../../components/AuthenticationContext";
-import { AddResourceToFolderModalContent } from "../../../components/MyNdla/AddResourceToFolderModal";
+import { AddResourceToFolderModalContent } from "../../../components/MyNdla/AddResourceToFolderModalContent";
 import { BlockWrapper } from "../../../components/MyNdla/BlockWrapper";
 import { ListResource } from "../../../components/MyNdla/ListResource";
 import { MyNdlaBreadcrumb } from "../../../components/MyNdla/MyNdlaBreadcrumb";

--- a/src/containers/MyNdla/Folders/components/DraggableResource.tsx
+++ b/src/containers/MyNdla/Folders/components/DraggableResource.tsx
@@ -17,7 +17,7 @@ import { styled } from "@ndla/styled-system/jsx";
 import { DragWrapper } from "./DraggableFolder";
 import { AuthContext } from "../../../../components/AuthenticationContext";
 import { DialogCloseButton } from "../../../../components/DialogCloseButton";
-import { AddResourceToFolderModalContent } from "../../../../components/MyNdla/AddResourceToFolderModal";
+import { AddResourceToFolderModalContent } from "../../../../components/MyNdla/AddResourceToFolderModalContent";
 import { DeleteModalContent } from "../../../../components/MyNdla/DeleteModalContent";
 import { ListResource } from "../../../../components/MyNdla/ListResource";
 import { useToast } from "../../../../components/ToastContext";


### PR DESCRIPTION
Denne var litt tricky. Fikser en bug som oppstår første gang en åpner "legg til ressurs"-dialogen i Min NDLA på desktop. Ser ut til at lazy-loading av en komponent går i beina på Dialog når den er nøstet i en Menu. Hvorfor? Vet ikke.