### PR TITLE
perf: defer some third-party scripts to improve initial load time

### DIFF
--- a/src/components/Scripts/Formbricks.tsx
+++ b/src/components/Scripts/Formbricks.tsx
@@ -16,6 +16,7 @@ export const Formbricks = () => {
   return (
     <script
       type="text/javascript"
+      defer
       dangerouslySetInnerHTML={{
         __html: `
     !function(){var t=document.createElement("script");t.type="text/javascript",t.async=!0,t.src="${host}/js/formbricks.umd.cjs";var e=document.getElementsByTagName("script")[0];e.parentNode.insertBefore(t,e),setTimeout(function(){window.formbricks?.setup({environmentId: "${config.formbricksId}", appUrl: "${host}"})},500)}();

--- a/src/components/Scripts/Monsido.tsx
+++ b/src/components/Scripts/Monsido.tsx
@@ -16,6 +16,7 @@ export const Monsido = () => {
     <>
       <script
         type="text/javascript"
+        defer
         dangerouslySetInnerHTML={{
           __html: `
     window._monsido = window._monsido || {


### PR DESCRIPTION
Det er ingen grunn til at disse skal laste før JS'en vår laster.