### PR TITLE
Generisk forside til nyttig info

### DIFF
--- a/src/messages/messagesEN.ts
+++ b/src/messages/messagesEN.ts
@@ -25,7 +25,7 @@ const messages = {
   },
   htmlTitles: {
     titleTemplate,
-    welcomePage: `Frontpage - ${titleTemplate}`,
+    welcomePage: `Learning resources for upper secondary education - ${titleTemplate}`,
     topicPage: "Topic",
     subjectsPage: `All subjects - ${titleTemplate}`,
     searchPage: `Search - ${titleTemplate}`,

--- a/src/messages/messagesNB.ts
+++ b/src/messages/messagesNB.ts
@@ -25,7 +25,7 @@ const messages = {
   },
   htmlTitles: {
     titleTemplate,
-    welcomePage: `Forsiden - ${titleTemplate}`,
+    welcomePage: `Læringsressurser for videregående opplæring - ${titleTemplate}`,
     topicPage: "Emne",
     subjectsPage: `Alle fag - ${titleTemplate}`,
     searchPage: `Søk - ${titleTemplate}`,

--- a/src/messages/messagesNN.ts
+++ b/src/messages/messagesNN.ts
@@ -25,7 +25,7 @@ const messages = {
   },
   htmlTitles: {
     titleTemplate,
-    welcomePage: `Framsida - ${titleTemplate}`,
+    welcomePage: `Læringsressursar for videregåande opplæring - ${titleTemplate}`,
     topicPage: "Emne",
     subjectsPage: `Alle fag - ${titleTemplate}`,
     searchPage: `Søk - ${titleTemplate}`,

--- a/src/messages/messagesSE.ts
+++ b/src/messages/messagesSE.ts
@@ -25,7 +25,7 @@ const messages = {
   },
   htmlTitles: {
     titleTemplate,
-    welcomePage: `Oahpparesursa. Joatkkaskuvla - ${titleTemplate}`,
+    welcomePage: `Oahpponeavvut joatkkaoahpahussii - ${titleTemplate}`,
     topicPage: "Fáddá",
     subjectsPage: `Vállje fága - ${titleTemplate}`,
     searchPage: `Oza - ${titleTemplate}`,

--- a/src/messages/messagesSE.ts
+++ b/src/messages/messagesSE.ts
@@ -25,7 +25,7 @@ const messages = {
   },
   htmlTitles: {
     titleTemplate,
-    welcomePage: `Ovdasiidu - ${titleTemplate}`,
+    welcomePage: `Oahpparesursa. Joatkkaskuvla - ${titleTemplate}`,
     topicPage: "Fáddá",
     subjectsPage: `Vállje fága - ${titleTemplate}`,
     searchPage: `Oza - ${titleTemplate}`,


### PR DESCRIPTION
Forsida har tittel Forsida - NDLA, me bytter til:
nb:Læringsressurser for videregående opplæring
nn: Læringsressursar for videregåande opplæring
en: Learning resources for upper secondary education