### PR TITLE
Check if embedurl is external first

### DIFF
--- a/src/containers/MyNdla/Learningpath/utils.ts
+++ b/src/containers/MyNdla/Learningpath/utils.ts
@@ -24,8 +24,8 @@ export const LEARNINGPATH_READY_FOR_SHARING = "READY_FOR_SHARING";
 
 export const getFormTypeFromStep = (step?: GQLMyNdlaLearningpathStepFragment): FormValues["type"] => {
   if (!step?.resource && !step?.oembed && !step?.embedUrl) return "text";
-  if (step?.resource || step.embedUrl?.url.includes("resource")) return "resource";
   if (step?.embedUrl?.embedType === "external") return "external";
+  if (step?.resource || step.embedUrl?.url.includes("resource")) return "resource";
   return "text";
 };
 


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/4506

Sjekker om embedUrl er external før sjekk på om steg er fra ndla. Kunne sikkert gjort resource-sjekken bedre også.