### PR TITLE
perf: add lazily imported chunks to document

### DIFF
--- a/src/Document.tsx
+++ b/src/Document.tsx
@@ -92,7 +92,12 @@ export const Document = ({ language, hash, children, chunkInfo }: Props) => {
           }}
         ></script>
         <Scripts />
-        {!!chunkInfo.entryPoint && <script type="module" src={`/${chunkInfo.entryPoint}`}></script>}
+        {!!chunkInfo.entryPoint && (
+          <>
+            <link rel="modulepreload" href={`/${chunkInfo.entryPoint}`}></link>
+            <script type="module" src={`/${chunkInfo.entryPoint}`}></script>
+          </>
+        )}
         {chunkInfo.importedChunks?.map((chunk) => (
           <link rel="modulepreload" href={`/${chunk}`} key={chunk}></link>
         ))}

--- a/src/appRoutes.tsx
+++ b/src/appRoutes.tsx
@@ -9,9 +9,10 @@
 import { RouteObject } from "react-router";
 import { ErrorPage } from "./containers/ErrorPage/ErrorPage";
 import { Layout } from "./containers/Page/Layout";
+import { RouteObjectWithImportPath } from "./interfaces";
 import { ErrorElement } from "./RouteErrorElement";
 
-export const routes: RouteObject[] = [
+export const routes: RouteObjectWithImportPath[] = [
   {
     path: "/",
     errorElement: <ErrorElement />,
@@ -19,22 +20,27 @@ export const routes: RouteObject[] = [
     children: [
       {
         index: true,
+        importPath: "src/containers/WelcomePage/WelcomePage.tsx",
         lazy: () => import("./containers/WelcomePage/WelcomePage"),
       },
       {
         path: "subjects",
+        importPath: "src/containers/AllSubjectsPage/AllSubjectsPage.tsx",
         lazy: () => import("./containers/AllSubjectsPage/AllSubjectsPage"),
       },
       {
         path: "search",
+        importPath: "src/containers/SearchPage/SearchPage.tsx",
         lazy: () => import("./containers/SearchPage/SearchPage"),
       },
       {
         path: "utdanning/:programme/:contextId/:grade?",
+        importPath: "src/containers/ProgrammePage/ProgrammePage.tsx",
         lazy: () => import("./containers/ProgrammePage/ProgrammePage"),
       },
       {
         path: "samling/:collectionId",
+        importPath: "src/containers/CollectionPage/CollectionPage.tsx",
         lazy: () => import("./containers/CollectionPage/CollectionPage"),
       },
       {
@@ -42,16 +48,19 @@ export const routes: RouteObject[] = [
         children: [
           {
             index: true,
+            importPath: "src/containers/PodcastPage/PodcastSeriesListPage.tsx",
             lazy: () => import("./containers/PodcastPage/PodcastSeriesListPage"),
           },
           {
             path: ":id",
+            importPath: "src/containers/PodcastPage/PodcastSeriesPage.tsx",
             lazy: () => import("./containers/PodcastPage/PodcastSeriesPage"),
           },
         ],
       },
       {
         path: "article/:articleId",
+        importPath: "src/containers/PlainArticlePage/PlainArticlePage.tsx",
         lazy: () => import("./containers/PlainArticlePage/PlainArticlePage"),
       },
       {
@@ -59,10 +68,12 @@ export const routes: RouteObject[] = [
         children: [
           {
             index: true,
+            importPath: "src/containers/PlainLearningpathPage/PlainLearningpathPage.tsx",
             lazy: () => import("./containers/PlainLearningpathPage/PlainLearningpathPage"),
           },
           {
             path: "steps/:stepId",
+            importPath: "src/containers/PlainLearningpathPage/PlainLearningpathPage.tsx",
             lazy: () => import("./containers/PlainLearningpathPage/PlainLearningpathPage"),
           },
         ],
@@ -72,10 +83,12 @@ export const routes: RouteObject[] = [
         children: [
           {
             path: ":contextId/:stepId?",
+            importPath: "src/containers/ResourcePage/ResourcePage.tsx",
             lazy: () => import("./containers/ResourcePage/ResourcePage"),
           },
           {
             path: ":root/:name/:contextId/:stepId?",
+            importPath: "src/containers/ResourcePage/ResourcePage.tsx",
             lazy: () => import("./containers/ResourcePage/ResourcePage"),
           },
         ],
@@ -85,64 +98,79 @@ export const routes: RouteObject[] = [
         children: [
           {
             path: ":contextId",
+            importPath: "src/containers/TopicPage/TopicPage.tsx",
             lazy: () => import("./containers/TopicPage/TopicPage"),
           },
           {
             path: ":root/:name/:contextId",
+            importPath: "src/containers/TopicPage/TopicPage.tsx",
             lazy: () => import("./containers/TopicPage/TopicPage"),
           },
         ],
       },
       {
         path: "f/:root?/:name?/:contextId",
+        importPath: "src/containers/SubjectPage/SubjectPage.tsx",
         lazy: () => import("./containers/SubjectPage/SubjectPage"),
       },
       {
         path: "video/:videoId",
+        importPath: "src/containers/ResourceEmbed/VideoPage.tsx",
         lazy: () => import("./containers/ResourceEmbed/VideoPage"),
       },
       {
         path: "image/:imageId",
+        importPath: "src/containers/ResourceEmbed/ImagePage.tsx",
         lazy: () => import("./containers/ResourceEmbed/ImagePage"),
       },
       {
         path: "concept/:conceptId",
+        importPath: "src/containers/ResourceEmbed/ConceptPage.tsx",
         lazy: () => import("./containers/ResourceEmbed/ConceptPage"),
       },
       {
         path: "audio/:audioId",
+        importPath: "src/containers/ResourceEmbed/AudioPage.tsx",
         lazy: () => import("./containers/ResourceEmbed/AudioPage"),
       },
       {
         path: "h5p/:h5pId",
+        importPath: "src/containers/ResourceEmbed/H5pPage.tsx",
         lazy: () => import("./containers/ResourceEmbed/H5pPage"),
       },
       {
         path: "minndla",
+        importPath: "src/containers/MyNdla/MyNdlaLayout.tsx",
         lazy: () => import("./containers/MyNdla/MyNdlaLayout"),
         children: [
           {
             index: true,
+            importPath: "src/containers/MyNdla/MyNdlaPage.tsx",
             lazy: () => import("./containers/MyNdla/MyNdlaPage"),
           },
           {
             path: "folders/:folderId?",
+            importPath: "src/containers/MyNdla/Folders/FoldersPage.tsx",
             lazy: () => import("./containers/MyNdla/Folders/FoldersPage"),
           },
           {
             path: "folders/tag/:tag",
+            importPath: "src/containers/MyNdla/Folders/FoldersTagPage.tsx",
             lazy: () => import("./containers/MyNdla/Folders/FoldersTagPage"),
           },
           {
             path: "learningpaths",
+            importPath: "src/containers/MyNdla/Learningpath/LearningpathCheck.tsx",
             lazy: () => import("./containers/MyNdla/Learningpath/LearningpathCheck"),
             children: [
               {
                 index: true,
+                importPath: "src/containers/MyNdla/Learningpath/LearningpathPage.tsx",
                 lazy: () => import("./containers/MyNdla/Learningpath/LearningpathPage"),
               },
               {
                 path: "new",
+                importPath: "src/containers/MyNdla/Learningpath/NewLearningpathPage.tsx",
                 lazy: () => import("./containers/MyNdla/Learningpath/NewLearningpathPage"),
               },
               {
@@ -150,18 +178,22 @@ export const routes: RouteObject[] = [
                 children: [
                   {
                     path: "title",
+                    importPath: "src/containers/MyNdla/Learningpath/EditLearningpathTitlePage.tsx",
                     lazy: () => import("./containers/MyNdla/Learningpath/EditLearningpathTitlePage"),
                   },
                   {
                     path: "steps",
+                    importPath: "src/containers/MyNdla/Learningpath/EditLearningpathStepsPage.tsx",
                     lazy: () => import("./containers/MyNdla/Learningpath/EditLearningpathStepsPage"),
                     children: [
                       {
                         index: true,
+                        importPath: "src/containers/MyNdla/Learningpath/components/EditLearningpathNewStepLink.tsx",
                         lazy: () => import("./containers/MyNdla/Learningpath/components/EditLearningpathNewStepLink"),
                       },
                       {
                         path: "new",
+                        importPath: "src/containers/MyNdla/Learningpath/components/LearningpathStepForm.tsx",
                         lazy: () => import("./containers/MyNdla/Learningpath/components/LearningpathStepForm"),
                       },
                       {
@@ -174,50 +206,61 @@ export const routes: RouteObject[] = [
               },
               {
                 path: ":learningpathId/save",
+                importPath: "src/containers/MyNdla/Learningpath/SaveLearningpathPage.tsx",
                 lazy: () => import("./containers/MyNdla/Learningpath/SaveLearningpathPage"),
               },
               {
                 path: ":learningpathId/preview/:stepId?",
+                importPath: "src/containers/MyNdla/Learningpath/PreviewLearningpathPage.tsx",
                 lazy: () => import("./containers/MyNdla/Learningpath/PreviewLearningpathPage"),
               },
             ],
           },
           {
             path: "subjects",
+            importPath: "src/containers/MyNdla/FavoriteSubjects/FavoriteSubjectsPage.tsx",
             lazy: () => import("./containers/MyNdla/FavoriteSubjects/FavoriteSubjectsPage"),
           },
           {
             path: "profile",
+            importPath: "src/containers/MyNdla/MyProfile/MyProfilePage.tsx",
             lazy: () => import("./containers/MyNdla/MyProfile/MyProfilePage"),
           },
         ],
       },
       {
         path: "om/:slug",
+        importPath: "src/containers/AboutPageV2/AboutPageV2.tsx",
         lazy: () => import("./containers/AboutPageV2/AboutPageV2"),
       },
       {
         path: "folder/:folderId",
+        importPath: "src/containers/SharedFolderPage/SharedFolderPage.tsx",
         lazy: () => import("./containers/SharedFolderPage/SharedFolderPage"),
       },
       {
         path: "film",
+        importPath: "src/containers/FilmRedirect/FilmRedirectPage.tsx",
         lazy: () => import("./containers/FilmRedirect/FilmRedirectPage"),
       },
       {
         path: "404",
+        importPath: "src/containers/NotFoundPage/NotFoundPage.tsx",
         lazy: () => import("./containers/NotFoundPage/NotFoundPage"),
       },
       {
         path: "403",
+        importPath: "src/containers/AccessDeniedPage/AccessDeniedPage.tsx",
         lazy: () => import("./containers/AccessDeniedPage/AccessDeniedPage"),
       },
       {
         path: "*",
+        importPath: "src/containers/NotFoundPage/NotFoundPage.tsx",
         lazy: () => import("./containers/NotFoundPage/NotFoundPage"),
       },
       {
         path: "p/:articleId",
+        importPath: "src/containers/PlainArticlePage/PlainArticlePage.tsx",
         lazy: () => import("./containers/PlainArticlePage/PlainArticlePage"),
       },
     ],

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -6,11 +6,17 @@
  *
  */
 
+import { RouteObject } from "react-router";
 import { NormalizedCacheObject } from "@apollo/client";
 import { ConfigType } from "./config";
 import { LocaleValues } from "./constants";
 import { RouteChunkInfo } from "./server/serverHelpers";
 import { RestrictedModeState } from "./components/RestrictedModeContext";
+
+export type RouteObjectWithImportPath = RouteObject & {
+  importPath?: string;
+  children?: RouteObjectWithImportPath[];
+};
 
 export type InitialProps = {
   articleId?: string;

--- a/src/lti/routes.tsx
+++ b/src/lti/routes.tsx
@@ -6,16 +6,17 @@
  *
  */
 
-import { RouteObject } from "react-router";
 import { ErrorBoundary } from "./ErrorBoundary";
+import { RouteObjectWithImportPath } from "../interfaces";
 
-export const routes: RouteObject[] = [
+export const routes: RouteObjectWithImportPath[] = [
   {
     path: "/",
     errorElement: <ErrorBoundary />,
     children: [
       {
         index: true,
+        importPath: "src/lti/LtiProvider.tsx",
         lazy: () => import("./LtiProvider"),
       },
       {
@@ -23,16 +24,19 @@ export const routes: RouteObject[] = [
         children: [
           {
             path: ":lang?/article/:articleId",
+            importPath: "src/lti/LtiIframePage.tsx",
             lazy: () => import("./LtiIframePage"),
           },
           {
             path: ":lang?/:taxonomyId/:articleId",
+            importPath: "src/lti/LtiIframePage.tsx",
             lazy: () => import("./LtiIframePage"),
           },
         ],
       },
       {
         path: "*",
+        importPath: "src/containers/NotFoundPage/NotFoundPage.tsx",
         lazy: () => import("../containers/NotFoundPage/NotFoundPage"),
       },
     ],

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,7 +22,7 @@ import { loggerContextMiddleware, getLoggerContextStore } from "./server/middlew
 import { contentSecurityPolicy } from "./server/contentSecurityPolicy";
 import api from "./server/api";
 import { healthRouter } from "./server/routes/healthRouter";
-import { RootRenderFunc, RouteChunkInfo, sendResponse } from "./server/serverHelpers";
+import { RootRenderFunc, RouteChunkInfoWithManifest, sendResponse } from "./server/serverHelpers";
 import { INTERNAL_SERVER_ERROR } from "./statusCodes";
 import { getRouteChunkInfo } from "./server/getManifestChunks";
 import { getLocaleInfoFromPath } from "./i18n";
@@ -97,7 +97,7 @@ if (isProduction) {
   manifest = (await import(`../build/public/.vite/manifest.json`)).default;
 }
 
-const renderRoute = async (req: Request, res: Response, renderer: string, chunkInfo: RouteChunkInfo) => {
+const renderRoute = async (req: Request, res: Response, renderer: string, chunkInfo: RouteChunkInfoWithManifest) => {
   const ctx = getLoggerContextStore();
   if (!ctx) {
     throw new Error("Logger context is not available");

--- a/src/server/render/__tests__/ltiRender-test.ts
+++ b/src/server/render/__tests__/ltiRender-test.ts
@@ -20,6 +20,7 @@ test("ltiRender 200 OK ", async () => {
   };
   const response = await ltiRender(
     {
+      path: "/article-iframe/nb/urn:resource:123/26050",
       params: {
         lang: "nb",
         articleId: "26050",
@@ -31,7 +32,7 @@ test("ltiRender 200 OK ", async () => {
         "user-agent": "Mozilla/5.0 Gecko/20100101 Firefox/58.0",
       },
     } as any as Request,
-    {},
+    { manifest: {} },
   );
 
   expect(response.status).toBe(200);
@@ -44,6 +45,7 @@ test("ltiRender 200 OK only required params", async () => {
   };
   const response = await ltiRender(
     {
+      path: "/article-iframe/nb/urn:resource:123/26050",
       params: {
         lang: "nb",
         articleId: "26050",
@@ -55,7 +57,7 @@ test("ltiRender 200 OK only required params", async () => {
         "user-agent": "Mozilla/5.0 Gecko/20100101 Firefox/58.0",
       },
     } as any as Request,
-    {},
+    { manifest: {} },
   );
 
   expect(response.status).toBe(200);
@@ -71,6 +73,7 @@ test("ltiRender 400 BAD REQUEST", async () => {
   };
   const response = await ltiRender(
     {
+      path: "/article-iframe/nb/urn:resource:123/26050",
       params: {
         lang: "nb",
         articleId: "26050",
@@ -82,7 +85,7 @@ test("ltiRender 400 BAD REQUEST", async () => {
         "user-agent": "Mozilla/5.0 Gecko/20100101 Firefox/58.0",
       },
     } as any as Request,
-    {},
+    { manifest: {} },
   );
 
   expect(response).toMatchSnapshot();
@@ -99,6 +102,7 @@ test("ltiRender 400 BAD REQUEST wrong values", async () => {
   };
   const response = await ltiRender(
     {
+      path: "/article-iframe/nb/urn:resource:123/26050",
       params: {
         lang: "nb",
         articleId: "26050",
@@ -110,7 +114,7 @@ test("ltiRender 400 BAD REQUEST wrong values", async () => {
         "user-agent": "Mozilla/5.0 Gecko/20100101 Firefox/58.0",
       },
     } as any as Request,
-    {},
+    { manifest: {} },
   );
 
   expect(response).toMatchSnapshot();

--- a/src/server/render/errorRender.tsx
+++ b/src/server/render/errorRender.tsx
@@ -26,7 +26,7 @@ import { RenderFunc } from "../serverHelpers";
 
 const { query, dataRoutes } = createStaticHandler(errorRoutes);
 
-export const errorRender: RenderFunc = async (req, chunkInfo) => {
+export const errorRender: RenderFunc = async (req, { manifest: _, ...chunkInfo }) => {
   const context: RedirectInfo = {};
 
   const lang = getHtmlLang(req.params.lang ?? "");

--- a/src/server/render/ltiRender.tsx
+++ b/src/server/render/ltiRender.tsx
@@ -10,7 +10,9 @@ import { renderToString } from "react-dom/server";
 import config from "../../config";
 import { Document } from "../../Document";
 import { getHtmlLang } from "../../i18n";
+import { routes } from "../../lti/routes";
 import { BAD_REQUEST, OK } from "../../statusCodes";
+import { getLazyLoadedChunks } from "../getManifestChunks";
 import { isRestrictedMode } from "../helpers/restrictedMode";
 import { stringifiedLanguages } from "../locales/locales";
 import { RenderFunc } from "../serverHelpers";
@@ -74,8 +76,10 @@ export const ltiRender: RenderFunc = async (req, chunkInfo) => {
     }
   }
 
+  const lazyChunkInfo = getLazyLoadedChunks(routes, req.path, chunkInfo);
+
   const htmlContent = renderToString(
-    <Document language={lang} chunkInfo={chunkInfo} hash={hash}>
+    <Document language={lang} chunkInfo={lazyChunkInfo} hash={hash}>
       {null}
     </Document>,
   );
@@ -90,7 +94,7 @@ export const ltiRender: RenderFunc = async (req, chunkInfo) => {
           ltiData: validParameters?.ltiData,
           locale: lang,
         },
-        chunkInfo,
+        chunkInfo: lazyChunkInfo,
         config,
         hash,
         restrictedMode,

--- a/src/server/serverHelpers.ts
+++ b/src/server/serverHelpers.ts
@@ -12,6 +12,7 @@ import { LocaleType } from "../interfaces";
 import { NDLAError } from "../util/error/NDLAError";
 import { handleError } from "../util/handleError";
 import { LoggerContext } from "../util/logger/loggerContext";
+import { Manifest } from "vite";
 
 interface RenderLocationReturn {
   status: number;
@@ -33,15 +34,19 @@ export interface RouteChunkInfo {
   css?: string[];
 }
 
+export interface RouteChunkInfoWithManifest extends RouteChunkInfo {
+  manifest: Manifest;
+}
+
 export type RenderReturn = RenderLocationReturn | RenderDataReturn;
 
-export type RenderFunc = (req: Request, chunkInfo: RouteChunkInfo) => Promise<RenderReturn>;
+export type RenderFunc = (req: Request, chunkInfo: RouteChunkInfoWithManifest) => Promise<RenderReturn>;
 
 export type RootRenderFunc = (
   req: Request,
   res: Response,
   renderer: string,
-  chunkInfo: RouteChunkInfo,
+  chunkInfo: RouteChunkInfoWithManifest,
   ctx: LoggerContext,
 ) => Promise<RenderReturn>;
 


### PR DESCRIPTION
Tar over for https://github.com/NDLANO/ndla-frontend/pull/2595/files
Tror dette skal hjelpe litt på page-load. Før hentet vi js-chunker i to steg: Først henter vi all JS'en vi trenger for å rendre et spesifikt entry-point, f.eks client.tsx. Deretter henter klienten JS'en den trenger for å rendre den spesifikke ruten man treffer. Slår disse to sammen, så vi bare trenger å hente JS i en omgang. Etter et par tester ser dette ut til å kutte rundt 50ms fra INP.

Før:
<img width="934" height="191" alt="image" src="https://github.com/user-attachments/assets/0e6614b4-92e4-4730-aac7-d168cbcad26d" />

Etter:
<img width="951" height="194" alt="image" src="https://github.com/user-attachments/assets/f9ea7e4c-1003-42db-9f75-f88067fcfa64" />
