### PR TITLE
fix: bottom-align alt text on transportation pages

### DIFF
--- a/src/components/TransportationPage/TransportationPageHeader.tsx
+++ b/src/components/TransportationPage/TransportationPageHeader.tsx
@@ -28,6 +28,8 @@ export const TransportationPageHeader = styled("div", {
         objectFit: "cover",
         maxWidth: "365px",
         borderRadius: "0",
+        display: "flex",
+        alignItems: "flex-end",
       },
       maxWidth: "365px",
     },


### PR DESCRIPTION
Fixes https://trello.com/c/km4Vg2Mx/1553-uu-alt-tekst-problem-i-bildevisning-for-emneartiklar

Det finnes vel en verden der alt-tekst er såpass langt at den fortsatt kuttes av clip-pathen, men den håper jeg vi ikke lever i. Den egentlige fiksen er å alltid rendre `Image` istedenfor `ImageEmbed`, så vi kan reagere på `onError`. Tror det kan gjøres dersom vi ender opp med en slik situasjon.