### PR TITLE
fix: remove custom folder merge logic

### DIFF
--- a/src/util/apiHelpers.ts
+++ b/src/util/apiHelpers.ts
@@ -74,20 +74,6 @@ const possibleTypes = {
 };
 
 const typePolicies: TypePolicies = {
-  Folder: {
-    fields: {
-      subfolders: {
-        merge(existing, incoming) {
-          return existing ? existing : incoming;
-        },
-      },
-      resources: {
-        merge(existing, incoming) {
-          return existing ? existing : incoming;
-        },
-      },
-    },
-  },
   SubjectPage: {
     fields: {
       about: {


### PR DESCRIPTION
Hvis vi beholder dette merges ikke ressurser inn en mappe hvis man laster mappe uten ressurser først.