### PR TITLE
chore: try running e2e tests with playwright docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
   integration_tests:
     name: "Integration tests"
     runs-on: ubuntu-latest
+    container: mcr.microsoft.com/playwright:v1.57.0-noble
     env:
       DEFAULT_TIMEOUT: 5000
       NDLA_PERSONAL_CLIENT_ID: ${{ secrets.NDLA_PERSONAL_CLIENT_ID }}
@@ -60,7 +61,5 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           MASTER_ALIAS: "ndla-frontend-master.vercel.app"
           REPO_NAME: "ndla-frontend"
-      - name: Install Playwright Browsers
-        run: yarn playwright install --with-deps chromium
       - name: "E2E"
         run: yarn e2e:headless


### PR DESCRIPTION
Sparer oss et sted mellom 10-20 sekunder. Ulempen er at vi må huske å oppdatere image når vi oppdaterer playwright. Også er det kanskje litt rart å kjøre hele CI'en vår i et playwright-image? Kjør debatt!