### PR TITLE
feat(my-ndla): support downloading your user data

### DIFF
--- a/src/containers/MyNdla/MyProfile/MyProfilePage.tsx
+++ b/src/containers/MyNdla/MyProfile/MyProfilePage.tsx
@@ -149,6 +149,9 @@ export const MyProfilePage = () => {
             </DialogFooter>
           </DialogContent>
         </DialogRoot>
+        <SafeLink to="/api/user-data-dump" download asAnchor>
+          {t("myNdla.myPage.downloadUserData")}
+        </SafeLink>
       </Stack>
     </MyNdlaPageWrapper>
   );

--- a/src/messages/messagesEN.ts
+++ b/src/messages/messagesEN.ts
@@ -566,6 +566,7 @@ const messages = {
       privacyLink: "https://ndla.no/article/personvernerklaering",
       questions: { question: "Any questions?", ask: "Ask NDLA" },
       wishToDelete: "Do you wish to delete your account?",
+      downloadUserData: "Download all content in your folders and your learning paths.",
       feide: "We have retrieved this information from Feide",
       feideWrongInfo:
         "If the information is incorrect, it has to be updated by the host organizationg or the school that the account is associated with. An overview of user support can be found here: feide.no/brukerstotte",

--- a/src/messages/messagesNB.ts
+++ b/src/messages/messagesNB.ts
@@ -564,6 +564,7 @@ const messages = {
       privacyLink: "https://ndla.no/article/personvernerklaering",
       questions: { question: "Lurer du på noe?", ask: "Spør NDLA" },
       wishToDelete: "Vil du ikke ha brukerprofil hos oss lenger?",
+      downloadUserData: "Last ned alt innholdet i dine mapper og dine læringsstier.",
       recentFavourites: {
         title: "Nylig lagt til i mine mapper",
         link: "Se alle mappene dine",

--- a/src/messages/messagesNN.ts
+++ b/src/messages/messagesNN.ts
@@ -564,6 +564,7 @@ const messages = {
       privacyLink: "https://ndla.no/article/personvernerklaering",
       questions: { question: "Lurer du på noko?", ask: "Spør NDLA" },
       wishToDelete: "Vil du ikkje ha brukerprofil hos oss lenger?",
+      downloadUserData: "Last ned alt innhaldet i dine mappar og dine læringsstiar.",
       recentFavourites: {
         title: "Nyleg lagt til i mappene mine",
         link: "Sjå alle mappene dine",

--- a/src/messages/messagesSE.ts
+++ b/src/messages/messagesSE.ts
@@ -563,6 +563,7 @@ const messages = {
       privacyLink: "https://ndla.no/article/personvernerklaering",
       questions: { question: "Lurer du på noe?", ask: "Spør NDLA" },
       wishToDelete: "Vil du ikke ha brukerprofil hos oss lenger?",
+      downloadUserData: "Last ned alt innholdet i dine mapper og dine læringsstier.",
       recentFavourites: {
         title: "Nylig lagt til i mine mapper",
         link: "Se alle mappene dine",

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -6,11 +6,15 @@
  *
  */
 
+import { LearningPathV2DTO } from "@ndla/types-backend/learningpath-api";
+import { ExportedUserDataDTO } from "@ndla/types-backend/myndla-api";
 import express from "express";
 import { ABOUT_PATH, FILM_PAGE_URL, UKR_PAGE_URL, programmeRedirects } from "../constants";
 import { isValidLocale } from "../i18n";
 import { BAD_REQUEST, INTERNAL_SERVER_ERROR } from "../statusCodes";
+import { apiResourceUrl, resolveJsonOrRejectWithError } from "../util/apiHelpers";
 import { fetchArticleRss } from "../util/articleApi";
+import { getFeideCookie } from "../util/authHelpers";
 import { isStatusError } from "../util/error/StatusError";
 import { log } from "../util/logger/logger";
 import authEndpoints from "./authEndpoints";
@@ -158,6 +162,36 @@ router.get(
     }
   },
 );
+
+router.get("/api/user-data-dump", async (req, res) => {
+  const token = getFeideCookie(req.headers.cookie ?? "");
+  if (!token) {
+    res.status(401).json({ message: "Unauthorized" });
+  }
+
+  try {
+    const userData = await fetch(apiResourceUrl("/myndla-api/v1/users/export"), {
+      headers: {
+        FeideAuthorization: `Bearer ${token}`,
+      },
+    }).then((r) => resolveJsonOrRejectWithError<ExportedUserDataDTO>(r));
+
+    const learningpaths = await fetch(apiResourceUrl("/learningpath-api/v2/learningpaths/mine"), {
+      headers: {
+        FeideAuthorization: `Bearer ${token}`,
+      },
+    }).then((r) => resolveJsonOrRejectWithError<LearningPathV2DTO[]>(r));
+
+    res.json({
+      ...userData,
+      learningpaths,
+    });
+  } catch (e) {
+    res
+      .status(isStatusError(e) ? (e.status ?? INTERNAL_SERVER_ERROR) : INTERNAL_SERVER_ERROR)
+      .json({ message: "Error fetching user data" });
+  }
+});
 
 router.get("/lmk/subjects", async (_, res) => {
   res.setHeader("Content-Type", "application/ld+json");


### PR DESCRIPTION
Fixes https://trello.com/c/KAUdO1OL/1677-minndla-takeout-brukar-kan-lasta-ned-hjertemerka-ressursar-og-l%C3%A6ringsstiar.

Gjør det enkelt i første omgang. Kan dra alt over til backend dersom dette faktisk tas i bruk etterhvert.