### PR TITLE
refactor: no skip to content id on preview learning path

### DIFF
--- a/src/components/Learningpath/LearningpathContent.tsx
+++ b/src/components/Learningpath/LearningpathContent.tsx
@@ -52,6 +52,7 @@ export const LearningpathContent = ({
     <>
       {!learningpathStep && !!learningpath?.introduction?.length && (
         <LearningpathIntroduction
+          skipToContentId={skipToContentId}
           introduction={learningpath.introduction}
           isInactive={!!resource?.context?.isArchived}
         />

--- a/src/components/Learningpath/components/LearningpathIntroduction.tsx
+++ b/src/components/Learningpath/components/LearningpathIntroduction.tsx
@@ -9,23 +9,25 @@
 import { transform } from "@ndla/article-converter";
 import { Badge } from "@ndla/primitives";
 import { ArticleContent, ArticleTitle, ArticleWrapper } from "@ndla/ui";
+import { useId } from "react";
 import { useTranslation } from "react-i18next";
-import { SKIP_TO_CONTENT_ID } from "../../../constants";
 import { InactiveMessageBox } from "../../InactiveMessageBox";
 import { ResourceContent } from "../../Resource/ResourceLayout";
 
 interface Props {
   introduction?: string;
   isInactive?: boolean;
+  skipToContentId?: string;
 }
 
-export const LearningpathIntroduction = ({ introduction, isInactive }: Props) => {
+export const LearningpathIntroduction = ({ introduction, isInactive, skipToContentId }: Props) => {
   const { t } = useTranslation();
+  const fallbackId = useId();
   return (
     <ResourceContent variant="content">
       <ArticleWrapper>
         <ArticleTitle
-          id={SKIP_TO_CONTENT_ID}
+          id={skipToContentId ?? fallbackId}
           title={t("learningpathPage.introduction")}
           badges={<Badge>{t("contentTypes.learning-path")}</Badge>}
         />

--- a/src/containers/MyNdla/Learningpath/PreviewLearningpathPage.tsx
+++ b/src/containers/MyNdla/Learningpath/PreviewLearningpathPage.tsx
@@ -154,7 +154,6 @@ export const PreviewLearningpathPage = () => {
             <ResourceContentContainer asChild consumeCss>
               <div>
                 <LearningpathContent
-                  // TODO: We should probably pass down `skipToContentId` here. Let's fix it when we fix the remaining learningpath previews
                   learningpath={learningpath}
                   learningpathStep={learningpathStep}
                   context="preview"


### PR DESCRIPTION
Trengs ikke. Sørger også for at skip-ID ikke er satt på introduksjon i forhåndsvisning